### PR TITLE
Use a proper iterator in subblocks

### DIFF
--- a/docs/src/lib/internals.md
+++ b/docs/src/lib/internals.md
@@ -25,4 +25,5 @@ BlockRange
 BlockIndexRange
 BlockSlice
 unblock
+SubBlockIterator
 ```


### PR DESCRIPTION
This PR optimizes `subblocks` iterator used in block-style broadcasting to cut down more runtime and allocations.  I also added some explanations in the docstring.

Performance after PR:

```julia
julia> begin
       using BlockArrays, FillArrays
       n = 2^12
       x = mortar([Fill(0.111, 4n), Fill(0.222, n)])
       y = mortar([Fill(-0.111, 4n), Fill(-0.222, n)])
       z = randn(size(x, 1))
       end;

julia> using BenchmarkTools

julia> @btime $z .= $x .+ $y .+ z;
  11.149 μs (85 allocations: 5.69 KiB)
```

Before (f2f99cf996184327558e579f76db5b220c27460b):

```julia
julia> @btime $z .= $x .+ $y .+ z;
  18.813 μs (195 allocations: 8.30 KiB)
```

The remaining overhead probably come from small vectors allocated in `blocksizes`.  But I'm not planning to touch it in this PR.
