### PR TITLE
Allow views of views with BlockRange #43

### DIFF
--- a/src/BlockArrays.jl
+++ b/src/BlockArrays.jl
@@ -3,6 +3,9 @@ __precompile__()
 module BlockArrays
 using Base.Cartesian
 using Compat
+if VERSION ≥ v"0.7.0-DEV.3465"
+    using LinearAlgebra
+end
 
 # AbstractBlockArray interface exports
 export AbstractBlockArray, AbstractBlockMatrix, AbstractBlockVector, AbstractBlockVecOrMat

--- a/src/BlockArrays.jl
+++ b/src/BlockArrays.jl
@@ -17,8 +17,9 @@ export uninitialized_blocks, UninitializedBlocks, uninitialized, Uninitialized
 import Base: @propagate_inbounds, Array, to_indices, to_index, indices,
             unsafe_indices, indices1, first, last, size, length, unsafe_length,
             getindex, show, start, next, done, @_inline_meta, _maybetail, tail,
-            colon, broadcast, eltype, iteratorsize
+            colon, broadcast, eltype, iteratorsize, convert, broadcast
 
+import Base: +, -, min, max, *, isless
 
 
 

--- a/src/BlockArrays.jl
+++ b/src/BlockArrays.jl
@@ -16,8 +16,9 @@ export uninitialized_blocks, UninitializedBlocks, uninitialized, Uninitialized
 
 import Base: @propagate_inbounds, Array, to_indices, to_index, indices,
             unsafe_indices, indices1, first, last, size, length, unsafe_length,
-            getindex, show, start, next, done, @_inline_meta, _maybetail, tail,
-            colon, broadcast, eltype, iteratorsize, convert, broadcast
+            getindex, show, start, next, done,
+            colon, broadcast, eltype, iteratorsize, convert, broadcast,
+            @_inline_meta, _maybetail, tail, @_propagate_inbounds_meta, reindex
 
 import Base: +, -, min, max, *, isless
 

--- a/src/BlockArrays.jl
+++ b/src/BlockArrays.jl
@@ -16,6 +16,7 @@ export uninitialized_blocks, UninitializedBlocks, uninitialized, Uninitialized
 
 import Base: @propagate_inbounds, Array, to_indices, to_index, indices,
             unsafe_indices, indices1, first, last, size, length, unsafe_length,
+            unsafe_convert,
             getindex, show, start, next, done,
             colon, broadcast, eltype, iteratorsize, convert, broadcast,
             @_inline_meta, _maybetail, tail, @_propagate_inbounds_meta, reindex

--- a/src/abstractblockarray.jl
+++ b/src/abstractblockarray.jl
@@ -96,13 +96,48 @@ julia> A[Block(1, 1)]
 """
 struct Block{N, T}
     n::NTuple{N, T}
+    Block{N, T}(n::NTuple{N, T}) where {N, T} = new{N, T}(n)
 end
 
+
+Block{N, T}(n::Vararg{T, N}) where {N,T} = Block{N, T}(n)
+Block{N}(n::Vararg{T, N}) where {N,T} = Block{N, T}(n)
 Block(n::Vararg{T, N}) where {N,T} = Block{N, T}(n)
+Block{1}(n::Tuple{T}) where {T} = Block{1, T}(n)
+Block{N}(n::NTuple{N, T}) where {N,T} = Block{N, T}(n)
+Block(n::NTuple{N, T}) where {N,T} = Block{N, T}(n)
 
 @inline function Block(blocks::NTuple{N, Block{1, T}}) where {N,T}
     Block{N, T}(ntuple(i -> blocks[i].n[1], Val(N)))
 end
+
+
+# The following code is taken from CartesianIndex
+@inline (+)(index::Block{N}) where {N} = Block{N}(map(+, index.n))
+@inline (-)(index::Block{N}) where {N} = Block{N}(map(-, index.n))
+
+@inline (+)(index1::Block{N}, index2::Block{N}) where {N} =
+    Block{N}(map(+, index1.n, index2.n))
+@inline (-)(index1::Block{N}, index2::Block{N}) where {N} =
+    Block{N}(map(-, index1.n, index2.n))
+@inline min(index1::Block{N}, index2::Block{N}) where {N} =
+    Block{N}(map(min, index1.n, index2.n))
+@inline max(index1::Block{N}, index2::Block{N}) where {N} =
+    Block{N}(map(max, index1.n, index2.n))
+
+@inline (+)(i::Integer, index::Block) = index+i
+@inline (+)(index::Block{N}, i::Integer) where {N} = Block{N}(map(x->x+i, index.n))
+@inline (-)(index::Block{N}, i::Integer) where {N} = Block{N}(map(x->x-i, index.n))
+@inline (-)(i::Integer, index::Block{N}) where {N} = Block{N}(map(x->i-x, index.n))
+@inline (*)(a::Integer, index::Block{N}) where {N} = Block{N}(map(x->a*x, index.n))
+@inline (*)(index::Block, a::Integer) = *(a,index)
+
+# comparison
+@inline isless(I1::Block{N}, I2::Block{N}) where {N} = Base.IteratorsMD._isless(0, I1.n, I2.n)
+
+# conversions
+convert(::Type{T}, index::Block{1}) where {T<:Number} = convert(T, index.n[1])
+convert(::Type{T}, index::Block) where {T<:Tuple} = convert(T, index.n)
 
 """
     getblock(A, inds...)

--- a/src/blockrange.jl
+++ b/src/blockrange.jl
@@ -23,7 +23,9 @@ BlockRange(inds::Vararg{AbstractUnitRange{Int},N}) where {N} =
 
 colon(start::Block{1}, stop::Block{1}) = BlockRange((first(start.n):first(stop.n),))
 colon(start::Block, stop::Block) = throw(ArgumentError("Use `BlockRange` to construct a cartesian range of blocks"))
+
 broadcast(::typeof(Block), range::UnitRange) = Block(first(range)):Block(last(range))
+broadcast(::typeof(Int), block_range::BlockRange{1}) = first(block_range.indices)
 
 eltype(R::BlockRange) = eltype(typeof(R))
 eltype(::Type{BlockRange{N}}) where {N} = Block{N,Int}

--- a/src/blocksizes.jl
+++ b/src/blocksizes.jl
@@ -48,6 +48,14 @@ end
     end
 end
 
+@inline function Base.size(block_sizes::BlockSizes{1})
+    (block_sizes[1][end] - 1,)
+end
+
+@inline function Base.size(block_sizes::BlockSizes{2})
+    (block_sizes[1][end] - 1,block_sizes[2][end] - 1)
+end
+
 function Base.show(io::IO, block_sizes::BlockSizes{N}) where {N}
     if N == 0
         print(io, "[]")

--- a/src/blocksizes.jl
+++ b/src/blocksizes.jl
@@ -18,7 +18,7 @@ BlockSizes(sizes::Vararg{AbstractVector{Int}, N}) where {N} =
 
 Base.:(==)(a::BlockSizes, b::BlockSizes) = a.cumul_sizes == b.cumul_sizes
 
-function _cumul_vec(v::Vector{T}) where {T}
+function _cumul_vec(v::AbstractVector{T}) where {T}
     v_cumul = similar(v, length(v) + 1)
     z = one(T)
     v_cumul[1] = z

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -1,15 +1,12 @@
-function convert(::Type{BlockArray{T, N}}, A::PseudoBlockArray{T2, N}) where {T,T2,N}
-    BlockArray(convert(Array{T, N}, Array(A)), A.block_sizes)
-end
-convert(::Type{BlockArray{T, N, R}}, A::PseudoBlockArray{T2, N}) where {T,T2,N,R} = convert(BlockArray{T, N}, A)
-convert(::Type{BlockArray{T1}}, A::PseudoBlockArray{T2, N}) where {T1,T2,N} = convert(BlockArray{T1, N}, A)
-convert(::Type{BlockArray}, A::PseudoBlockArray{T, N}) where {T,N} = convert(BlockArray{T, N}, A)
-BlockArray(A::BlockArray) = convert(BlockArray, A)
+BlockArray{T, N}(A::PseudoBlockArray{T2, N}) where {T,T2,N} = BlockArray(Array{T, N}(A), A.block_sizes)
+BlockArray{T, N, R}(A::PseudoBlockArray{T2, N}) where {T,T2,N,R} = BlockArray{T, N}(A)
+BlockArray{T1}(A::PseudoBlockArray{T2, N}) where {T1,T2,N} = BlockArray{T1, N}(A)
+BlockArray(A::PseudoBlockArray{T, N}) where {T,N} = BlockArray{T, N}(A)
 
-function convert(::Type{PseudoBlockArray{T, N}}, A::BlockArray{T2, N}) where {T,T2,N}
-    PseudoBlockArray(convert(Array{T, N}, Array(A)), A.block_sizes)
-end
-convert(::Type{PseudoBlockArray{T, N, R}}, A::BlockArray{T2, N}) where {T,T2,N,R} = convert(PseudoBlockArray{T, N}, A)
-convert(::Type{PseudoBlockArray}, A::BlockArray{T, N}) where {T,N} = convert(PseudoBlockArray{T, N}, A)
-convert(::Type{PseudoBlockArray{T1}}, A::BlockArray{T2, N}) where {T1,T2,N} = convert(PseudoBlockArray{T1, N}, A)
-PseudoBlockArray(A::BlockArray) = convert(PseudoBlockArray, A)
+PseudoBlockArray{T, N}(A::BlockArray{T2, N}) where {T,T2,N} = PseudoBlockArray(Array{T, N}(A), A.block_sizes)
+PseudoBlockArray{T, N, R}(A::BlockArray{T2, N}) where {T,T2,N,R} = PseudoBlockArray{T, N}(A)
+PseudoBlockArray{T1}(A::BlockArray{T2, N}) where {T1,T2,N} = PseudoBlockArray{T1, N}(A)
+PseudoBlockArray(A::BlockArray{T, N}) where {T,N} = PseudoBlockArray{T, N}(A)
+
+convert(::Type{BA}, A::PseudoBlockArray) where BA <: BlockArray = BA(A)
+convert(::Type{BA}, A::BlockArray) where BA <: PseudoBlockArray = BA(A)

--- a/src/convert.jl
+++ b/src/convert.jl
@@ -1,15 +1,15 @@
-function Base.convert(::Type{BlockArray{T, N}}, A::PseudoBlockArray{T2, N}) where {T,T2,N}
+function convert(::Type{BlockArray{T, N}}, A::PseudoBlockArray{T2, N}) where {T,T2,N}
     BlockArray(convert(Array{T, N}, Array(A)), A.block_sizes)
 end
-Base.convert(::Type{BlockArray{T, N, R}}, A::PseudoBlockArray{T2, N}) where {T,T2,N,R} = convert(BlockArray{T, N}, A)
-Base.convert(::Type{BlockArray{T1}}, A::PseudoBlockArray{T2, N}) where {T1,T2,N} = convert(BlockArray{T1, N}, A)
-Base.convert(::Type{BlockArray}, A::PseudoBlockArray{T, N}) where {T,N} = convert(BlockArray{T, N}, A)
+convert(::Type{BlockArray{T, N, R}}, A::PseudoBlockArray{T2, N}) where {T,T2,N,R} = convert(BlockArray{T, N}, A)
+convert(::Type{BlockArray{T1}}, A::PseudoBlockArray{T2, N}) where {T1,T2,N} = convert(BlockArray{T1, N}, A)
+convert(::Type{BlockArray}, A::PseudoBlockArray{T, N}) where {T,N} = convert(BlockArray{T, N}, A)
 BlockArray(A::BlockArray) = convert(BlockArray, A)
 
-function Base.convert(::Type{PseudoBlockArray{T, N}}, A::BlockArray{T2, N}) where {T,T2,N}
+function convert(::Type{PseudoBlockArray{T, N}}, A::BlockArray{T2, N}) where {T,T2,N}
     PseudoBlockArray(convert(Array{T, N}, Array(A)), A.block_sizes)
 end
-Base.convert(::Type{PseudoBlockArray{T, N, R}}, A::BlockArray{T2, N}) where {T,T2,N,R} = convert(PseudoBlockArray{T, N}, A)
-Base.convert(::Type{PseudoBlockArray}, A::BlockArray{T, N}) where {T,N} = convert(PseudoBlockArray{T, N}, A)
-Base.convert(::Type{PseudoBlockArray{T1}}, A::BlockArray{T2, N}) where {T1,T2,N} = convert(PseudoBlockArray{T1, N}, A)
+convert(::Type{PseudoBlockArray{T, N, R}}, A::BlockArray{T2, N}) where {T,T2,N,R} = convert(PseudoBlockArray{T, N}, A)
+convert(::Type{PseudoBlockArray}, A::BlockArray{T, N}) where {T,N} = convert(PseudoBlockArray{T, N}, A)
+convert(::Type{PseudoBlockArray{T1}}, A::BlockArray{T2, N}) where {T1,T2,N} = convert(PseudoBlockArray{T1, N}, A)
 PseudoBlockArray(A::BlockArray) = convert(PseudoBlockArray, A)

--- a/src/views.jl
+++ b/src/views.jl
@@ -29,32 +29,42 @@ done(S::BlockSlice, s) = done(S.indices, s)
 
 Returns the indices associated with a block as a `BlockSlice`.
 """
-function unblock(block_sizes::BlockSizes{N}, inds, I::Tuple{Block{1, T},Vararg{Any}}) where {N, T}
+function _unblock(cum_sizes, I::Tuple{Block{1, T},Vararg{Any}}) where {T}
     B = first(I)
     b = first(B.n)
-    # the size of inds tells us how many indices have been processed
-    M = length(inds)
-    J = N - M + 1
 
-    range = block_sizes[J, b]:block_sizes[J, b + 1] - 1
+    range = cum_sizes[b]:cum_sizes[b + 1] - 1
 
     BlockSlice(B, range)
 end
 
 
 
-function unblock(block_sizes::BlockSizes{N}, inds, I::Tuple{BlockRange{1,R}, Vararg{Any}}) where {N, R}
+function _unblock(cum_sizes, I::Tuple{BlockRange{1,R}, Vararg{Any}}) where {R}
     B = first(I)
     b_start = first(first(B.indices))
     b_stop = last(first(B.indices))
-    # the size of inds tells us how many indices have been processed
-    M = length(inds)
-    J = N - M + 1
 
-    range = block_sizes[J, b_start]:block_sizes[J, b_stop + 1] - 1
+    range = cum_sizes[b_start]:cum_sizes[b_stop + 1] - 1
 
     BlockSlice(B, range)
 end
+
+
+@inline _cumul_sizes(A::AbstractArray, j) = A.block_sizes[j]
+
+# For a SubArray, we need to shift the block indices appropriately
+function _cumul_sizes(V::SubArray, j)
+    sl = parentindexes(V)[j]
+    @assert sl isa BlockSlice{BlockRange{1,Tuple{UnitRange{Int}}}}
+    A = parent(V)
+    ret = view(_cumul_sizes(A, j), sl.block.indices[1])
+    ret .- ret[1] .+ 1
+end
+
+
+unblock(A::AbstractArray{T,N}, inds, I) where {T, N} =
+    _unblock(_cumul_sizes(A, N - length(inds) + 1), I)
 
 
 
@@ -62,7 +72,7 @@ to_index(::Block) = throw(ArgumentError("Block must be converted by to_indices(.
 to_index(::BlockRange) = throw(ArgumentError("BlockRange must be converted by to_indices(...)"))
 
 @inline to_indices(A, inds, I::Tuple{Block{1}, Vararg{Any}}) =
-    (unblock(A.block_sizes, inds, I), to_indices(A, _maybetail(inds), tail(I))...)
+    (unblock(A, inds, I), to_indices(A, _maybetail(inds), tail(I))...)
 
 # splat out higher dimensional blocks
 # this mimics view of a CartesianIndex
@@ -70,7 +80,7 @@ to_index(::BlockRange) = throw(ArgumentError("BlockRange must be converted by to
     to_indices(A, inds, (Block.(I[1].n)..., tail(I)...))
 
 @inline to_indices(A, inds, I::Tuple{BlockRange{1,R}, Vararg{Any}}) where R =
-    (unblock(A.block_sizes, inds, I), to_indices(A, _maybetail(inds), tail(I))...)
+    (unblock(A, inds, I), to_indices(A, _maybetail(inds), tail(I))...)
 
 # splat out higher dimensional blocks
 # this mimics view of a CartesianIndex
@@ -84,3 +94,20 @@ to_index(::BlockRange) = throw(ArgumentError("BlockRange must be converted by to
 
 @inline to_indices(A, I::Tuple{BlockRange, Vararg{Any}}) =
     to_indices(A, indices(A), I)
+
+
+# BlockSlices map the blocks and the indices
+# this is loosely based on Slice reindex in subarray.jl
+
+import Base: @_propagate_inbounds_meta
+reindex(V, idxs::Tuple{BlockSlice{<:BlockRange}, Vararg{Any}},
+        subidxs::Tuple{BlockSlice{<:BlockRange}, Vararg{Any}}) =
+    (@_propagate_inbounds_meta; (BlockSlice(BlockRange(idxs[1].block.indices[1][Int.(subidxs[1].block)]),
+                                            idxs[1].indices[subidxs[1].indices]),
+                                    reindex(V, tail(idxs), tail(subidxs))...))
+
+reindex(V, idxs::Tuple{BlockSlice{<:BlockRange}, Vararg{Any}},
+        subidxs::Tuple{BlockSlice{<:Block{1}}, Vararg{Any}}) =
+    (@_propagate_inbounds_meta; (BlockSlice(idxs[1].block.indices[1][Int(subidxs[1].block)]),
+                                            idxs[1].indices[subidxs[1].indices]),
+                                    reindex(V, tail(idxs), tail(subidxs))...))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,10 +1,4 @@
-using BlockArrays
-
-if VERSION > v"0.7.0-DEV.2004"
-    using Test
-else
-    using Base.Test
-end
+using BlockArrays, Compat, Compat.Test
 
 
 include("test_blockindices.jl")

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -254,3 +254,55 @@ end
     A[Block(2,3)] = ones(2,3)
     @test A[Block(2,3)] == ones(2,3)
 end
+
+@testset "Block arithmetic" begin
+    @test +(Block(1)) == Block(1)
+    @test -(Block(1)) == Block(-1)
+    @test Block(2) + Block(1) == Block(3)
+    @test Block(2) + 1 == Block(3)
+    @test 2 + Block(1) == Block(3)
+    @test Block(2) - Block(1) == Block(1)
+    @test Block(2) - 1 == Block(1)
+    @test 2 - Block(1) == Block(1)
+    @test 2*Block(1) == Block(2)
+    @test Block(1)*2 == Block(2)
+
+    @test isless(Block(1), Block(2))
+    @test !isless(Block(1), Block(1))
+    @test !isless(Block(2), Block(1))
+    @test Block(1) < Block(2)
+    @test Block(1) ≤ Block(1)
+    @test Block(2) > Block(1)
+    @test Block(1) ≥ Block(1)
+    @test min(Block(1), Block(2)) == Block(1)
+    @test max(Block(1), Block(2)) == Block(2)
+
+    @test +(Block(1,2)) == Block(1,2)
+    @test -(Block(1,2)) == Block(-1,-2)
+    @test Block(1,2) + Block(2,3) == Block(3,5)
+    @test Block(1,2) + 1 == Block(2,3)
+    @test 1 + Block(1,2) == Block(2,3)
+    @test Block(2,3) - Block(1,2) == Block(1,1)
+    @test Block(1,2) - 1 == Block(0,1)
+    @test 1 - Block(1,2) == Block(0,-1)
+    @test 2*Block(1,2) == Block(2,4)
+    @test Block(1,2)*2 == Block(2,4)
+
+    @test isless(Block(1,1), Block(2,2))
+    @test isless(Block(1,1), Block(2,1))
+    @test !isless(Block(1,1), Block(1,1))
+    @test !isless(Block(2,1), Block(1,1))
+    @test Block(1,1) < Block(2,1)
+    @test Block(1,1) ≤ Block(1,1)
+    @test Block(2,1) > Block(1,1)
+    @test Block(1,1) ≥ Block(1,1)
+    @test min(Block(1,2), Block(2,2)) == Block(1,2)
+    @test max(Block(1,2), Block(2,2)) == Block(2,2)
+
+    @test convert(Int, Block(2)) == 2
+    @test convert(Float64, Block(2)) == 2.0
+
+    @test_throws MethodError convert(Int, Block(2,1))
+    @test convert(Tuple{Int,Int}, Block(2,1)) == (2,1)
+    @test convert(Tuple{Float64,Int}, Block(2,1)) == (2.0,1)
+end

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -1,4 +1,6 @@
-
+if VERSION ≥ v"0.7.0-DEV.3465"
+    using SparseArrays
+end
 import BlockArrays: _BlockArray
 
 
@@ -122,7 +124,7 @@ end
         end
         fill!(BA_1, 1.0)
         @test BA_1 == ones(size(BA_1))
-        ran = rand(size(BA_1))
+        ran = rand(size(BA_1)...)
         copy!(BA_1, ran)
         @test BA_1 == ran
 
@@ -153,7 +155,7 @@ end
         end
         fill!(BA_2, 1.0)
         @test BA_2 == ones(size(BA_2))
-        ran = rand(size(BA_2))
+        ran = rand(size(BA_2)...)
         copy!(BA_2, ran)
         @test BA_2 == ran
 
@@ -183,7 +185,7 @@ end
         end
         fill!(BA_3, 1.0)
         @test BA_3 == ones(size(BA_3))
-        ran = rand(size(BA_3))
+        ran = rand(size(BA_3)...)
         copy!(BA_3, ran)
         @test BA_3 == ran
     end

--- a/test/test_blockrange.jl
+++ b/test/test_blockrange.jl
@@ -9,6 +9,7 @@
     @test eltype(BlockRange{1}) == Block{1,Int}
     @test Block(1):Block(3) == BlockRange((1:3,))
     @test Block.(1:3) == BlockRange((1:3,))
+    @test Int.(BlockRange((1:3,))) == 1:3
 
     @test collect(Block(1):Block(2)) == Block.([1,2])
 

--- a/test/test_blockrange.jl
+++ b/test/test_blockrange.jl
@@ -38,3 +38,36 @@
     B = BlockRange((1:2,1:2))
     @test collect(B) == [Block(1,1) Block(1,2); Block(2,1) Block(2,2)]
 end
+
+
+using BlockArrays
+    import BlockArrays: _cumul_sizes
+A = BlockArray(collect(1:6), 1:3)
+    V = view(A, Block.(1:2))
+    BlockArrays.to_indices(V, (Block(1),))
+A = V“
+    V = A
+    j = 1
+    sl = parentindexes(V)[j]
+
+    A = parent(V)
+    _cumul_sizes(A, j)
+
+sl.block.indices
+ret .- ret[1] .+ 1
+BlockArrays._cumul_sizes(A, 1)
+
+cie
+
+parent(A)
+inds, I = (indices(A),(Block.(1:2),))
+typeof(A)
+BlockArrays.unblock(A, inds, I)
+
+N = 1
+BlockArrays._unblock(BlockArrays._cumul_sizes(A, N - length(inds) + 1), I)
+BlockArrays._cumul_sizes(A, 1 - length(inds) + 1)
+
+
+typeof(A)
+parentindexes(V)

--- a/test/test_blockviews.jl
+++ b/test/test_blockviews.jl
@@ -84,3 +84,26 @@ end
     @test view(A, 1, Block(2), 1) == A[1,2:3,1]
     @test view(A, 1, 2, Block(2)) == A[1,2,2:3]
 end
+
+@testset "block view pointers" begin
+    A = BlockArray(reshape(Vector{Float64}(1:(6^2)),6,6), 1:3, 1:3)
+
+    V = view(A, Block(1,2))
+    @test Base.unsafe_convert(Ptr{Float64}, V) == Base.unsafe_convert(Ptr{Float64}, A.blocks[1,2])
+    @test unsafe_load(pointer(V)) == V[1,1]
+
+
+    A = PseudoBlockArray(reshape(Vector{Float64}(1:(6^2)),6,6), 1:3, 1:3)
+
+    V = view(A, Block(1,2))
+    @test Base.unsafe_convert(Ptr{Float64}, V) == Base.unsafe_convert(Ptr{Float64}, view(A.blocks, 1:1, 2:3))
+    @test unsafe_load(pointer(V)) == V[1,1]
+
+    V = view(A, Block(2), 2:3)
+    @test Base.unsafe_convert(Ptr{Float64}, V) == Base.unsafe_convert(Ptr{Float64}, view(A.blocks, 2:3, 2:3))
+    @test unsafe_load(pointer(V)) == V[1,1]
+
+    V = view(A, 2:3, Block(2))
+    @test Base.unsafe_convert(Ptr{Float64}, V) == Base.unsafe_convert(Ptr{Float64}, view(A.blocks, 2:3, 2:3))
+    @test unsafe_load(pointer(V)) == V[1,1]
+end


### PR DESCRIPTION
This taps into Base's `view` infrastructure to properly support, for example, `view(view(A, Block.(1:2)), Block(1))`.

It also contains Pull Request #42.