### PR TITLE
#38 add arithmetic for Blocks a la CartesianIndex

### DIFF
--- a/src/BlockArrays.jl
+++ b/src/BlockArrays.jl
@@ -17,8 +17,9 @@ export uninitialized_blocks, UninitializedBlocks, uninitialized, Uninitialized
 import Base: @propagate_inbounds, Array, to_indices, to_index, indices,
             unsafe_indices, indices1, first, last, size, length, unsafe_length,
             getindex, show, start, next, done, @_inline_meta, _maybetail, tail,
-            colon, broadcast, eltype, iteratorsize
+            colon, broadcast, eltype, iteratorsize, convert
 
+import Base: +, -, min, max, *, isless
 
 
 

--- a/src/BlockArrays.jl
+++ b/src/BlockArrays.jl
@@ -17,7 +17,7 @@ export uninitialized_blocks, UninitializedBlocks, uninitialized, Uninitialized
 import Base: @propagate_inbounds, Array, to_indices, to_index, indices,
             unsafe_indices, indices1, first, last, size, length, unsafe_length,
             getindex, show, start, next, done, @_inline_meta, _maybetail, tail,
-            colon, broadcast, eltype, iteratorsize, convert
+            colon, broadcast, eltype, iteratorsize, convert, broadcast
 
 import Base: +, -, min, max, *, isless
 

--- a/src/abstractblockarray.jl
+++ b/src/abstractblockarray.jl
@@ -96,6 +96,7 @@ julia> A[Block(1, 1)]
 """
 struct Block{N, T}
     n::NTuple{N, T}
+    Block{N, T}(n::NTuple{N, T}) where {N, T} = new{N, T}(n)
 end
 
 

--- a/src/blockrange.jl
+++ b/src/blockrange.jl
@@ -23,7 +23,9 @@ BlockRange(inds::Vararg{AbstractUnitRange{Int},N}) where {N} =
 
 colon(start::Block{1}, stop::Block{1}) = BlockRange((first(start.n):first(stop.n),))
 colon(start::Block, stop::Block) = throw(ArgumentError("Use `BlockRange` to construct a cartesian range of blocks"))
+
 broadcast(::typeof(Block), range::UnitRange) = Block(first(range)):Block(last(range))
+broadcast(::typeof(Int), block_range::BlockRange{1}) = first(block_range.indices)
 
 eltype(R::BlockRange) = eltype(typeof(R))
 eltype(::Type{BlockRange{N}}) where {N} = Block{N,Int}

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -1,15 +1,15 @@
-function Base.convert(::Type{BlockArray{T, N}}, A::PseudoBlockArray{T2, N}) where {T,T2,N}
+function convert(::Type{BlockArray{T, N}}, A::PseudoBlockArray{T2, N}) where {T,T2,N}
     BlockArray(convert(Array{T, N}, Array(A)), A.block_sizes)
 end
-Base.convert(::Type{BlockArray{T, N, R}}, A::PseudoBlockArray{T2, N}) where {T,T2,N,R} = convert(BlockArray{T, N}, A)
-Base.convert(::Type{BlockArray{T1}}, A::PseudoBlockArray{T2, N}) where {T1,T2,N} = convert(BlockArray{T1, N}, A)
-Base.convert(::Type{BlockArray}, A::PseudoBlockArray{T, N}) where {T,N} = convert(BlockArray{T, N}, A)
+convert(::Type{BlockArray{T, N, R}}, A::PseudoBlockArray{T2, N}) where {T,T2,N,R} = convert(BlockArray{T, N}, A)
+convert(::Type{BlockArray{T1}}, A::PseudoBlockArray{T2, N}) where {T1,T2,N} = convert(BlockArray{T1, N}, A)
+convert(::Type{BlockArray}, A::PseudoBlockArray{T, N}) where {T,N} = convert(BlockArray{T, N}, A)
 BlockArray(A::BlockArray) = convert(BlockArray, A)
 
-function Base.convert(::Type{PseudoBlockArray{T, N}}, A::BlockArray{T2, N}) where {T,T2,N}
+function convert(::Type{PseudoBlockArray{T, N}}, A::BlockArray{T2, N}) where {T,T2,N}
     PseudoBlockArray(convert(Array{T, N}, Array(A)), A.block_sizes)
 end
-Base.convert(::Type{PseudoBlockArray{T, N, R}}, A::BlockArray{T2, N}) where {T,T2,N,R} = convert(PseudoBlockArray{T, N}, A)
-Base.convert(::Type{PseudoBlockArray}, A::BlockArray{T, N}) where {T,N} = convert(PseudoBlockArray{T, N}, A)
-Base.convert(::Type{PseudoBlockArray{T1}}, A::BlockArray{T2, N}) where {T1,T2,N} = convert(PseudoBlockArray{T1, N}, A)
+convert(::Type{PseudoBlockArray{T, N, R}}, A::BlockArray{T2, N}) where {T,T2,N,R} = convert(PseudoBlockArray{T, N}, A)
+convert(::Type{PseudoBlockArray}, A::BlockArray{T, N}) where {T,N} = convert(PseudoBlockArray{T, N}, A)
+convert(::Type{PseudoBlockArray{T1}}, A::BlockArray{T2, N}) where {T1,T2,N} = convert(PseudoBlockArray{T1, N}, A)
 PseudoBlockArray(A::BlockArray) = convert(PseudoBlockArray, A)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,10 +1,4 @@
-using BlockArrays
-
-if VERSION > v"0.7.0-DEV.2004"
-    using Test
-else
-    using Base.Test
-end
+using BlockArrays, Compat, Compat.Test
 
 
 include("test_blockindices.jl")

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -254,3 +254,55 @@ end
     A[Block(2,3)] = ones(2,3)
     @test A[Block(2,3)] == ones(2,3)
 end
+
+@testset "Block arithmetic" begin
+    @test +(Block(1)) == Block(1)
+    @test -(Block(1)) == Block(-1)
+    @test Block(2) + Block(1) == Block(3)
+    @test Block(2) + 1 == Block(3)
+    @test 2 + Block(1) == Block(3)
+    @test Block(2) - Block(1) == Block(1)
+    @test Block(2) - 1 == Block(1)
+    @test 2 - Block(1) == Block(1)
+    @test 2*Block(1) == Block(2)
+    @test Block(1)*2 == Block(2)
+
+    @test isless(Block(1), Block(2))
+    @test !isless(Block(1), Block(1))
+    @test !isless(Block(2), Block(1))
+    @test Block(1) < Block(2)
+    @test Block(1) ≤ Block(1)
+    @test Block(2) > Block(1)
+    @test Block(1) ≥ Block(1)
+    @test min(Block(1), Block(2)) == Block(1)
+    @test max(Block(1), Block(2)) == Block(2)
+
+    @test +(Block(1,2)) == Block(1,2)
+    @test -(Block(1,2)) == Block(-1,-2)
+    @test Block(1,2) + Block(2,3) == Block(3,5)
+    @test Block(1,2) + 1 == Block(2,3)
+    @test 1 + Block(1,2) == Block(2,3)
+    @test Block(2,3) - Block(1,2) == Block(1,1)
+    @test Block(1,2) - 1 == Block(0,1)
+    @test 1 - Block(1,2) == Block(0,-1)
+    @test 2*Block(1,2) == Block(2,4)
+    @test Block(1,2)*2 == Block(2,4)
+
+    @test isless(Block(1,1), Block(2,2))
+    @test isless(Block(1,1), Block(2,1))
+    @test !isless(Block(1,1), Block(1,1))
+    @test !isless(Block(2,1), Block(1,1))
+    @test Block(1,1) < Block(2,1)
+    @test Block(1,1) ≤ Block(1,1)
+    @test Block(2,1) > Block(1,1)
+    @test Block(1,1) ≥ Block(1,1)
+    @test min(Block(1,2), Block(2,2)) == Block(1,2)
+    @test max(Block(1,2), Block(2,2)) == Block(2,2)
+
+    @test convert(Int, Block(2)) == 2
+    @test convert(Float64, Block(2)) == 2.0
+
+    @test_throws MethodError convert(Int, Block(2,1))
+    @test convert(Tuple{Int,Int}, Block(2,1)) == (2,1)
+    @test convert(Tuple{Float64,Int}, Block(2,1)) == (2.0,1)
+end

--- a/test/test_blockrange.jl
+++ b/test/test_blockrange.jl
@@ -9,6 +9,7 @@
     @test eltype(BlockRange{1}) == Block{1,Int}
     @test Block(1):Block(3) == BlockRange((1:3,))
     @test Block.(1:3) == BlockRange((1:3,))
+    @test Int.(BlockRange((1:3,))) == 1:3
 
     @test collect(Block(1):Block(2)) == Block.([1,2])
 


### PR DESCRIPTION
This adds `Block(1) < Block(2)`, `Block(1) + Block(2)`, etc. by copying over the code for `CartesianIndex`.

I couldn't find unit tests for `CartesianIndex`, so perhaps the tests here should be backported to Base.