### PR TITLE
Optimizing the block-style broadcasting

### DIFF
--- a/src/BlockArrays.jl
+++ b/src/BlockArrays.jl
@@ -23,7 +23,7 @@ import Base: @propagate_inbounds, Array, to_indices, to_index,
             RangeIndex, Int, Integer, Number,
             +, -, min, max, *, isless, in, copy, copyto!, axes, @deprecate,
             BroadcastStyle
-using Base: dataids
+using Base: ReshapedArray, dataids
 
 
 

--- a/src/blockbroadcast.jl
+++ b/src/blockbroadcast.jl
@@ -118,3 +118,9 @@ end
         return dest
     end
 end
+
+@inline function Broadcast.instantiate(
+        bc::Broadcasted{Style}) where {Style <:AbstractBlockStyle}
+    bcf = Broadcast.flatten(Broadcasted{Nothing}(bc.f, bc.args, bc.axes))
+    return Broadcasted{Style}(bcf.f, bcf.args, bcf.axes)
+end

--- a/src/blockindexrange.jl
+++ b/src/blockindexrange.jl
@@ -93,16 +93,7 @@ end
         A::PseudoBlockArray{<:Any, N},
         I::Vararg{BlockSlice{<:BlockIndexRange{1}}, N}) where {N}
     @_propagate_inbounds_meta
-    return view(A.blocks, _pseudo_block_view_indices(A, I)...)
-end
-
-@inline function _pseudo_block_view_indices(A, I)
-    @_propagate_inbounds_meta
-    bs = blocksizes(A)
-    return ntuple(length(I)) do dim
-        x = I[dim]
-        (cumulsizes(bs, dim, x.block.block.n[1]) - 1) .+ x.block.indices[1]
-    end
+    return view(A.blocks, map(x -> x.indices, I)...)
 end
 
 @inline function Base.unsafe_view(
@@ -117,7 +108,7 @@ end
         A::AbstractArray{<:Any, N},
         I::Vararg{BlockSlice{<:BlockIndexRange{1}}, N}) where {N}
     @_propagate_inbounds_meta
-    return view(A, _pseudo_block_view_indices(A, I)...)
+    return view(A, map(x -> x.indices, I)...)
 end
 
 # Disambiguation
@@ -125,7 +116,7 @@ end
         A::SubArray,
         I::Vararg{BlockSlice{<:BlockIndexRange{1}}, N}) where {N}
     @_propagate_inbounds_meta
-    return view(A, _pseudo_block_view_indices(A, I)...)
+    return view(A, map(x -> x.indices, I)...)
 end
 
 

--- a/src/blockindexrange.jl
+++ b/src/blockindexrange.jl
@@ -82,7 +82,7 @@ reindex(V, idxs::Tuple{BlockSlice{<:BlockRange}, Vararg{Any}},
 # De-reference blocks before creating a view to avoid taking `global2blockindex`
 # path in `AbstractBlockStyle` broadcasting.
 @inline function Base.unsafe_view(
-        A::AbstractBlockArray{<:Any, N},
+        A::BlockArray{<:Any, N},
         I::Vararg{BlockSlice{<:BlockIndexRange{1}}, N}) where {N}
     @_propagate_inbounds_meta
     B = A[map(x -> x.block.block, I)...]

--- a/src/blockindexrange.jl
+++ b/src/blockindexrange.jl
@@ -120,6 +120,14 @@ end
     return view(A, _pseudo_block_view_indices(A, I)...)
 end
 
+# Disambiguation
+@inline function Base.unsafe_view(
+        A::SubArray,
+        I::Vararg{BlockSlice{<:BlockIndexRange{1}}, N}) where {N}
+    @_propagate_inbounds_meta
+    return view(A, _pseudo_block_view_indices(A, I)...)
+end
+
 
 # #################
 # # support for pointers

--- a/src/blockindexrange.jl
+++ b/src/blockindexrange.jl
@@ -79,7 +79,46 @@ reindex(V, idxs::Tuple{BlockSlice{<:BlockRange}, Vararg{Any}},
                                             idxs[1].indices[subidxs[1].indices]),
                                     reindex(V, tail(idxs), tail(subidxs))...))
 
+# De-reference blocks before creating a view to avoid taking `global2blockindex`
+# path in `AbstractBlockStyle` broadcasting.
+@inline function Base.unsafe_view(
+        A::AbstractBlockArray{<:Any, N},
+        I::Vararg{BlockSlice{<:BlockIndexRange{1}}, N}) where {N}
+    @_propagate_inbounds_meta
+    B = A[map(x -> x.block.block, I)...]
+    return view(B, _splatmap(x -> x.block.indices, I)...)
+end
 
+@inline function Base.unsafe_view(
+        A::PseudoBlockArray{<:Any, N},
+        I::Vararg{BlockSlice{<:BlockIndexRange{1}}, N}) where {N}
+    @_propagate_inbounds_meta
+    return view(A.blocks, _pseudo_block_view_indices(A, I)...)
+end
+
+@inline function _pseudo_block_view_indices(A, I)
+    @_propagate_inbounds_meta
+    bs = blocksizes(A)
+    return ntuple(length(I)) do dim
+        x = I[dim]
+        (cumulsizes(bs, dim, x.block.block.n[1]) - 1) .+ x.block.indices[1]
+    end
+end
+
+@inline function Base.unsafe_view(
+        A::ReshapedArray{<:Any, N, <:AbstractBlockArray{<:Any, M}},
+        I::Vararg{BlockSlice{<:BlockIndexRange{1}}, N}) where {N, M}
+    @_propagate_inbounds_meta
+    # Note: assuming that I[M+1:end] are verified to be singletons
+    return reshape(view(A.parent, I[1:M]...), Val(N))
+end
+
+@inline function Base.unsafe_view(
+        A::AbstractArray{<:Any, N},
+        I::Vararg{BlockSlice{<:BlockIndexRange{1}}, N}) where {N}
+    @_propagate_inbounds_meta
+    return view(A, _pseudo_block_view_indices(A, I)...)
+end
 
 
 # #################

--- a/src/views.jl
+++ b/src/views.jl
@@ -71,8 +71,15 @@ blocksizes(V::SubArray) = BlockSizes(_sub_cumul_sizes(cumulsizes(parent(V)), par
 
 Returns the indices associated with a block as a `BlockSlice`.
 """
-unblock(A::AbstractArray{T,N}, inds, I) where {T, N} = _unblock(cumulsizes(A, N - length(inds) + 1), I)
-
+function unblock(A::AbstractArray{T,N}, inds, I) where {T, N}
+    if length(inds) == 0
+        # Allow `ones(2)[Block(1)[1:1], Block(1)[1:1]]` which is
+        # similar to `ones(2)[1:1, 1:1]`.
+        _unblock(Base.OneTo(2), I)
+    else
+        _unblock(cumulsizes(A, N - length(inds) + 1), I)
+    end
+end
 
 
 to_index(::Block) = throw(ArgumentError("Block must be converted by to_indices(...)"))


### PR DESCRIPTION
I implemented a somewhat optimized version of the block-style broadcasting.  Before optimizing more, I think it's better to ask if this direction is good.

There are three ingredients:

(1) Generate the appropriate nested loop (using `@generated` function):

```julia
for (b¹₁, ..., b¹ₙ) in zip(...)
    for (b²₁, ..., b²ₙ) in zip(...)
        for ...
            for (bᵐ₁, ..., bᵐₙ) in zip(...)
                broadcast!(
                    bc.f,
                    view(dest, b¹₀, b²₀, ..., bᵐ₀),
                    view(bc.args[1], b¹₁, b²₁, ..., bᵐ₁),
                    ...,
                    view(bc.args[n], b¹ₙ, b²ₙ, ..., bᵐₙ),
                )
            end
        end
    end
end
```

where `bⁱⱼ :: BlockIndexRange` selects the "sub-block" of `i`-th dimension of `j`-th argument (`bc.args[j]`).  By a "sub-block" I meant a contiguous region within a block which is discovered by `combine_cumulsizes`.

(2) Define `view(::AbstractBlockArray, ::BlockIndexRange...)` which "de-reference" blocks and provide a view within the underlying array of each block (i.e., a view to the "sub-block").  This is required to avoid the indexing overhead.

(3) Flatten nested Broadcasted object such as:

```
julia> Meta.lower(Main, :(x .* y .* z))
:($(Expr(:thunk, CodeInfo(
1 ─ %1 = (Base.broadcasted)(*, x, y)
│   %2 = (Base.broadcasted)(*, %1, z)
│   %3 = (Base.materialize)(%2)
└──      return %3
))))
```

by defining `Broadcast.instantiate(::Broadcasted{<:AbstractBlockStyle})`.  This is required to analyze the block structure of each argument.


I think my implementation can be improved by turning the ad-hoc iterator `subblocks` by a proper iterator object.  But I thought it's better to discuss if this whole direction is good at this point.


### Benchmark

```julia
using BlockArrays
using FillArrays

function blocks_to_vector(blocks)
    R = eltype(blocks)
    T = eltype(R)
    @assert R <: AbstractVector
    ba = BlockArray{T, 1, R}(undef_blocks, size.(blocks, 1))
    ba.blocks .= blocks
    return ba
end

using BenchmarkTools
@btime (@. z = x + y + z) setup=begin
    n = 2^12
    x = blocks_to_vector([Fill(111.0, 4n), Fill(222.0, n)])
    y = blocks_to_vector([Fill(333.0, 4n), Fill(444.0, n)])
    z = randn(size(x, 1))
end
```

Before: `116.069 μs (2 allocations: 64 bytes)`
After: `21.777 μs (195 allocations: 8.58 KiB)`
