### PR TITLE
fix inlining expression usage in generated functions

### DIFF
--- a/src/blockindices.jl
+++ b/src/blockindices.jl
@@ -38,7 +38,7 @@ end
     @assert M < N
     α_ex = Expr(:tuple, [k <= M ? :(α[$k]) : :(1) for k = 1:N]...)
     return quote
-        $Expr(:meta, :inline)
+        $(Expr(:meta, :inline))
         @inbounds α2 = $α_ex
         BlockIndex(I, α2)
     end
@@ -54,7 +54,7 @@ Converts from global indices `inds` to a `BlockIndex`.
     I_ex = Expr(:tuple, [:(block_index[$k][1]) for k = 1:N]...)
     α_ex = Expr(:tuple, [:(block_index[$k][2]) for k = 1:N]...)
     return quote
-        $Expr(:meta, :inline)
+        $(Expr(:meta, :inline))
         @inbounds block_index = $block_index_ex
         @inbounds I = $I_ex
         @inbounds α = $α_ex
@@ -70,7 +70,7 @@ Converts from a block index to a tuple containing the global indices
 @generated function blockindex2global(block_sizes::BlockSizes{N}, block_index::BlockIndex{N}) where {N}
     ex = Expr(:tuple, [:(block_sizes[$k, block_index.I[$k]] + block_index.α[$k] - 1) for k = 1:N]...)
     return quote
-        $Expr(:meta, :inline)
+        $(Expr(:meta, :inline))
         @inbounds v = $ex
         return $ex
     end

--- a/src/blocksizes.jl
+++ b/src/blocksizes.jl
@@ -109,7 +109,7 @@ end
 @generated function globalrange(block_sizes::BlockSizes{N}, block_index::NTuple{N, Int}) where {N}
     indices_ex = Expr(:tuple, [:(block_sizes[$i, block_index[$i]]:block_sizes[$i, block_index[$i] + 1] - 1) for i = 1:N]...)
     return quote
-        $Expr(:meta, :inline)
+        $(Expr(:meta, :inline))
         @inbounds inds = $indices_ex
         return inds
     end

--- a/test/test_blockindices.jl
+++ b/test/test_blockindices.jl
@@ -18,18 +18,18 @@ block_size = BlockSizes([1,2,3], [2, 3])
 @test nblocks(block_size, 1) == 3
 @test nblocks(block_size, 2) == 2
 
-@inferred globalrange(block_size, (1,1)) == (1:1, 1:2)
-@inferred globalrange(block_size, (1,2)) == (1:1, 3:5)
-@inferred globalrange(block_size, (2,1)) == (2:3, 1:2)
-@inferred globalrange(block_size, (2,2)) == (2:3, 3:5)
+@test @inferred(globalrange(block_size, (1,1))) == (1:1, 1:2)
+@test @inferred(globalrange(block_size, (1,2))) == (1:1, 3:5)
+@test @inferred(globalrange(block_size, (2,1))) == (2:3, 1:2)
+@test @inferred(globalrange(block_size, (2,2))) == (2:3, 3:5)
 
-@inferred global2blockindex(block_size, (3, 1)) == BlockIndex((2,1), (2,1))
-@inferred global2blockindex(block_size, (1, 4)) == BlockIndex((1,2), (1,2))
-@inferred global2blockindex(block_size, (4, 5)) == BlockIndex((3,2), (1,3))
+@test @inferred(global2blockindex(block_size, (3, 1))) == BlockIndex((2,1), (2,1))
+@test @inferred(global2blockindex(block_size, (1, 4))) == BlockIndex((1,2), (1,2))
+@test @inferred(global2blockindex(block_size, (4, 5))) == BlockIndex((3,2), (1,3))
 
-@inferred blockindex2global(block_size, BlockIndex((2,1), (2,1))) == (3, 1)
-@inferred blockindex2global(block_size, BlockIndex((1,2), (1,2))) == (1, 4)
-@inferred blockindex2global(block_size, BlockIndex((3,2), (1,3))) == (4, 5)
+@test @inferred(blockindex2global(block_size, BlockIndex((2,1), (2,1)))) == (3, 1)
+@test @inferred(blockindex2global(block_size, BlockIndex((1,2), (1,2)))) == (1, 4)
+@test @inferred(blockindex2global(block_size, BlockIndex((3,2), (1,3)))) == (4, 5)
 
 
 @test block_size == BlockSizes(1:3, 2:3)

--- a/test/test_blockindices.jl
+++ b/test/test_blockindices.jl
@@ -23,14 +23,24 @@ block_size = BlockSizes([1,2,3], [2, 3])
 @test @inferred(globalrange(block_size, (2,1))) == (2:3, 1:2)
 @test @inferred(globalrange(block_size, (2,2))) == (2:3, 3:5)
 
+# Test for allocations inside a function to avoid noise due to global 
+# variable references
+wrapped_allocations = (bs, i) -> @allocated(globalrange(bs, i))
+@test wrapped_allocations(block_size, (1, 1)) == 0
+
 @test @inferred(global2blockindex(block_size, (3, 1))) == BlockIndex((2,1), (2,1))
 @test @inferred(global2blockindex(block_size, (1, 4))) == BlockIndex((1,2), (1,2))
 @test @inferred(global2blockindex(block_size, (4, 5))) == BlockIndex((3,2), (1,3))
+
+wrapped_allocations = (bs, i) -> @allocated(global2blockindex(bs, i))
+@test wrapped_allocations(block_size, (3, 1)) == 0
 
 @test @inferred(blockindex2global(block_size, BlockIndex((2,1), (2,1)))) == (3, 1)
 @test @inferred(blockindex2global(block_size, BlockIndex((1,2), (1,2)))) == (1, 4)
 @test @inferred(blockindex2global(block_size, BlockIndex((3,2), (1,3)))) == (4, 5)
 
+wrapped_allocations = (bs, i) -> @allocated(blockindex2global(bs, i))
+@test wrapped_allocations(block_size, BlockIndex((2,1), (2,1))) == 0
 
 @test block_size == BlockSizes(1:3, 2:3)
 


### PR DESCRIPTION
See https://github.com/JuliaMatrices/BlockBandedMatrices.jl/issues/10#issuecomment-399229062

All of the `$Expr(:meta, :inline)` lines are doing the wrong thing currently: they're interpolating *just* the `Expr` symbol, not the entire expression, which actually results in trying to construct a new `Expr` at run-time inside each generated function body. Fixing this brings things like `global2blockindex` down to 0 memory allocation and improves performance substantially. 