### PR TITLE
Define dataids for BlockArray

### DIFF
--- a/src/BlockArrays.jl
+++ b/src/BlockArrays.jl
@@ -23,6 +23,7 @@ import Base: @propagate_inbounds, Array, to_indices, to_index,
             RangeIndex, Int, Integer, Number,
             +, -, min, max, *, isless, in, copy, copyto!, axes, @deprecate,
             BroadcastStyle
+using Base: dataids
 
 
 

--- a/src/blockarray.jl
+++ b/src/blockarray.jl
@@ -276,6 +276,10 @@ end
     getblock(block_array, block_index.I...)[block_index.α...] = v
 end
 
+Base.dataids(arr::BlockArray) = (dataids(arr.blocks)..., dataids(arr.block_sizes)...)
+# This is not entirely valid.  In principle, we have to concatenate
+# all dataids of all blocks.  However, it makes `dataids` non-inferable.
+
 ########
 # Misc #
 ########

--- a/src/blocksizes.jl
+++ b/src/blocksizes.jl
@@ -26,6 +26,11 @@ BlockSizes(sizes::Vararg{AbstractVector{Int}, N}) where {N} =
 
 Base.:(==)(a::BlockSizes, b::BlockSizes) = cumulsizes(a) == cumulsizes(b)
 
+Base.dataids(b::BlockSizes) = _splatmap(dataids, b.cumul_sizes)
+# _splatmap taken from Base:
+_splatmap(f, ::Tuple{}) = ()
+_splatmap(f, t::Tuple) = (f(t[1])..., _splatmap(f, tail(t))...)
+
 function _cumul_vec(v::AbstractVector{T}) where {T}
     v_cumul = similar(v, length(v) + 1)
     z = one(T)


### PR DESCRIPTION
Previously, `Base.dataids(::BlockArray)` was calling `objectid` which was rather slow:

```
julia> x = BlockArray(randn(6), 1:3);

julia> @btime Base.objectid($x)  # equivalent to dataids($x) before this PR
  150.738 ns (0 allocations: 0 bytes)
0x34d4c35d64a7d6ef

julia> @btime Base.dataids($x)
  1.647 ns (0 allocations: 0 bytes)
(0x00007fc3cc79fc40, 0x00007fc3cc79fbd0)
```

This patch also makes alias detection slightly stronger for block arrays.  But I then noticed that block arrays can't have proper `dataids` because the number of "data arrays" can't be determined by the type parameters (if we try to make it precise, `dataids` cannot be inferred and also it's not O(1) function anymore).

FYI we are trying to improve alias detection in `Base`.  The discussion in Julia repo is not super relevant to this issue.  But I wonder this should be taken into account if we were to redesign it in `Base`: https://github.com/JuliaLang/julia/pull/29546
