### PR TITLE
Add API for creating BlockArray from blocks

### DIFF
--- a/docs/src/lib/public.md
+++ b/docs/src/lib/public.md
@@ -46,6 +46,8 @@ blockcheckbounds
 BlockArray
 undef_blocks
 UndefBlocksInitializer
+blocks2array
+blocks2matrix
 ```
 
 

--- a/docs/src/lib/public.md
+++ b/docs/src/lib/public.md
@@ -46,8 +46,7 @@ blockcheckbounds
 BlockArray
 undef_blocks
 UndefBlocksInitializer
-blocks2array
-blocks2matrix
+mortar
 ```
 
 

--- a/src/BlockArrays.jl
+++ b/src/BlockArrays.jl
@@ -9,7 +9,7 @@ export AbstractBlockArray, AbstractBlockMatrix, AbstractBlockVector, AbstractBlo
 export Block, getblock, getblock!, setblock!, nblocks, blocksize, blocksizes, blockcheckbounds, BlockBoundsError, BlockIndex
 export BlockRange
 
-export BlockArray, BlockMatrix, BlockVector, BlockVecOrMat, blocks2array, blocks2matrix
+export BlockArray, BlockMatrix, BlockVector, BlockVecOrMat, mortar
 export PseudoBlockArray, PseudoBlockMatrix, PseudoBlockVector, PseudoBlockVecOrMat
 
 export undef_blocks, undef

--- a/src/BlockArrays.jl
+++ b/src/BlockArrays.jl
@@ -9,7 +9,7 @@ export AbstractBlockArray, AbstractBlockMatrix, AbstractBlockVector, AbstractBlo
 export Block, getblock, getblock!, setblock!, nblocks, blocksize, blocksizes, blockcheckbounds, BlockBoundsError, BlockIndex
 export BlockRange
 
-export BlockArray, BlockMatrix, BlockVector, BlockVecOrMat
+export BlockArray, BlockMatrix, BlockVector, BlockVecOrMat, blocks2array, blocks2matrix
 export PseudoBlockArray, PseudoBlockMatrix, PseudoBlockVector, PseudoBlockVecOrMat
 
 export undef_blocks, undef

--- a/src/blockarray.jl
+++ b/src/blockarray.jl
@@ -194,9 +194,9 @@ end
 end
 
 """
-    blocks2array(blocks::AbstractArray)
-    blocks2array(blocks::AbstractArray{R, N}, sizes_1, sizes_2, ..., sizes_N)
-    blocks2array(blocks::AbstractArray{R, N}, block_sizes::BlockSizes{N})
+    mortar(blocks::AbstractArray)
+    mortar(blocks::AbstractArray{R, N}, sizes_1, sizes_2, ..., sizes_N)
+    mortar(blocks::AbstractArray{R, N}, block_sizes::BlockSizes{N})
 
 Construct a `BlockArray` from `blocks`.  `block_sizes` is computed from
 `blocks` if it is not given.
@@ -211,27 +211,27 @@ julia> blocks = permutedims(reshape([
  [1.0 1.0 1.0]               [2.0 2.0]
  [3.0 3.0 3.0; 3.0 3.0 3.0]  [4.0 4.0; 4.0 4.0]
 
-julia> blocks2array(blocks)
+julia> mortar(blocks)
 3×5 BlockArray{Float64,2,Array{Float64,2}}:
  1.0  1.0  1.0  │  2.0  2.0
  ───────────────┼──────────
  3.0  3.0  3.0  │  4.0  4.0
  3.0  3.0  3.0  │  4.0  4.0
 
-julia> ans == blocks2matrix(
+julia> ans == mortar(
            (1ones(1, 3), 2ones(1, 2)),
            (3ones(2, 3), 4ones(2, 2)),
        )
 true
 ```
 """
-blocks2array(blocks::AbstractArray{R, N}, block_sizes::BlockSizes{N}) where {R, N} =
+mortar(blocks::AbstractArray{R, N}, block_sizes::BlockSizes{N}) where {R, N} =
     _BlockArray(convert(Array, blocks), block_sizes)
 
-blocks2array(blocks::AbstractArray{R, N}, block_sizes::Vararg{AbstractVector{Int}, N}) where {R, N} =
+mortar(blocks::AbstractArray{R, N}, block_sizes::Vararg{AbstractVector{Int}, N}) where {R, N} =
     _BlockArray(convert(Array, blocks), block_sizes...)
 
-blocks2array(blocks::AbstractArray) = blocks2array(blocks, sizes_from_blocks(blocks)...)
+mortar(blocks::AbstractArray) = mortar(blocks, sizes_from_blocks(blocks)...)
 
 function sizes_from_blocks(blocks::AbstractArray{<:Any, N}) where N
     if length(blocks) == 0
@@ -266,13 +266,13 @@ getsizes(block_sizes, block_index) = getindex.(block_sizes, block_index)
 end
 
 """
-    blocks2matrix((block_11, ..., block_1m), ... (block_n1, ..., block_nm))
+    mortar((block_11, ..., block_1m), ... (block_n1, ..., block_nm))
 
 Construct a `BlockMatrix` with `n * m`  blocks.  Each `block_ij` must be an
-`AbstractMatrix`.  See [`blocks2array`](@ref).
+`AbstractMatrix`.
 """
-blocks2matrix(rows::Vararg{NTuple{M, AbstractMatrix}}) where M =
-    blocks2array(permutedims(reshape(
+mortar(rows::Vararg{NTuple{M, AbstractMatrix}}) where M =
+    mortar(permutedims(reshape(
         foldl(append!, rows, init=eltype(eltype(rows))[]),
         M, length(rows))))
 

--- a/src/blockarray.jl
+++ b/src/blockarray.jl
@@ -193,6 +193,89 @@ end
     end
 end
 
+"""
+    blocks2array(blocks::AbstractArray)
+    blocks2array(blocks::AbstractArray{R, N}, sizes_1, sizes_2, ..., sizes_N)
+    blocks2array(blocks::AbstractArray{R, N}, block_sizes::BlockSizes{N})
+
+Construct a `BlockArray` from `blocks`.  `block_sizes` is computed from
+`blocks` if it is not given.
+
+# Examples
+```jldoctest
+julia> blocks = permutedims(reshape([
+           1ones(1, 3), 2ones(1, 2),
+           3ones(2, 3), 4ones(2, 2),
+       ], (2, 2)))
+2×2 Array{Array{Float64,2},2}:
+ [1.0 1.0 1.0]               [2.0 2.0]
+ [3.0 3.0 3.0; 3.0 3.0 3.0]  [4.0 4.0; 4.0 4.0]
+
+julia> blocks2array(blocks)
+3×5 BlockArray{Float64,2,Array{Float64,2}}:
+ 1.0  1.0  1.0  │  2.0  2.0
+ ───────────────┼──────────
+ 3.0  3.0  3.0  │  4.0  4.0
+ 3.0  3.0  3.0  │  4.0  4.0
+
+julia> ans == blocks2matrix(
+           (1ones(1, 3), 2ones(1, 2)),
+           (3ones(2, 3), 4ones(2, 2)),
+       )
+true
+```
+"""
+blocks2array(blocks::AbstractArray{R, N}, block_sizes::BlockSizes{N}) where {R, N} =
+    _BlockArray(convert(Array, blocks), block_sizes)
+
+blocks2array(blocks::AbstractArray{R, N}, block_sizes::Vararg{AbstractVector{Int}, N}) where {R, N} =
+    _BlockArray(convert(Array, blocks), block_sizes...)
+
+blocks2array(blocks::AbstractArray) = blocks2array(blocks, sizes_from_blocks(blocks)...)
+
+function sizes_from_blocks(blocks::AbstractArray{<:Any, N}) where N
+    if length(blocks) == 0
+        return zeros.(Int, size(blocks))
+    end
+    if !all(b -> ndims(b) == N, blocks)
+        error("All blocks must have ndims consistent with ndims = $N of `blocks` array.")
+    end
+    fullsizes = map!(size, Array{NTuple{N,Int}, N}(undef, size(blocks)), blocks)
+    block_sizes = ntuple(ndims(blocks)) do i
+        [s[i] for s in view(fullsizes, ntuple(j -> j == i ? (:) : 1, ndims(blocks))...)]
+    end
+    checksizes(fullsizes, block_sizes)
+    return block_sizes
+end
+
+getsizes(block_sizes, block_index) = getindex.(block_sizes, block_index)
+
+@generated function checksizes(fullsizes::Array{NTuple{N,Int}, N}, block_sizes::NTuple{N,Vector{Int}}) where N
+    quote
+        @nloops $N i fullsizes begin
+            block_index = @ntuple $N i
+            if fullsizes[block_index...] != getsizes(block_sizes, block_index)
+                error("size(blocks[", strip(repr(block_index), ['(', ')']),
+                      "]) (= ", fullsizes[block_index...],
+                      ") is incompatible with expected size: ",
+                      getsizes(block_sizes, block_index))
+            end
+        end
+        return fullsizes
+    end
+end
+
+"""
+    blocks2matrix((block_11, ..., block_1m), ... (block_n1, ..., block_nm))
+
+Construct a `BlockMatrix` with `n * m`  blocks.  Each `block_ij` must be an
+`AbstractMatrix`.  See [`blocks2array`](@ref).
+"""
+blocks2matrix(rows::Vararg{NTuple{M, AbstractMatrix}}) where M =
+    blocks2array(permutedims(reshape(
+        foldl(append!, rows, init=eltype(eltype(rows))[]),
+        M, length(rows))))
+
 # Convert AbstractArrays that conform to block array interface
 convert(::Type{BlockArray{T,N,R}}, A::BlockArray{T,N,R}) where {T,N,R} = A
 convert(::Type{BlockArray{T,N}}, A::BlockArray{T,N}) where {T,N} = A

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -89,14 +89,14 @@ end
     @testset for sizes in [(1:3,), (1:3, 1:3), (1:3, 1:3, 1:3)]
         dims = sum.(sizes)
         A = BlockArray(copy(reshape(1:prod(dims), dims)), sizes...)
-        @test blocks2array(A.blocks) == A
+        @test mortar(A.blocks) == A
     end
 
-    ret = blocks2array([spzeros(2), spzeros(3)])
+    ret = mortar([spzeros(2), spzeros(3)])
     @test eltype(ret.blocks) <: SparseVector
     @test blocksizes(ret) == BlockArrays.BlockSizes([2, 3])
 
-    ret = blocks2matrix(
+    ret = mortar(
         (spzeros(1, 3), spzeros(1, 4)),
         (spzeros(2, 3), spzeros(2, 4)),
         (spzeros(5, 3), spzeros(5, 4)),
@@ -106,13 +106,13 @@ end
     @test blocksizes(ret) == BlockArrays.BlockSizes([1, 2, 5], [3, 4])
 
     test_error_message("must have ndims consistent with ndims = 1") do
-        blocks2array([ones(2,2)])
+        mortar([ones(2,2)])
     end
     test_error_message("must have ndims consistent with ndims = 2") do
-        blocks2array(reshape([ones(2), ones(2, 2)], (1, 2)))
+        mortar(reshape([ones(2), ones(2, 2)], (1, 2)))
     end
     test_error_message("size(blocks[2, 2]) (= (111, 222)) is incompatible with expected size: (2, 4)") do
-        blocks2matrix(
+        mortar(
             (zeros(1, 3), zeros(1, 4)),
             (zeros(2, 3), zeros(111, 222)),
         )


### PR DESCRIPTION
This PR adds two new API functions `blocks2array` and `blocks2matrix` for constructing `BlockArray` directly from blocks specified by the user.  It closes #62.

Does it make sense to add this API?  Here is the proposed API:

>     blocks2array(blocks::AbstractArray)
>     blocks2array(blocks::AbstractArray{R, N}, sizes_1, sizes_2, ..., sizes_N)
>     blocks2array(blocks::AbstractArray{R, N}, block_sizes::BlockSizes{N})
> 
> construct a `BlockArray` from `blocks`.  `block_sizes` is computed from
> `blocks` if it is not given.
>
>     blocks2matrix((block_11, ..., block_1m), ... (block_n1, ..., block_nm))
>
> Construct a `BlockMatrix` with `n * m`  blocks.  Each `block_ij` must be an
> `AbstractMatrix`.
>
> #### Examples
> ```julia
> julia> blocks = permutedims(reshape([
>            1ones(1, 3), 2ones(1, 2),
>            3ones(2, 3), 4ones(2, 2),
>        ], (2, 2)))
> 2×2 Array{Array{Float64,2},2}:
>  [1.0 1.0 1.0]               [2.0 2.0]
>  [3.0 3.0 3.0; 3.0 3.0 3.0]  [4.0 4.0; 4.0 4.0]
> 
> julia> blocks2array(blocks)
> 3×5 BlockArray{Float64,2,Array{Float64,2}}:
>  1.0  1.0  1.0  │  2.0  2.0
>  ───────────────┼──────────
>  3.0  3.0  3.0  │  4.0  4.0
>  3.0  3.0  3.0  │  4.0  4.0
> 
> julia> ans == blocks2matrix(
>            (1ones(1, 3), 2ones(1, 2)),
>            (3ones(2, 3), 4ones(2, 2)),
>        )
> true
> ```

I wondered if I should call it `blocks2array` or `blockstoarray` but it seems that "`x2y`" is more popular in Julia, especially in mathematical functions:

```console
$ cd doc/src  # in Julia's Git repository

$ rg '\.[a-z]+to[a-z]+$'
base/io-network.md
132:Base.ntoh
133:Base.hton
134:Base.ltoh
135:Base.htol

base/math.md
30:Base.numerator
31:Base.denominator
164:Base.factorial

$ rg '\.[a-z]+2[a-z]+$'
base/math.md
21:Base.rem2pi
22:Base.Math.mod2pi
101:Base.Math.deg2rad
102:Base.Math.rad2deg

base/numbers.md
57:Base.hex2bytes
59:Base.bytes2hex
```
