### PR TITLE
Fix broadcast for BlockArray-of-Fill

### DIFF
--- a/src/blockindexrange.jl
+++ b/src/blockindexrange.jl
@@ -104,6 +104,12 @@ end
     return reshape(view(A.parent, I[1:M]...), Val(N))
 end
 
+@inline function Base.unsafe_view(
+        A::Array{<:Any, N},
+        I::Vararg{BlockSlice{<:BlockIndexRange{1}}, N}) where {N}
+    @_propagate_inbounds_meta
+    return view(A, map(x -> x.indices, I)...)
+end
 
 # #################
 # # support for pointers

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,1 +1,2 @@
 Documenter
+FillArrays

--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,2 +1,1 @@
 Documenter
-FillArrays

--- a/test/test_blockbroadcast.jl
+++ b/test/test_blockbroadcast.jl
@@ -89,11 +89,11 @@ using BlockArrays, Test
 
     @testset "UnitRange" begin
         n = 3
-        xblocks = [1:4n, 1:n]
-        x = BlockArrays._BlockArray(xblocks, [4n, n])
+        x = mortar([1:4n, 1:n])
+        @test eltype(x.blocks) <: UnitRange
         y = 1:length(x)
         z = randn(size(x))
-        x2 = vcat(xblocks...)
+        x2 = vcat(x.blocks...)
         y2 = copy(y)
         z2 = copy(z)
         @test (@. z = x + y + z; z) == (@. z2 = x2 + y2 + z2; z2)

--- a/test/test_blockbroadcast.jl
+++ b/test/test_blockbroadcast.jl
@@ -1,4 +1,5 @@
 using BlockArrays, Test
+using FillArrays
 
 @testset "broadcast" begin
     @testset "BlockArray" begin
@@ -85,5 +86,17 @@ using BlockArrays, Test
         B = BlockArray(randn(6,6), fill(2,3), fill(3,2))
 
         @test blocksizes(A+B) == BlockArrays.BlockSizes([1,1,1,1,2], 1:3)
+    end
+
+    @testset "Fill" begin
+        n = 3
+        xblocks = [Fill(111.0, 4n), Fill(222.0, n)]
+        x = BlockArrays._BlockArray(xblocks, [4n, n])
+        y = Fill(333, size(x))
+        z = randn(size(x))
+        x2 = vcat(xblocks...)
+        y2 = copy(y)
+        z2 = copy(z)
+        @test (@. z = x + y + z; z) == (@. z2 = x2 + y2 + z2; z2)
     end
 end

--- a/test/test_blockbroadcast.jl
+++ b/test/test_blockbroadcast.jl
@@ -1,5 +1,4 @@
 using BlockArrays, Test
-using FillArrays
 
 @testset "broadcast" begin
     @testset "BlockArray" begin
@@ -88,11 +87,11 @@ using FillArrays
         @test blocksizes(A+B) == BlockArrays.BlockSizes([1,1,1,1,2], 1:3)
     end
 
-    @testset "Fill" begin
+    @testset "UnitRange" begin
         n = 3
-        xblocks = [Fill(111.0, 4n), Fill(222.0, n)]
+        xblocks = [1:4n, 1:n]
         x = BlockArrays._BlockArray(xblocks, [4n, n])
-        y = Fill(333, size(x))
+        y = 1:length(x)
         z = randn(size(x))
         x2 = vcat(xblocks...)
         y2 = copy(y)


### PR DESCRIPTION
First commit adds the test for the broadcasting with a block array whose blocks are `Fill` (similar to the benchmark I posted in #66).  It fails in master branch with the following error message:

```julia
julia> begin
           n = 3
           xblocks = [Fill(111.0, 4n), Fill(222.0, n)]
           x = BlockArrays._BlockArray(xblocks, [4n, n])
           y = randn(size(x))
           x2 = vcat(xblocks...)
           y2 = copy(y)
           (@. y = x + y; y) == (@. y2 = x2 + y2; y2)
       end
ERROR: MethodError: no method matching BlockArrays.BlockSlice{BlockIndexRange{1,Tuple{UnitRange{Int64}}}}(::Base.OneTo{Int64})
Closest candidates are:
  BlockArrays.BlockSlice{BlockIndexRange{1,Tuple{UnitRange{Int64}}}}(::Any, ::Any) where BB at /home/takafumi/.julia/dev/BlockArrays/src/views.jl:12
Stacktrace:
 [1] convert(::Type{BlockArrays.BlockSlice{BlockIndexRange{1,Tuple{UnitRange{Int64}}}}}, ::Base.OneTo{Int64}) at ./range.jl:143
 [2] oftype(::BlockArrays.BlockSlice{BlockIndexRange{1,Tuple{UnitRange{Int64}}}}, ::Base.OneTo{Int64}) at ./essentials.jl:341
 [3] _trimmedindex(::BlockArrays.BlockSlice{BlockIndexRange{1,Tuple{UnitRange{Int64}}}}) at ./subarray.jl:111
 [4] map(::typeof(Base._trimmedindex), ::Tuple{BlockArrays.BlockSlice{BlockIndexRange{1,Tuple{UnitRange{Int64}}}}}) at ./tuple.jl:125
 [5] unaliascopy(::SubArray{Float64,1,Array{Float64,1},Tuple{BlockArrays.BlockSlice{BlockIndexRange{1,Tuple{UnitRange{Int64}}}}},true}) at ./subarray.jl:107
 [6] materialize! at ./abstractarray.jl:1103 [inlined]
 [7] broadcast!(::typeof(+), ::SubArray{Float64,1,Array{Float64,1},Tuple{UnitRange{Int64}},true}, ::SubArray{Float64,1,Fill{Float64,1,Tuple{Base.OneTo{Int64}}},Tuple{UnitRange{Int64}},true}, ::SubArray{Float64,1,Array{Float64,1},Tuple{BlockArrays.BlockSlice{BlockIndexRange{1,Tuple{UnitRange{Int64}}}}},true}) at ./broadcast.jl:790
 [8] copyto!(::PseudoBlockArray{Float64,1,Array{Float64,1}}, ::Base.Broadcast.Broadcasted{BlockArrays.BlockStyle{1},Tuple{Base.OneTo{Int64}},typeof(+),Tuple{BlockArray{Float64,1,Fill{Float64,1,Tuple{Base.OneTo{Int64}}}},Array{Float64,1}}}) at /home/takafumi/.julia/dev/BlockArrays/src/blockbroadcast.jl:105
 [9] macro expansion at /home/takafumi/.julia/dev/BlockArrays/src/blockbroadcast.jl:113 [inlined]
 [10] copyto!(::Array{Float64,1}, ::Base.Broadcast.Broadcasted{BlockArrays.BlockStyle{1},Tuple{Base.OneTo{Int64}},typeof(+),Tuple{BlockArray{Float64,1,Fill{Float64,1,Tuple{Base.OneTo{Int64}}}},Array{Float64,1}}}) at /home/takafumi/.julia/dev/BlockArrays/src/blockbroadcast.jl:84
 [11] materialize!(::Array{Float64,1}, ::Base.Broadcast.Broadcasted{BlockArrays.BlockStyle{1},Nothing,typeof(+),Tuple{BlockArray{Float64,1,Fill{Float64,1,Tuple{Base.OneTo{Int64}}}},Array{Float64,1}}}) at ./broadcast.jl:800
 [12] top-level scope at REPL[41]:8
```

It looks like the issue is caused by [this specialization of `Base.unaliascopy`](https://github.com/JuliaLang/julia/blob/cd0da8c48e581f6e1441e56dac3f82e85f000f8f/base/subarray.jl#L102-L112):

```julia
# When the parent is an Array we can trim the size down a bit. In the future this
# could possibly be extended to any mutable array.
function unaliascopy(V::SubArray{T,N,A,I,LD}) where {T,N,A<:Array,I<:Tuple{Vararg{Union{Real,AbstractRange,Array}}},LD}
    dest = Array{T}(undef, index_lengths(V.indices...))
    copyto!(dest, V)
    SubArray{T,N,A,I,LD}(dest, map(_trimmedindex, V.indices), 0, Int(LD))
end
# Transform indices to be "dense"
_trimmedindex(i::Real) = oftype(i, 1)
_trimmedindex(i::AbstractUnitRange) = oftype(i, OneTo(length(i)))
_trimmedindex(i::AbstractArray) = oftype(i, reshape(eachindex(IndexLinear(), i), axes(i)))
```

Since it looks like there is no good public interface for modifying this behavior _and_ the approach I took in #66 was to convert indexing by `BlockIndexRange` to a broadcasting-friendly view, I suggest to convert `view(::Array, ::BlockIndexRange)` to a `SubArray` with "standard" indices (i.e., let's not use `BlockIndexRange`).  This way, the standard broadcasting mechanism just works for each block.  This is done in the second commit.
