### PR TITLE
support general backends for BlockArray

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ docs/build/
 docs/site/
 *.jld
 benchmark/*.md
+src/.DS_Store

--- a/docs/src/man/abstractblockarrayinterface.md
+++ b/docs/src/man/abstractblockarrayinterface.md
@@ -28,7 +28,7 @@ With the methods above implemented the following are automatically provided:
 * A pretty printing `show` function that uses unicode lines to split up the blocks:
 ```
 julia> A = BlockArray(rand(4, 5), [1,3], [2,3])
-2×2-blocked 4×5 BlockArrays.BlockArray{Float64,2,Array{Float64,2}}:
+2×2-blocked 4×5 BlockArray{Float64,2}:
 0.61179   0.965631  │  0.696476   0.392796  0.712462
 --------------------┼-------------------------------
 0.620099  0.364706  │  0.0311643  0.27895   0.73477

--- a/docs/src/man/blockarrays.md
+++ b/docs/src/man/blockarrays.md
@@ -15,7 +15,7 @@ A block array can be created with initialized blocks using the `BlockArray{T}(bl
 function. The block_sizes are each an `AbstractVector{Int}` which determines the size of the blocks in that dimension. We here create a `[1,2]×[3,2]` block matrix of `Float32`s:
 ```julia
 julia> BlockArray{Float32}(undef, [1,2], [3,2])
-2×2-blocked 3×5 BlockArrays.BlockArray{Float32,2,Array{Float32,2}}:
+2×2-blocked 3×5 BlockArray{Float32,2}:
  9.39116f-26  1.4013f-45   3.34245f-21  │  9.39064f-26  1.4013f-45
  ───────────────────────────────────────┼──────────────────────────
  3.28434f-21  9.37645f-26  3.28436f-21  │  8.05301f-24  9.39077f-26

--- a/docs/src/man/blockarrays.md
+++ b/docs/src/man/blockarrays.md
@@ -30,7 +30,7 @@ The `block_type` should be an array type, it could for example be `Matrix{Float6
 
 ```jldoctest
 julia> BlockArray{Float32}(undef_blocks, [1,2], [3,2])
-3×5 BlockArray{Float32,2,Array{Float32,2}}:
+2×2-blocked 3×5 BlockArray{Float32,2}:
  #undef  #undef  #undef  │  #undef  #undef
  ────────────────────────┼────────────────
  #undef  #undef  #undef  │  #undef  #undef
@@ -42,7 +42,7 @@ specifying it as the second argument:
 
 ```jl
 julia> BlockArray(undef_blocks, SparseVector{Float64, Int}, [1,2])
-2-blocked 3-element BlockArrays.BlockArray{Float64,1,SparseVector{Float64,Int64}}:
+2-blocked 3-element BlockArray{Float64,1,Array{SparseVector{Float64,Int64},1},BlockArrays.BlockSizes{1,Array{Int64,1}}}:
  #undef
  ------
  #undef
@@ -59,14 +59,14 @@ An alternative syntax for this is `block_array[Block(i...)] = v` or
 
 ```jldoctest block_array
 julia> block_array = BlockArray{Float64}(undef_blocks, [1,2], [2,2])
-3×4 BlockArray{Float64,2,Array{Float64,2}}:
+2×2-blocked 3×4 BlockArray{Float64,2}:
  #undef  #undef  │  #undef  #undef
  ────────────────┼────────────────
  #undef  #undef  │  #undef  #undef
  #undef  #undef  │  #undef  #undef
 
 julia> setblock!(block_array, rand(2,2), 2, 1)
-3×4 BlockArray{Float64,2,Array{Float64,2}}:
+2×2-blocked 3×4 BlockArray{Float64,2}:
  #undef      #undef      │  #undef  #undef
  ────────────────────────┼────────────────
    0.590845    0.566237  │  #undef  #undef
@@ -75,7 +75,7 @@ julia> setblock!(block_array, rand(2,2), 2, 1)
 julia> block_array[Block(1, 1)] = [1 2];
 
 julia> block_array
-3×4 BlockArray{Float64,2,Array{Float64,2}}:
+2×2-blocked 3×4 BlockArray{Float64,2}:
  1.0       2.0       │  #undef  #undef
  ────────────────────┼────────────────
  0.590845  0.566237  │  #undef  #undef
@@ -112,7 +112,7 @@ We can also view and modify views of blocks of `BlockArray` using the `view` syn
 julia> A = BlockArray(ones(6), 1:3);
 
 julia> view(A, Block(2))
-2-element view(::BlockArray{Float64,1,Array{Float64,1}}, BlockSlice(Block{1,Int64}((2,)),2:3)) with eltype Float64:
+2-element view(::BlockArray{Float64,1,Array{Array{Float64,1},1},BlockArrays.BlockSizes{1,Array{Int64,1}}}, BlockSlice(Block{1,Int64}((2,)),2:3)) with eltype Float64:
  1.0
  1.0
 
@@ -130,7 +130,7 @@ An array can be repacked into a `BlockArray` with `BlockArray(array, block_sizes
 
 ```jl
 julia> block_array_sparse = BlockArray(sprand(4, 5, 0.7), [1,3], [2,3])
-2×2-blocked 4×5 BlockArrays.BlockArray{Float64,2,SparseMatrixCSC{Float64,Int64}}:
+2×2-blocked 4×5 BlockArray{Float64,2,Array{SparseMatrixCSC{Float64,Int64},2},BlockArrays.BlockSizes{2,Array{Int64,1}}}:
  0.0341601  0.374187  │  0.0118196  0.299058  0.0     
  ---------------------┼-------------------------------
  0.0945445  0.931115  │  0.0460428  0.0       0.0     
@@ -141,16 +141,19 @@ julia> block_array_sparse = BlockArray(sprand(4, 5, 0.7), [1,3], [2,3])
 To get back the underlying array use `Array`:
 
 ```jl
-julia> Array(block_array_sparse))
-4×5 SparseMatrixCSC{Float64,Int64} with 15 stored entries:
-  [1, 1]  =  0.0341601
-  [2, 1]  =  0.0945445
-  [3, 1]  =  0.314926
-  [4, 1]  =  0.12781
-  ⋮
-  [3, 3]  =  0.496169
-  [4, 3]  =  0.732
-  [1, 4]  =  0.299058
-  [4, 4]  =  0.449182
-  [4, 5]  =  0.875096
+julia> Array(block_array_sparse)
+4×5 SparseMatrixCSC{Float64,Int64} with 13 stored entries:
+  [1, 1]  =  0.30006
+  [2, 1]  =  0.451742
+  [3, 1]  =  0.243174
+  [4, 1]  =  0.156468
+  [1, 2]  =  0.94057
+  [3, 2]  =  0.544175
+  [4, 2]  =  0.598345
+  [3, 3]  =  0.737486
+  [4, 3]  =  0.929512
+  [1, 4]  =  0.539601
+  [3, 4]  =  0.757658
+  [4, 4]  =  0.44709
+  [2, 5]  =  0.514679
 ```

--- a/docs/src/man/pseudoblockarrays.md
+++ b/docs/src/man/pseudoblockarrays.md
@@ -23,7 +23,7 @@ Creating a `PseudoBlockArray` works in the same way as a `BlockArray`.
 
 ```jldoctest A
 julia> pseudo = PseudoBlockArray(rand(3,3), [1,2], [2,1])
-3×3 PseudoBlockArray{Float64,2,Array{Float64,2}}:
+2×2-blocked 3×3 PseudoBlockArray{Float64,2}:
  0.590845  0.460085  │  0.200586
  ────────────────────┼──────────
  0.766797  0.794026  │  0.298614
@@ -39,11 +39,11 @@ A block array can be created with uninitialized entries using the `BlockArray{T}
 function. The block_sizes are each an `AbstractVector{Int}` which determines the size of the blocks in that dimension. We here create a `[1,2]×[3,2]` block matrix of `Float32`s:
 ```julia
 julia> PseudoBlockArray{Float32}(undef, [1,2], [3,2])
-2×2-blocked 3×5 BlockArrays.BlockArray{Float32,2,Array{Float32,2}}:
- 9.39116f-26  1.4013f-45   3.34245f-21  │  9.39064f-26  1.4013f-45
+2×2-blocked 3×5 PseudoBlockArray{Float32,2}:
+ 1.02295e-43  0.0          1.09301e-43  │  0.0          1.17709e-43
  ───────────────────────────────────────┼──────────────────────────
- 3.28434f-21  9.37645f-26  3.28436f-21  │  8.05301f-24  9.39077f-26
- 1.4013f-45   1.4013f-45   1.4013f-45   │  1.4013f-45   1.4013f-45
+ 0.0          1.06499e-43  0.0          │  1.14906e-43  0.0        
+ 1.05097e-43  0.0          1.13505e-43  │  0.0          1.1911e-43 
 ```
 We can also any other user defined array type that supports `similar`.
 
@@ -83,7 +83,7 @@ We can also view and modify views of blocks of `PseudoBlockArray` using the `vie
 julia> A = PseudoBlockArray(ones(6), 1:3);
 
 julia> view(A, Block(2))
-2-element view(::PseudoBlockArray{Float64,1,Array{Float64,1}}, BlockSlice(Block{1,Int64}((2,)),2:3)) with eltype Float64:
+2-element view(::PseudoBlockArray{Float64,1,Array{Float64,1},BlockArrays.BlockSizes{1,Array{Int64,1}}}, BlockSlice(Block{1,Int64}((2,)),2:3)) with eltype Float64:
  1.0
  1.0
 

--- a/src/abstractblockarray.jl
+++ b/src/abstractblockarray.jl
@@ -139,11 +139,11 @@ julia> v = Array(reshape(1:6, (2, 3)))
  1  3  5
  2  4  6
 
- julia> A = BlockArray(v, [1,1], [2,1])
- 2×2-blocked 2×3 BlockArray{Int64,2}:
-  1  3  │  5
-  ──────┼───
-  2  4  │  6 
+julia> A = BlockArray(v, [1,1], [2,1])
+2×2-blocked 2×3 BlockArray{Int64,2}:
+ 1  3  │  5
+ ──────┼───
+ 2  4  │  6
 
 julia> getblock(A, 2, 1)
 1×2 Array{Int64,2}:
@@ -252,7 +252,7 @@ specialize this method if they need to provide custom block bounds checking beha
 julia> A = BlockArray(rand(2,3), [1,1], [2,1]);
 
 julia> blockcheckbounds(A, 3, 2)
-ERROR: BlockBoundsError: attempt to access 2×2-blocked 2×3 BlockArray{Float64,2,Array{Float64,2}} at block index [3,2]
+ERROR: BlockBoundsError: attempt to access 2×2-blocked 2×3 BlockArray{Float64,2,Array{Array{Float64,2},2},BlockArrays.BlockSizes{2,Array{Int64,1}}} at block index [3,2]
 [...]
 ```
 """

--- a/src/abstractblockarray.jl
+++ b/src/abstractblockarray.jl
@@ -23,6 +23,12 @@ const AbstractBlockVecOrMat{T} = Union{AbstractBlockMatrix{T}, AbstractBlockVect
 
 block2string(b, s) = string(join(map(string,b), '×'), "-blocked ", Base.dims2string(s))
 Base.summary(a::AbstractBlockArray) = string(block2string(nblocks(a), size(a)), " ", typeof(a))
+_show_typeof(io, a) = show(io, typeof(a))
+function Base.summary(io::IO, a::AbstractBlockArray) 
+    print(io, block2string(nblocks(a), size(a)))
+    print(io, ' ')
+    _show_typeof(io, a)
+end
 Base.similar(block_array::AbstractBlockArray{T}) where {T} = similar(block_array, T)
 Base.IndexStyle(::Type{<:AbstractBlockArray}) = IndexCartesian()
 

--- a/src/abstractblockarray.jl
+++ b/src/abstractblockarray.jl
@@ -67,7 +67,7 @@ a single element.
 
 ```jldoctest; setup = quote using BlockArrays end
 julia> A = BlockArray(ones(2,3), [1, 1], [2, 1])
-2×3 BlockArray{Float64,2,Array{Float64,2}}:
+2×2-blocked 2×3 BlockArray{Float64,2}:
  1.0  1.0  │  1.0
  ──────────┼─────
  1.0  1.0  │  1.0
@@ -139,11 +139,11 @@ julia> v = Array(reshape(1:6, (2, 3)))
  1  3  5
  2  4  6
 
-julia> A = BlockArray(v, [1,1], [2,1])
-2×3 BlockArray{Int64,2,Array{Int64,2}}:
- 1  3  │  5
- ──────┼───
- 2  4  │  6
+ julia> A = BlockArray(v, [1,1], [2,1])
+ 2×2-blocked 2×3 BlockArray{Int64,2}:
+  1  3  │  5
+  ──────┼───
+  2  4  │  6 
 
 julia> getblock(A, 2, 1)
 1×2 Array{Int64,2}:
@@ -168,7 +168,7 @@ attempted assigned block is out of bounds.
 
 ```jldoctest; setup = quote using BlockArrays end
 julia> A = PseudoBlockArray(ones(2, 3), [1, 1], [2, 1])
-2×3 PseudoBlockArray{Float64,2,Array{Float64,2}}:
+2×2-blocked 2×3 PseudoBlockArray{Float64,2}:
  1.0  1.0  │  1.0
  ──────────┼─────
  1.0  1.0  │  1.0
@@ -202,7 +202,7 @@ julia> setblock!(A, [1 2], 1, 1);
 julia> A[Block(2, 1)] = [3 4];
 
 julia> A
-2×3 PseudoBlockArray{Float64,2,Array{Float64,2}}:
+2×2-blocked 2×3 PseudoBlockArray{Float64,2}:
  1.0  2.0  │  0.0
  ──────────┼─────
  3.0  4.0  │  0.0
@@ -285,7 +285,7 @@ Returns the array stored in `A` as a `Array`.
 
 ```jldoctest; setup = quote using BlockArrays end
 julia> A = BlockArray(ones(2,3), [1,1], [2,1])
-2×3 BlockArray{Float64,2,Array{Float64,2}}:
+2×2-blocked 2×3 BlockArray{Float64,2}:
  1.0  1.0  │  1.0
  ──────────┼─────
  1.0  1.0  │  1.0

--- a/src/blockarray.jl
+++ b/src/blockarray.jl
@@ -204,24 +204,24 @@ Construct a `BlockArray` from `blocks`.  `block_sizes` is computed from
 # Examples
 ```jldoctest; setup = quote using BlockArrays end
 julia> blocks = permutedims(reshape([
-           1ones(1, 3), 2ones(1, 2),
-           3ones(2, 3), 4ones(2, 2),
-       ], (2, 2)))
+                  1ones(1, 3), 2ones(1, 2),
+                  3ones(2, 3), 4ones(2, 2),
+              ], (2, 2)))
 2×2 Array{Array{Float64,2},2}:
- [1.0 1.0 1.0]               [2.0 2.0]
+ [1.0 1.0 1.0]               [2.0 2.0]         
  [3.0 3.0 3.0; 3.0 3.0 3.0]  [4.0 4.0; 4.0 4.0]
 
- julia> mortar(blocks)
- 2×2-blocked 3×5 BlockArray{Float64,2}:
+julia> mortar(blocks)
+2×2-blocked 3×5 BlockArray{Float64,2}:
  1.0  1.0  1.0  │  2.0  2.0
  ───────────────┼──────────
  3.0  3.0  3.0  │  4.0  4.0
  3.0  3.0  3.0  │  4.0  4.0
 
 julia> ans == mortar(
-           (1ones(1, 3), 2ones(1, 2)),
-           (3ones(2, 3), 4ones(2, 2)),
-       )
+                  (1ones(1, 3), 2ones(1, 2)),
+                  (3ones(2, 3), 4ones(2, 2)),
+              )
 true
 ```
 """

--- a/src/blockarray.jl
+++ b/src/blockarray.jl
@@ -55,46 +55,46 @@ const undef_blocks = UndefBlocksInitializer()
 function _BlockArray end
 
 """
-    BlockArray{T, N, R <: AbstractArray{T, N}} <: AbstractBlockArray{T, N}
+    BlockArray{T, N, R<:AbstractArray{<:AbstractArray{T,N},N}} <: AbstractBlockArray{T, N}
 
 A `BlockArray` is an array where each block is stored contiguously. This means that insertions and retrieval of blocks
 can be very fast and non allocating since no copying of data is needed.
 
-In the type definition, `R` defines the array type that each block has, for example `Matrix{Float64}`.
+In the type definition, `R` defines the array type that holds the blocks, for example `Matrix{Matrix{Float64}}`.
 """
-struct BlockArray{T, N, R <: AbstractArray{T, N}} <: AbstractBlockArray{T, N}
-    blocks::Array{R, N}
+struct BlockArray{T, N, R <: AbstractArray{<:AbstractArray{T,N},N}} <: AbstractBlockArray{T, N}
+    blocks::R
     block_sizes::BlockSizes{N}
 
-    global function _BlockArray(blocks::Array{R, N}, block_sizes::BlockSizes{N}) where {T, N, R <: AbstractArray{T, N}}
+    global function _BlockArray(blocks::R, block_sizes::BlockSizes{N}) where {T, N, R<:AbstractArray{<:AbstractArray{T,N},N}}
         new{T, N, R}(blocks, block_sizes)
     end
 end
 
 # Auxilary outer constructors
-function _BlockArray(blocks::Array{R, N}, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R <: AbstractArray{T, N}}
+function _BlockArray(blocks::R, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R<:AbstractArray{<:AbstractArray{T,N},N}}
     return _BlockArray(blocks, BlockSizes(block_sizes...))
 end
 
-const BlockMatrix{T, R <: AbstractMatrix{T}} = BlockArray{T, 2, R}
-const BlockVector{T, R <: AbstractVector{T}} = BlockArray{T, 1, R}
+const BlockMatrix{T, R <: AbstractMatrix{<:AbstractMatrix{T}}} = BlockArray{T, 2, R}
+const BlockVector{T, R <: AbstractVector{<:AbstractVector{T}}} = BlockArray{T, 1, R}
 const BlockVecOrMat{T, R} = Union{BlockMatrix{T, R}, BlockVector{T, R}}
 
 ################
 # Constructors #
 ################
 
-@inline function _BlockArray(::Type{R}, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R <: AbstractArray{T, N}}
+@inline function _BlockArray(::Type{R}, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R<:AbstractArray{<:AbstractArray{T,N},N}}
     _BlockArray(R, BlockSizes(block_sizes...))
 end
 
-function _BlockArray(::Type{R}, block_sizes::BlockSizes{N}) where {T, N, R <: AbstractArray{T, N}}
+function _BlockArray(::Type{R}, block_sizes::BlockSizes{N}) where {T, N, R<:AbstractArray{<:AbstractArray{T,N},N}}
     n_blocks = nblocks(block_sizes)
-    blocks = Array{R, N}(undef, n_blocks)
+    blocks = R(undef, n_blocks)
     _BlockArray(blocks, block_sizes)
 end
 
-@inline function undef_blocks_BlockArray(::Type{R}, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R <: AbstractArray{T, N}}
+@inline function undef_blocks_BlockArray(::Type{R}, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R<:AbstractArray{<:AbstractArray{T,N},N}}
     _BlockArray(R, block_sizes...)
 end
 
@@ -112,30 +112,30 @@ julia> BlockArray(undef_blocks, Matrix{Float64}, [1,3], [2,2])
  #undef  │  #undef  #undef  #undef  │
 ```
 """
-@inline function BlockArray(::UndefBlocksInitializer, ::Type{R}, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R <: AbstractArray{T, N}}
+@inline function BlockArray(::UndefBlocksInitializer, ::Type{R}, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R<:AbstractArray{<:AbstractArray{T,N},N}}
     undef_blocks_BlockArray(R, block_sizes...)
 end
 
 @inline function BlockArray{T}(::UndefBlocksInitializer, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N}
-    BlockArray(undef_blocks, Array{T,N}, block_sizes...)
+    BlockArray(undef_blocks, Array{Array{T,N},N}, block_sizes...)
 end
 
 @inline function BlockArray{T,N}(::UndefBlocksInitializer, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N}
-    BlockArray(undef_blocks, Array{T,N}, block_sizes...)
+    BlockArray(undef_blocks, Array{Array{T,N},N}, block_sizes...)
 end
 
-@inline function BlockArray{T,N,R}(::UndefBlocksInitializer, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R <: AbstractArray{T, N}}
+@inline function BlockArray{T,N,R}(::UndefBlocksInitializer, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R<:AbstractArray{<:AbstractArray{T,N},N}}
     BlockArray(undef_blocks, R, block_sizes...)
 end
 
 
 
-@generated function initialized_blocks_BlockArray(::Type{R}, block_sizes::BlockSizes{N}) where {T, N, R <: AbstractArray{T, N}}
+@generated function initialized_blocks_BlockArray(::Type{R}, block_sizes::BlockSizes{N}) where R<:AbstractArray{V,N} where {T,N,V<:AbstractArray{T,N}}
     return quote
         block_arr = _BlockArray(R, block_sizes)
         @nloops $N i i->(1:nblocks(block_sizes, i)) begin
             block_index = @ntuple $N i
-            setblock!(block_arr, similar(R, blocksize(block_sizes, block_index)), block_index...)
+            setblock!(block_arr, similar(V, blocksize(block_sizes, block_index)), block_index...)
         end
 
         return block_arr
@@ -143,31 +143,31 @@ end
 end
 
 
-function initialized_blocks_BlockArray(::Type{R}, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R <: AbstractArray{T, N}}
+function initialized_blocks_BlockArray(::Type{R}, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R<:AbstractArray{<:AbstractArray{T,N},N}}
     initialized_blocks_BlockArray(R, BlockSizes(block_sizes...))
 end
 
 @inline function BlockArray{T}(::UndefInitializer, block_sizes::BlockSizes{N}) where {T, N}
-    initialized_blocks_BlockArray(Array{T, N}, block_sizes)
+    initialized_blocks_BlockArray(Array{Array{T,N},N}, block_sizes)
 end
 
 @inline function BlockArray{T, N}(::UndefInitializer, block_sizes::BlockSizes{N}) where {T, N}
-    initialized_blocks_BlockArray(Array{T, N}, block_sizes)
+    initialized_blocks_BlockArray(Array{Array{T,N},N}, block_sizes)
 end
 
-@inline function BlockArray{T, N, R}(::UndefInitializer, block_sizes::BlockSizes{N}) where {T, N, R <: AbstractArray{T, N}}
+@inline function BlockArray{T, N, R}(::UndefInitializer, block_sizes::BlockSizes{N}) where {T, N, R<:AbstractArray{<:AbstractArray{T,N},N}}
     initialized_blocks_BlockArray(R, block_sizes)
 end
 
 @inline function BlockArray{T}(::UndefInitializer, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N}
-    initialized_blocks_BlockArray(Array{T, N}, block_sizes...)
+    initialized_blocks_BlockArray(Array{Array{T,N},N}, block_sizes...)
 end
 
 @inline function BlockArray{T, N}(::UndefInitializer, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N}
-    initialized_blocks_BlockArray(Array{T, N}, block_sizes...)
+    initialized_blocks_BlockArray(Array{Array{T,N},N}, block_sizes...)
 end
 
-@inline function BlockArray{T, N, R}(::UndefInitializer, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R <: AbstractArray{T, N}}
+@inline function BlockArray{T, N, R}(::UndefInitializer, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R<:AbstractArray{<:AbstractArray{T,N},N}}
     initialized_blocks_BlockArray(R, block_sizes...)
 end
 
@@ -182,7 +182,7 @@ end
 
 @generated function BlockArray(arr::AbstractArray{T, N}, block_sizes::BlockSizes{N}) where {T,N}
     return quote
-        block_arr = _BlockArray(typeof(arr), block_sizes)
+        block_arr = _BlockArray(Array{typeof(arr),N}, block_sizes)
         @nloops $N i i->(1:nblocks(block_sizes, i)) begin
             block_index = @ntuple $N i
             indices = globalrange(block_sizes, block_index)

--- a/src/blockarray.jl
+++ b/src/blockarray.jl
@@ -225,7 +225,7 @@ julia> ans == mortar(
 true
 ```
 """
-mortar(blocks::AbstractArray{R, N}, block_sizes::BlockSizes{N}) where {R, N} =
+mortar(blocks::AbstractArray{R, N}, block_sizes::AbstractBlockSizes{N}) where {R, N} =
     _BlockArray(blocks, block_sizes)
 
 mortar(blocks::AbstractArray{R, N}, block_sizes::Vararg{AbstractVector{Int}, N}) where {R, N} =

--- a/src/blockarray.jl
+++ b/src/blockarray.jl
@@ -18,9 +18,9 @@ Examples
 ≡≡≡≡≡≡≡≡≡≡
 ```julia
 julia> BlockArray(undef_blocks, Matrix{Float32}, [1,2], [3,2])
-2×2-blocked 3×5 BlockArrays.BlockArray{Float32,2,Array{Float32,2}}:
+2×2-blocked 3×5 BlockArray{Float32,2}:
  #undef  #undef  #undef  │  #undef  #undef
- ------------------------┼----------------
+ ────────────────────────┼────────────────
  #undef  #undef  #undef  │  #undef  #undef
  #undef  #undef  #undef  │  #undef  #undef
  ```
@@ -39,7 +39,7 @@ Examples
 ≡≡≡≡≡≡≡≡≡≡
 ```julia
 julia> BlockArray(undef_blocks, Matrix{Float32}, [1,2], [3,2])
-2×2-blocked 3×5 BlockArrays.BlockArray{Float32,2,Array{Float32,2}}:
+2×2-blocked 3×5 BlockArray{Float32,2}:
  #undef  #undef  #undef  │  #undef  #undef
  ------------------------┼----------------
  #undef  #undef  #undef  │  #undef  #undef
@@ -55,7 +55,7 @@ const undef_blocks = UndefBlocksInitializer()
 function _BlockArray end
 
 """
-    BlockArray{T, N, R<:AbstractArray{<:AbstractArray{T,N},N}} <: AbstractBlockArray{T, N}
+    BlockArray{T, N, R<:AbstractArray{<:AbstractArray{T,N},N}, BS<:AbstractBlockSizes{N}} <: AbstractBlockArray{T, N}
 
 A `BlockArray` is an array where each block is stored contiguously. This means that insertions and retrieval of blocks
 can be very fast and non allocating since no copying of data is needed.
@@ -211,8 +211,8 @@ julia> blocks = permutedims(reshape([
  [1.0 1.0 1.0]               [2.0 2.0]
  [3.0 3.0 3.0; 3.0 3.0 3.0]  [4.0 4.0; 4.0 4.0]
 
-julia> mortar(blocks)
-3×5 BlockArray{Float64,2,Array{Float64,2}}:
+ julia> mortar(blocks)
+ 2×2-blocked 3×5 BlockArray{Float64,2}:
  1.0  1.0  1.0  │  2.0  2.0
  ───────────────┼──────────
  3.0  3.0  3.0  │  4.0  4.0

--- a/src/blockarray.jl
+++ b/src/blockarray.jl
@@ -231,7 +231,7 @@ mortar(blocks::AbstractArray{R, N}, block_sizes::BlockSizes{N}) where {R, N} =
 mortar(blocks::AbstractArray{R, N}, block_sizes::Vararg{AbstractVector{Int}, N}) where {R, N} =
     _BlockArray(blocks, block_sizes...)
 
-mortar(blocks::AbstractArray) = mortar(blocks, sizes_from_blocks(blocks)...)
+mortar(blocks::AbstractArray) = mortar(blocks, sizes_from_blocks(blocks))
 
 function sizes_from_blocks(blocks::AbstractArray{<:Any, N}) where N
     if length(blocks) == 0
@@ -245,7 +245,7 @@ function sizes_from_blocks(blocks::AbstractArray{<:Any, N}) where N
         [s[i] for s in view(fullsizes, ntuple(j -> j == i ? (:) : 1, ndims(blocks))...)]
     end
     checksizes(fullsizes, block_sizes)
-    return block_sizes
+    return BlockSizes(block_sizes...)
 end
 
 getsizes(block_sizes, block_index) = getindex.(block_sizes, block_index)

--- a/src/blockarray.jl
+++ b/src/blockarray.jl
@@ -308,7 +308,7 @@ end
 
 @inline function Base.getindex(block_arr::BlockArray{T,N}, blockindex::BlockIndex{N}) where {T,N}
     @boundscheck checkbounds(block_arr.blocks, blockindex.I...)
-    @inbounds block = block_arr.blocks[blockindex.I...]
+    @inbounds block = getblock(block_arr, blockindex.I...)
     @boundscheck checkbounds(block, blockindex.α...)
     @inbounds v = block[blockindex.α...]
     return v

--- a/src/blockarray.jl
+++ b/src/blockarray.jl
@@ -103,7 +103,7 @@ Constructs a `BlockArray` with uninitialized blocks from a block type `R` with s
 
 ```jldoctest; setup = quote using BlockArrays end
 julia> BlockArray(undef_blocks, Matrix{Float64}, [1,3], [2,2])
-2×2-blocked 4×4 BlockArrays.BlockArray{Float64,2,Array{Float64,2}}:
+2×2-blocked 4×4 BlockArray{Float64,2}:
  #undef  │  #undef  #undef  #undef  │
  --------┼--------------------------┼
  #undef  │  #undef  #undef  #undef  │
@@ -112,20 +112,20 @@ julia> BlockArray(undef_blocks, Matrix{Float64}, [1,3], [2,2])
  #undef  │  #undef  #undef  #undef  │
 ```
 """
-@inline function BlockArray(::UndefBlocksInitializer, ::Type{R}, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R<:AbstractArray{<:AbstractArray{T,N},N}}
-    undef_blocks_BlockArray(R, block_sizes...)
+@inline function BlockArray(::UndefBlocksInitializer, ::Type{R}, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R<:AbstractArray{T,N}}
+    undef_blocks_BlockArray(Array{R,N}, block_sizes...)
 end
 
 @inline function BlockArray{T}(::UndefBlocksInitializer, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N}
-    BlockArray(undef_blocks, Array{Array{T,N},N}, block_sizes...)
+    BlockArray(undef_blocks, Array{T,N}, block_sizes...)
 end
 
 @inline function BlockArray{T,N}(::UndefBlocksInitializer, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N}
-    BlockArray(undef_blocks, Array{Array{T,N},N}, block_sizes...)
+    BlockArray(undef_blocks, Array{T,N}, block_sizes...)
 end
 
 @inline function BlockArray{T,N,R}(::UndefBlocksInitializer, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R<:AbstractArray{<:AbstractArray{T,N},N}}
-    BlockArray(undef_blocks, R, block_sizes...)
+    undef_blocks_BlockArray(R, block_sizes...)
 end
 
 

--- a/src/blockarray.jl
+++ b/src/blockarray.jl
@@ -62,12 +62,12 @@ can be very fast and non allocating since no copying of data is needed.
 
 In the type definition, `R` defines the array type that holds the blocks, for example `Matrix{Matrix{Float64}}`.
 """
-struct BlockArray{T, N, R <: AbstractArray{<:AbstractArray{T,N},N}} <: AbstractBlockArray{T, N}
+struct BlockArray{T, N, R <: AbstractArray{<:AbstractArray{T,N},N}, BS<:AbstractBlockSizes{N}} <: AbstractBlockArray{T, N}
     blocks::R
-    block_sizes::BlockSizes{N}
+    block_sizes::BS
 
-    global function _BlockArray(blocks::R, block_sizes::BlockSizes{N}) where {T, N, R<:AbstractArray{<:AbstractArray{T,N},N}}
-        new{T, N, R}(blocks, block_sizes)
+    global function _BlockArray(blocks::R, block_sizes::BS) where {T, N, R<:AbstractArray{<:AbstractArray{T,N},N}, BS<:AbstractBlockSizes{N}}
+        new{T, N, R, BS}(blocks, block_sizes)
     end
 end
 

--- a/src/blockarray.jl
+++ b/src/blockarray.jl
@@ -226,10 +226,10 @@ true
 ```
 """
 mortar(blocks::AbstractArray{R, N}, block_sizes::BlockSizes{N}) where {R, N} =
-    _BlockArray(convert(Array, blocks), block_sizes)
+    _BlockArray(blocks, block_sizes)
 
 mortar(blocks::AbstractArray{R, N}, block_sizes::Vararg{AbstractVector{Int}, N}) where {R, N} =
-    _BlockArray(convert(Array, blocks), block_sizes...)
+    _BlockArray(blocks, block_sizes...)
 
 mortar(blocks::AbstractArray) = mortar(blocks, sizes_from_blocks(blocks)...)
 

--- a/src/blockarrayinterface.jl
+++ b/src/blockarrayinterface.jl
@@ -10,6 +10,18 @@ blocksizes(A::HermOrSym) = blocksizes(parent(A))
 blocksizes(A::AdjOrTrans{<:Any,<:AbstractMatrix}) = BlockSizes(reverse(cumulsizes(blocksizes(parent(A)))))
 blocksizes(A::AdjOrTrans{<:Any,<:AbstractVector}) = BlockSizes(([1,2],cumulsizes(blocksizes(parent(A)))[1]))
 
+function sizes_from_blocks(A::Tridiagonal{<:AbstractMatrix})
+    sz = (size.(A.d, 1), size.(A.d,2))
+    for k = 1:length(A.du)
+        size(A.du[k],1) == sz[1][k] || throw(ArgumentError("block sizes of upper diagonal inconsisent with diagonal"))
+        size(A.du[k],2) == sz[2][k+1] || throw(ArgumentError("block sizes of upper diagonal inconsisent with diagonal"))
+        size(A.dl[k],1) == sz[1][k+1] || throw(ArgumentError("block sizes of lower diagonal inconsisent with diagonal"))
+        size(A.dl[k],2) == sz[2][k] || throw(ArgumentError("block sizes of lower diagonal inconsisent with diagonal"))
+    end
+    sz
+end
+
+
 Base.print_matrix_row(io::IO,
         X::Union{AbstractTriangular{<:Any,<:AbstractBlockMatrix},
                  Symmetric{<:Any,<:AbstractBlockMatrix},

--- a/src/blockarrayinterface.jl
+++ b/src/blockarrayinterface.jl
@@ -10,17 +10,6 @@ blocksizes(A::HermOrSym) = blocksizes(parent(A))
 blocksizes(A::AdjOrTrans{<:Any,<:AbstractMatrix}) = BlockSizes(reverse(cumulsizes(blocksizes(parent(A)))))
 blocksizes(A::AdjOrTrans{<:Any,<:AbstractVector}) = BlockSizes(([1,2],cumulsizes(blocksizes(parent(A)))[1]))
 
-function sizes_from_blocks(A::Tridiagonal{<:AbstractMatrix})
-    sz = (size.(A.d, 1), size.(A.d,2))
-    for k = 1:length(A.du)
-        size(A.du[k],1) == sz[1][k] || throw(ArgumentError("block sizes of upper diagonal inconsisent with diagonal"))
-        size(A.du[k],2) == sz[2][k+1] || throw(ArgumentError("block sizes of upper diagonal inconsisent with diagonal"))
-        size(A.dl[k],1) == sz[1][k+1] || throw(ArgumentError("block sizes of lower diagonal inconsisent with diagonal"))
-        size(A.dl[k],2) == sz[2][k] || throw(ArgumentError("block sizes of lower diagonal inconsisent with diagonal"))
-    end
-    sz
-end
-
 
 Base.print_matrix_row(io::IO,
         X::Union{AbstractTriangular{<:Any,<:AbstractBlockMatrix},

--- a/src/blockbroadcast.jl
+++ b/src/blockbroadcast.jl
@@ -65,8 +65,9 @@ be ensured by the caller.
 
 # Examples
 ```jldoctest
-julia> using BlockArrays
-       using BlockArrays: SubBlockIterator, BlockIndexRange, cumulsizes
+julia> using BlockArrays 
+
+julia> import BlockArrays: SubBlockIterator, BlockIndexRange, cumulsizes
 
 julia> A = BlockArray(1:6, 1:3);
 

--- a/src/blockbroadcast.jl
+++ b/src/blockbroadcast.jl
@@ -80,7 +80,6 @@ julia> cumulsize = [1, 2, 4, 5, 7];
 julia> for idx in SubBlockIterator(subcumulsize, cumulsize)
            B = @show view(A, idx)
            @assert !(parent(B) isa BlockArray)
-
            idx :: BlockIndexRange
            idx.block :: Block{1}
            idx.indices :: Tuple{UnitRange}

--- a/src/blockindices.jl
+++ b/src/blockindices.jl
@@ -10,7 +10,7 @@ It can be used to index into `BlockArrays` in the following manner:
 julia> arr = Array(reshape(1:25, (5,5)));
 
 julia> a = PseudoBlockArray(arr, [3,2], [1,4])
-5×5 PseudoBlockArray{Int64,2,Array{Int64,2}}:
+2×2-blocked 5×5 PseudoBlockArray{Int64,2}:
  1  │   6  11  16  21
  2  │   7  12  17  22
  3  │   8  13  18  23

--- a/src/blocksizes.jl
+++ b/src/blocksizes.jl
@@ -89,14 +89,11 @@ end
     return l
 end
 
+_find_block(bs::AbstractVector, i::Integer) = length(bs) > 10 ? last(searchsorted(bs, i)) : searchlinear(bs, i)
+
 @inline function _find_block(block_sizes::AbstractBlockSizes, dim::Int, i::Int)
     bs = cumulsizes(block_sizes, dim)
-    block = 0
-    if length(bs) > 10
-        block = last(searchsorted(bs, i))
-    else
-        block = searchlinear(bs, i)
-    end
+    block = _find_block(bs, i)
     @inbounds cum_size = cumulsizes(block_sizes, dim, block) - 1
     return block, i - cum_size
 end

--- a/src/blocksizes.jl
+++ b/src/blocksizes.jl
@@ -81,7 +81,7 @@ function Base.show(io::IO, block_sizes::AbstractBlockSizes{N}) where {N}
     end
 end
 
-@inline function searchlinear(vec::Vector, a)
+@inline function searchlinear(vec::AbstractVector, a)
     l = length(vec)
     @inbounds for i in 1:l
         vec[i] > a && return i - 1

--- a/src/blocksizes.jl
+++ b/src/blocksizes.jl
@@ -5,24 +5,23 @@
 abstract type AbstractBlockSizes{N} end
 
 # Keeps track of the (cumulative) sizes of all the blocks in the `BlockArray`.
-struct BlockSizes{N} <: AbstractBlockSizes{N}
-    cumul_sizes::NTuple{N, Vector{Int}}
+struct BlockSizes{N,VT<:AbstractVector{Int}} <: AbstractBlockSizes{N}
+    cumul_sizes::NTuple{N,VT}
     # Takes a tuple of sizes, accumulates them and create a `BlockSizes`
-    BlockSizes{N}() where N = new{N}()
-    BlockSizes{N}(cs::NTuple{N,Vector{Int}}) where N = new{N}(cs)
+    BlockSizes{N,VT}() where {N,VT<:AbstractVector{Int}} = new{N,VT}()
+    BlockSizes{N,VT}(cs::NTuple{N,VT}) where {N,VT<:AbstractVector{Int}} = new{N,VT}(cs)
 end
 
+BlockSizes{N}(cs::NTuple{N,VT}) where {N,VT<:AbstractVector{Int}} = BlockSizes{N,VT}(cs)
+BlockSizes{N}() where N = BlockSizes{N,Vector{Int}}()
 BlockSizes() = BlockSizes{0}()
 
-BlockSizes(cs::NTuple{N,Vector{Int}}) where N = BlockSizes{N}(cs)
+BlockSizes(cs::NTuple{N,VT}) where {N,VT<:AbstractVector{Int}} = BlockSizes{N}(cs)
 
-function BlockSizes(sizes::Vararg{Vector{Int}, N}) where {N}
+function BlockSizes(sizes::Vararg{AbstractVector{Int}, N}) where {N}
     cumul_sizes = ntuple(k -> _cumul_vec(sizes[k]), Val(N))
     return BlockSizes(cumul_sizes)
 end
-
-BlockSizes(sizes::Vararg{AbstractVector{Int}, N}) where {N} =
-    BlockSizes(Vector{Int}.(sizes)...)
 
 Base.:(==)(a::BlockSizes, b::BlockSizes) = cumulsizes(a) == cumulsizes(b)
 

--- a/src/pseudo_blockarray.jl
+++ b/src/pseudo_blockarray.jl
@@ -28,16 +28,16 @@ julia> A = PseudoBlockArray(rand(2,3), [1,1], [2,1])
  ────────────────────┼──────────
  0.849939  0.283365  │  0.365801
 
- julia> A = PseudoBlockArray(sprand(6, 0.5), [3,2,1])
- 3-blocked 6-element PseudoBlockArray{Float64,1,SparseVector{Float64,Int64},BlockArrays.BlockSizes{1,Array{Int64,1}}}:
- 0.0
- 0.5865981007905481
- 0.0
+julia> A = PseudoBlockArray(sprand(6, 0.5), [3,2,1])
+3-blocked 6-element PseudoBlockArray{Float64,1,SparseVector{Float64,Int64},BlockArrays.BlockSizes{1,Array{Int64,1}}}:
+ 0.0                
+ 0.5865981007905481 
+ 0.0                
  ───────────────────
  0.05016684053503706
- 0.0
+ 0.0                
  ───────────────────
- 0.0
+ 0.0       
 ```
 """
 struct PseudoBlockArray{T, N, R<:AbstractArray{T,N}, BS<:AbstractBlockSizes{N}} <: AbstractBlockArray{T, N}

--- a/src/pseudo_blockarray.jl
+++ b/src/pseudo_blockarray.jl
@@ -23,13 +23,13 @@ julia> using BlockArrays, Random, SparseArrays
 julia> Random.seed!(12345);
 
 julia> A = PseudoBlockArray(rand(2,3), [1,1], [2,1])
-2×3 PseudoBlockArray{Float64,2,Array{Float64,2}}:
+2×2-blocked 2×3 PseudoBlockArray{Float64,2}:
  0.562714  0.371605  │  0.381128
  ────────────────────┼──────────
  0.849939  0.283365  │  0.365801
 
-julia> A = PseudoBlockArray(sprand(6, 0.5), [3,2,1])
-6-element PseudoBlockArray{Float64,1,SparseVector{Float64,Int64}}:
+ julia> A = PseudoBlockArray(sprand(6, 0.5), [3,2,1])
+ 3-blocked 6-element PseudoBlockArray{Float64,1,SparseVector{Float64,Int64},BlockArrays.BlockSizes{1,Array{Int64,1}}}:
  0.0
  0.5865981007905481
  0.0

--- a/src/pseudo_blockarray.jl
+++ b/src/pseudo_blockarray.jl
@@ -40,11 +40,11 @@ julia> A = PseudoBlockArray(sprand(6, 0.5), [3,2,1])
  0.0
 ```
 """
-struct PseudoBlockArray{T, N, R <: AbstractArray{T, N}} <: AbstractBlockArray{T, N}
+struct PseudoBlockArray{T, N, R<:AbstractArray{T,N}, BS<:AbstractBlockSizes{N}} <: AbstractBlockArray{T, N}
     blocks::R
-    block_sizes::BlockSizes{N}
-    PseudoBlockArray{T, N, R}(blocks::R, block_sizes::BlockSizes{N}) where {T,N,R} =
-        new{T,N,R}(blocks, block_sizes)
+    block_sizes::BS
+    PseudoBlockArray{T,N,R,BS}(blocks::R, block_sizes::BS) where {T,N,R,BS<:AbstractBlockSizes{N}} =
+        new{T,N,R,BS}(blocks, block_sizes)
 end
 
 const PseudoBlockMatrix{T, R} = PseudoBlockArray{T, 2, R}
@@ -52,12 +52,12 @@ const PseudoBlockVector{T, R} = PseudoBlockArray{T, 1, R}
 const PseudoBlockVecOrMat{T, R} = Union{PseudoBlockMatrix{T, R}, PseudoBlockVector{T, R}}
 
 # Auxiliary outer constructors
-@inline function PseudoBlockArray(blocks::R, block_sizes::BlockSizes{N}) where {T,N,R <: AbstractArray{T, N}}
-    return PseudoBlockArray{T, N, R}(blocks, block_sizes)
+@inline function PseudoBlockArray(blocks::R, block_sizes::BS) where {T,N,R<:AbstractArray{T,N},BS<:AbstractBlockSizes{N}}
+    return PseudoBlockArray{T, N, R,BS}(blocks, block_sizes)
 end
 
 @inline function PseudoBlockArray(blocks::R, block_sizes::Vararg{Vector{Int}, N}) where {T,N,R <: AbstractArray{T, N}}
-    return PseudoBlockArray{T, N, R}(blocks, BlockSizes(block_sizes...))
+    return PseudoBlockArray(blocks, BlockSizes(block_sizes...))
 end
 
 PseudoBlockArray(blocks::R, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R <: AbstractArray{T, N}} =
@@ -90,6 +90,7 @@ end
 end
 
 # Convert AbstractArrays that conform to block array interface
+convert(::Type{PseudoBlockArray{T,N,R,BS}}, A::PseudoBlockArray{T,N,R,BS}) where {T,N,R,BS} = A
 convert(::Type{PseudoBlockArray{T,N,R}}, A::PseudoBlockArray{T,N,R}) where {T,N,R} = A
 convert(::Type{PseudoBlockArray{T,N}}, A::PseudoBlockArray{T,N}) where {T,N} = A
 convert(::Type{PseudoBlockArray{T}}, A::PseudoBlockArray{T}) where {T} = A

--- a/src/show.jl
+++ b/src/show.jl
@@ -79,3 +79,12 @@ Base.print_matrix_row(io::IO,
         X::AbstractBlockVecOrMat, A::Vector,
         i::Integer, cols::AbstractVector, sep::AbstractString) =
         _blockarray_print_matrix_row(io, X, A, i, cols, sep)
+
+function _show_typeof(io::IO, a::BlockArray{T,N,Array{Array{T,N},N},BlockSizes{2,Vector{Int}}}) where {T,N}
+    Base.show_type_name(io, typeof(a).name)
+    print(io, '{')
+    show(io, T)
+    print(io, ',')
+    show(io, N)
+    print(io, '}')
+end

--- a/src/show.jl
+++ b/src/show.jl
@@ -88,3 +88,12 @@ function _show_typeof(io::IO, a::BlockArray{T,N,Array{Array{T,N},N},BlockSizes{N
     show(io, N)
     print(io, '}')
 end
+
+function _show_typeof(io::IO, a::PseudoBlockArray{T,N,Array{T,N},BlockSizes{N,Vector{Int}}}) where {T,N}
+    Base.show_type_name(io, typeof(a).name)
+    print(io, '{')
+    show(io, T)
+    print(io, ',')
+    show(io, N)
+    print(io, '}')
+end

--- a/src/show.jl
+++ b/src/show.jl
@@ -80,7 +80,7 @@ Base.print_matrix_row(io::IO,
         i::Integer, cols::AbstractVector, sep::AbstractString) =
         _blockarray_print_matrix_row(io, X, A, i, cols, sep)
 
-function _show_typeof(io::IO, a::BlockArray{T,N,Array{Array{T,N},N},BlockSizes{2,Vector{Int}}}) where {T,N}
+function _show_typeof(io::IO, a::BlockArray{T,N,Array{Array{T,N},N},BlockSizes{N,Vector{Int}}}) where {T,N}
     Base.show_type_name(io, typeof(a).name)
     print(io, '{')
     show(io, T)

--- a/src/views.jl
+++ b/src/views.jl
@@ -164,7 +164,7 @@ end  # if VERSION >= v"1.2-"
 const BlockOrRangeIndex = Union{RangeIndex, BlockSlice}
 
 function unsafe_convert(::Type{Ptr{T}},
-                        V::SubArray{T, N, BlockArray{T, N, AT}, NTuple{N, BlockSlice{Block{1,Int}}}}) where AT <: AbstractArray{T, N} where {T,N}
+                        V::SubArray{T, N, BlockArray{T, N, AT}, NTuple{N, BlockSlice{Block{1,Int}}}}) where AT <: AbstractArray{<:AbstractArray{T,N},N} where {T,N}
     unsafe_convert(Ptr{T}, parent(V).blocks[Int.(Block.(parentindices(V)))...])
 end
 

--- a/src/views.jl
+++ b/src/views.jl
@@ -164,7 +164,7 @@ end  # if VERSION >= v"1.2-"
 const BlockOrRangeIndex = Union{RangeIndex, BlockSlice}
 
 function unsafe_convert(::Type{Ptr{T}},
-                        V::SubArray{T, N, BlockArray{T, N, AT}, NTuple{N, BlockSlice{Block{1,Int}}}}) where AT <: AbstractArray{<:AbstractArray{T,N},N} where {T,N}
+                        V::SubArray{T, N, BlockArray{T,N,AT,BS}, NTuple{N, BlockSlice{Block{1,Int}}}}) where {AT <: AbstractArray{<:AbstractArray{T,N},N}, BS <: AbstractBlockSizes{N}} where {T,N}
     unsafe_convert(Ptr{T}, parent(V).blocks[Int.(Block.(parentindices(V)))...])
 end
 

--- a/test/test_blockarrayinterface.jl
+++ b/test/test_blockarrayinterface.jl
@@ -1,4 +1,4 @@
-using BlockArrays
+using BlockArrays, LinearAlgebra
 
 struct PartiallyImplementedBlockVector <: AbstractBlockArray{Float64,1} end
 
@@ -73,8 +73,12 @@ end
     @test BlockArray(transpose(A)) == transpose(A)
 end
 
-@testset "BlockArray with other blocks" begin
+@testset "Diagonal BlockArray" begin
     A = mortar(Diagonal(fill([1 2],2)))
     @test A isa BlockMatrix{Int,Diagonal{Matrix{Int}, Vector{Matrix{Int}}}}
+    @test A[Block(1,2)] == [0 0]
+    @test_throws BlockBoundsError A[Block(1,3)]
     @test A == [1 2 0 0; 0 0 1 2]
 end
+
+

--- a/test/test_blockarrayinterface.jl
+++ b/test/test_blockarrayinterface.jl
@@ -72,3 +72,9 @@ end
     @test BlockArray(A') == A'
     @test BlockArray(transpose(A)) == transpose(A)
 end
+
+@testset "BlockArray with other blocks" begin
+    A = mortar(Diagonal(fill([1 2],2)))
+    @test A isa BlockMatrix{Int,Diagonal{Matrix{Int}, Vector{Matrix{Int}}}}
+    @test A == [1 2 0 0; 0 0 1 2]
+end

--- a/test/test_blockarrayinterface.jl
+++ b/test/test_blockarrayinterface.jl
@@ -1,4 +1,4 @@
-using BlockArrays, LinearAlgebra
+using BlockArrays, LinearAlgebra, Base64
 
 struct PartiallyImplementedBlockVector <: AbstractBlockArray{Float64,1} end
 
@@ -44,8 +44,9 @@ end
 
 @testset "Triangular/Symmetric/Hermitian block arrays" begin
     A = PseudoBlockArray{ComplexF64}(undef, (1:4), (1:4))
-    A .= randn.() .+ randn.().*im
+    A .= reshape(1:length(A), size(A))
 
+    @test blocksizes(UpperTriangular(A)) == blocksizes(Symmetric(A)) == blocksizes(A)
     @test UpperTriangular(A)[Block(2,2)] == UpperTriangular(A[2:3,2:3])
     @test UpperTriangular(A)[Block(2,3)] == A[2:3,4:6]
     @test UpperTriangular(A)[Block(3,2)] == zeros(3,2)
@@ -55,6 +56,8 @@ end
     @test Hermitian(A)[Block(2,2)] == Hermitian(A[2:3,2:3])
     @test Hermitian(A)[Block(2,3)] == A[2:3,4:6]
     @test Hermitian(A)[Block(3,2)] == A[2:3,4:6]'
+
+    @test stringmime("text/plain", UpperTriangular(A)) == "10×10 UpperTriangular{Complex{Float64},PseudoBlockArray{Complex{Float64},2,Array{Complex{Float64},2},BlockArrays.BlockSizes{2,Array{Int64,1}}}}:\n 1.0+0.0im  │  11.0+0.0im  21.0+0.0im  │  31.0+0.0im  41.0+0.0im  51.0+0.0im  │  61.0+0.0im  71.0+0.0im  81.0+0.0im   91.0+0.0im\n ───────────┼──────────────────────────┼──────────────────────────────────────┼─────────────────────────────────────────────────\n     ⋅      │  12.0+0.0im  22.0+0.0im  │  32.0+0.0im  42.0+0.0im  52.0+0.0im  │  62.0+0.0im  72.0+0.0im  82.0+0.0im   92.0+0.0im\n     ⋅      │       ⋅      23.0+0.0im  │  33.0+0.0im  43.0+0.0im  53.0+0.0im  │  63.0+0.0im  73.0+0.0im  83.0+0.0im   93.0+0.0im\n ───────────┼──────────────────────────┼──────────────────────────────────────┼─────────────────────────────────────────────────\n     ⋅      │       ⋅           ⋅      │  34.0+0.0im  44.0+0.0im  54.0+0.0im  │  64.0+0.0im  74.0+0.0im  84.0+0.0im   94.0+0.0im\n     ⋅      │       ⋅           ⋅      │       ⋅      45.0+0.0im  55.0+0.0im  │  65.0+0.0im  75.0+0.0im  85.0+0.0im   95.0+0.0im\n     ⋅      │       ⋅           ⋅      │       ⋅           ⋅      56.0+0.0im  │  66.0+0.0im  76.0+0.0im  86.0+0.0im   96.0+0.0im\n ───────────┼──────────────────────────┼──────────────────────────────────────┼─────────────────────────────────────────────────\n     ⋅      │       ⋅           ⋅      │       ⋅           ⋅           ⋅      │  67.0+0.0im  77.0+0.0im  87.0+0.0im   97.0+0.0im\n     ⋅      │       ⋅           ⋅      │       ⋅           ⋅           ⋅      │       ⋅      78.0+0.0im  88.0+0.0im   98.0+0.0im\n     ⋅      │       ⋅           ⋅      │       ⋅           ⋅           ⋅      │       ⋅           ⋅      89.0+0.0im   99.0+0.0im\n     ⋅      │       ⋅           ⋅      │       ⋅           ⋅           ⋅      │       ⋅           ⋅           ⋅      100.0+0.0im"
 end
 
 @testset "Adjoint/Transpose block arrays" begin

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -1,4 +1,4 @@
-using SparseArrays, Base64
+using SparseArrays, BlockArrays, Base64
 import BlockArrays: _BlockArray
 
 function test_error_message(f, needle, expected = Exception)
@@ -21,7 +21,7 @@ end
     fill!(ret, 0)
     @test Array(ret)  == zeros(6)
 
-    ret = BlockArray{Float64,1,Vector{Float64}}(undef, 1:3)
+    ret = BlockArray{Float64,1,Vector{Vector{Float64}}}(undef, 1:3)
     fill!(ret, 0)
     @test Array(ret)  == zeros(6)
 
@@ -33,7 +33,7 @@ end
     fill!(ret, 0)
     @test Array(ret)  == zeros(6)
 
-    ret = BlockArray{Float64,1,Vector{Float64}}(undef, BlockArrays.BlockSizes(1:3))
+    ret = BlockArray{Float64,1,Vector{Vector{Float64}}}(undef, BlockArrays.BlockSizes(1:3))
     fill!(ret, 0)
     @test Array(ret)  == zeros(6)
 
@@ -51,7 +51,7 @@ end
     @test eltype(ret.blocks) == Vector{Float32}
     @test_throws UndefRefError ret.blocks[1]
 
-    ret = BlockArray{Float32,1,Vector{Float32}}(undef_blocks, 1:3)
+    ret = BlockArray{Float32,1,Vector{Vector{Float32}}}(undef_blocks, 1:3)
     @test eltype(ret.blocks) == Vector{Float32}
     @test_throws UndefRefError ret.blocks[1]
 
@@ -59,14 +59,14 @@ end
     @test eltype(ret.blocks) == Matrix{Float32}
     @test_throws UndefRefError ret.blocks[1]
 
-    ret = BlockArray(undef_blocks, Vector{Float32}, 1:3)
+    ret = BlockArray(undef_blocks, Vector{Vector{Float32}}, 1:3)
     @test eltype(ret) == Float32
     @test eltype(ret.blocks) == Vector{Float32}
     @test_throws UndefRefError ret.blocks[1]
 
     ret = BlockArray{Float64}(undef, 1:3, 1:3)
     fill!(ret, 0)
-    Matrix(ret) == zeros(6,6)
+    @test Matrix(ret) == zeros(6,6)
 
     ret = PseudoBlockArray{Float64}(undef, 1:3)
     fill!(ret, 0)
@@ -100,7 +100,7 @@ end
         (spzeros(1, 3), spzeros(1, 4)),
         (spzeros(2, 3), spzeros(2, 4)),
         (spzeros(5, 3), spzeros(5, 4)),
-    )
+     )
     @test Array(ret) == zeros(8, 7)
     @test eltype(ret.blocks) <: SparseMatrixCSC
     @test blocksizes(ret) == BlockArrays.BlockSizes([1, 2, 5], [3, 4])
@@ -120,7 +120,7 @@ end
 end
 
 @testset "block indexing" begin
-    BA_1 = BlockArray(undef_blocks, Vector{Float64}, [1,2,3])
+    BA_1 = BlockArray(undef_blocks, Vector{Vector{Float64}}, [1,2,3])
     a_1 = rand(2)
     BA_1[Block(2)] = a_1
     @test BA_1[BlockIndex(2, 1)] == a_1[1]
@@ -132,7 +132,7 @@ end
     @test_throws BlockBoundsError blockcheckbounds(BA_1, 4)
     @test_throws BlockBoundsError BA_1[Block(4)]
 
-    BA_2 = BlockArray(undef_blocks, Matrix{Float64}, [1,2], [3,4])
+    BA_2 = BlockArray(undef_blocks, Matrix{Matrix{Float64}}, [1,2], [3,4])
     a_2 = rand(1,4)
     BA_2[Block(1,2)] = a_2
     @test BA_2[Block(1,2)] == a_2
@@ -266,7 +266,7 @@ end
     A = BlockArray(rand(4, 5), [1,3], [2,3]);
     buf = IOBuffer()
     Base.showerror(buf, BlockBoundsError(A, (3,2)))
-    @test String(take!(buf)) == "BlockBoundsError: attempt to access 2×2-blocked 4×5 BlockArray{Float64,2,Array{Float64,2}} at block index [3,2]"
+    @test String(take!(buf)) == "BlockBoundsError: attempt to access 2×2-blocked 4×5 BlockArray{Float64,2,Array{Array{Float64,2},2}} at block index [3,2]"
 end
 
 if isdefined(Base, :flatten)
@@ -278,10 +278,10 @@ end
 
 replstrmime(x) = stringmime("text/plain", x)
 @testset "replstring" begin
-    @test replstrmime(BlockArray(collect(reshape(1:16, 4, 4)), [1,3], [2,2])) == "4×4 BlockArray{Int64,2,Array{Int64,2}}:\n 1  5  │   9  13\n ──────┼────────\n 2  6  │  10  14\n 3  7  │  11  15\n 4  8  │  12  16"
+    @test replstrmime(BlockArray(collect(reshape(1:16, 4, 4)), [1,3], [2,2])) == "4×4 BlockArray{Int64,2,Array{Array{Int64,2},2}}:\n 1  5  │   9  13\n ──────┼────────\n 2  6  │  10  14\n 3  7  │  11  15\n 4  8  │  12  16"
     design = zeros(Int16,6,9);
     A = BlockArray(design,[6],[4,5])
-    @test replstrmime(A) == "6×9 BlockArray{Int16,2,Array{Int16,2}}:\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0"
+    @test replstrmime(A) == "6×9 BlockArray{Int16,2,Array{Array{Int16,2},2}}:\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0"
 end
 
 @testset "AbstractVector{Int} blocks" begin
@@ -289,7 +289,7 @@ end
     @test A[1,1] == 1
     @test A[Block(2,3)] == ones(2,3)
 
-    A = BlockArray(undef_blocks, Matrix{Float64}, 1:3, 1:3)
+    A = BlockArray(undef_blocks, Matrix{Matrix{Float64}}, 1:3, 1:3)
     A[Block(2,3)] = ones(2,3)
     @test A[Block(2,3)] == ones(2,3)
 end

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -1,5 +1,5 @@
 using SparseArrays, BlockArrays, Base64
-import BlockArrays: _BlockArray
+import BlockArrays: _BlockArray, BlockSizes
 
 function test_error_message(f, needle, expected = Exception)
     err = nothing
@@ -395,4 +395,13 @@ end
     B[1] = 2
     @test B[1] == 2
     @test A[1] ≠ 2
+end
+
+@testset "const block size" begin
+    N = 10
+    # In the future this will be automated via mortar(..., Fill(2,N))
+    A = mortar(fill([1,2], N), BlockSizes((1:2:2N+1,)))
+    B = PseudoBlockArray(vcat(fill([1,2], N)...), BlockSizes((1:2:2N+1,)))
+    @test A == vcat(A.blocks...) == B
+    @test A[Block(1)] == B[Block(1)] == [1,2]
 end

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -1,5 +1,5 @@
 using SparseArrays, BlockArrays, Base64
-import BlockArrays: _BlockArray, BlockSizes
+import BlockArrays: _BlockArray
 
 function test_error_message(f, needle, expected = Exception)
     err = nothing
@@ -266,22 +266,22 @@ end
     A = BlockArray(rand(4, 5), [1,3], [2,3]);
     buf = IOBuffer()
     Base.showerror(buf, BlockBoundsError(A, (3,2)))
-    @test String(take!(buf)) == "BlockBoundsError: attempt to access 2×2-blocked 4×5 BlockArray{Float64,2,Array{Array{Float64,2},2},BlockSizes{2,Array{Int64,1}}} at block index [3,2]"
-end
+    @test String(take!(buf)) == "BlockBoundsError: attempt to access 2×2-blocked 4×5 BlockArray{Float64,2,Array{Array{Float64,2},2},BlockArrays.BlockSizes{2,Array{Int64,1}}} at block index [3,2]"
 
-if isdefined(Base, :flatten)
-    flat = Base.flatten
-else
-    flat = Base.Iterators.flatten
+    A = PseudoBlockArray(rand(4, 5), [1,3], [2,3]);
+    Base.showerror(buf, BlockBoundsError(A, (3,2)))
+    @test String(take!(buf)) == "BlockBoundsError: attempt to access 2×2-blocked 4×5 PseudoBlockArray{Float64,2,Array{Float64,2},BlockArrays.BlockSizes{2,Array{Int64,1}}} at block index [3,2]"
 end
-
 
 replstrmime(x) = stringmime("text/plain", x)
 @testset "replstring" begin
     @test replstrmime(BlockArray(collect(reshape(1:16, 4, 4)), [1,3], [2,2])) == "2×2-blocked 4×4 BlockArray{Int64,2}:\n 1  5  │   9  13\n ──────┼────────\n 2  6  │  10  14\n 3  7  │  11  15\n 4  8  │  12  16"
+    @test replstrmime(PseudoBlockArray(collect(reshape(1:16, 4, 4)), [1,3], [2,2])) == "2×2-blocked 4×4 PseudoBlockArray{Int64,2}:\n 1  5  │   9  13\n ──────┼────────\n 2  6  │  10  14\n 3  7  │  11  15\n 4  8  │  12  16"
     design = zeros(Int16,6,9);
     A = BlockArray(design,[6],[4,5])
     @test replstrmime(A) == "1×2-blocked 6×9 BlockArray{Int16,2}:\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0"
+    A = PseudoBlockArray(design,[6],[4,5])
+    @test replstrmime(A) == "1×2-blocked 6×9 PseudoBlockArray{Int16,2}:\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0"
 end
 
 @testset "AbstractVector{Int} blocks" begin
@@ -400,8 +400,8 @@ end
 @testset "const block size" begin
     N = 10
     # In the future this will be automated via mortar(..., Fill(2,N))
-    A = mortar(fill([1,2], N), BlockSizes((1:2:2N+1,)))
-    B = PseudoBlockArray(vcat(fill([1,2], N)...), BlockSizes((1:2:2N+1,)))
+    A = mortar(fill([1,2], N), BlockArrays.BlockSizes((1:2:2N+1,)))
+    B = PseudoBlockArray(vcat(fill([1,2], N)...), BlockArrays.BlockSizes((1:2:2N+1,)))
     @test A == vcat(A.blocks...) == B
     @test A[Block(1)] == B[Block(1)] == [1,2]
 end

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -121,6 +121,8 @@ end
 
 @testset "block indexing" begin
     BA_1 = BlockArray(undef_blocks, Vector{Float64}, [1,2,3])
+    @test Base.IndexStyle(typeof(BA_1)) == IndexCartesian()
+
     a_1 = rand(2)
     BA_1[Block(2)] = a_1
     @test BA_1[BlockIndex(2, 1)] == a_1[1]
@@ -273,15 +275,15 @@ end
     @test String(take!(buf)) == "BlockBoundsError: attempt to access 2×2-blocked 4×5 PseudoBlockArray{Float64,2,Array{Float64,2},BlockArrays.BlockSizes{2,Array{Int64,1}}} at block index [3,2]"
 end
 
-replstrmime(x) = stringmime("text/plain", x)
+
 @testset "replstring" begin
-    @test replstrmime(BlockArray(collect(reshape(1:16, 4, 4)), [1,3], [2,2])) == "2×2-blocked 4×4 BlockArray{Int64,2}:\n 1  5  │   9  13\n ──────┼────────\n 2  6  │  10  14\n 3  7  │  11  15\n 4  8  │  12  16"
-    @test replstrmime(PseudoBlockArray(collect(reshape(1:16, 4, 4)), [1,3], [2,2])) == "2×2-blocked 4×4 PseudoBlockArray{Int64,2}:\n 1  5  │   9  13\n ──────┼────────\n 2  6  │  10  14\n 3  7  │  11  15\n 4  8  │  12  16"
+    @test stringmime("text/plain",BlockArray(collect(reshape(1:16, 4, 4)), [1,3], [2,2])) == "2×2-blocked 4×4 BlockArray{Int64,2}:\n 1  5  │   9  13\n ──────┼────────\n 2  6  │  10  14\n 3  7  │  11  15\n 4  8  │  12  16"
+    @test stringmime("text/plain",PseudoBlockArray(collect(reshape(1:16, 4, 4)), [1,3], [2,2])) == "2×2-blocked 4×4 PseudoBlockArray{Int64,2}:\n 1  5  │   9  13\n ──────┼────────\n 2  6  │  10  14\n 3  7  │  11  15\n 4  8  │  12  16"
     design = zeros(Int16,6,9);
     A = BlockArray(design,[6],[4,5])
-    @test replstrmime(A) == "1×2-blocked 6×9 BlockArray{Int16,2}:\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0"
+    @test stringmime("text/plain",A) == "1×2-blocked 6×9 BlockArray{Int16,2}:\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0"
     A = PseudoBlockArray(design,[6],[4,5])
-    @test replstrmime(A) == "1×2-blocked 6×9 PseudoBlockArray{Int16,2}:\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0"
+    @test stringmime("text/plain",A) == "1×2-blocked 6×9 PseudoBlockArray{Int16,2}:\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0"
 end
 
 @testset "AbstractVector{Int} blocks" begin

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -59,7 +59,7 @@ end
     @test eltype(ret.blocks) == Matrix{Float32}
     @test_throws UndefRefError ret.blocks[1]
 
-    ret = BlockArray(undef_blocks, Vector{Vector{Float32}}, 1:3)
+    ret = BlockArray(undef_blocks, Vector{Float32}, 1:3)
     @test eltype(ret) == Float32
     @test eltype(ret.blocks) == Vector{Float32}
     @test_throws UndefRefError ret.blocks[1]
@@ -120,7 +120,7 @@ end
 end
 
 @testset "block indexing" begin
-    BA_1 = BlockArray(undef_blocks, Vector{Vector{Float64}}, [1,2,3])
+    BA_1 = BlockArray(undef_blocks, Vector{Float64}, [1,2,3])
     a_1 = rand(2)
     BA_1[Block(2)] = a_1
     @test BA_1[BlockIndex(2, 1)] == a_1[1]
@@ -132,7 +132,7 @@ end
     @test_throws BlockBoundsError blockcheckbounds(BA_1, 4)
     @test_throws BlockBoundsError BA_1[Block(4)]
 
-    BA_2 = BlockArray(undef_blocks, Matrix{Matrix{Float64}}, [1,2], [3,4])
+    BA_2 = BlockArray(undef_blocks, Matrix{Float64}, [1,2], [3,4])
     a_2 = rand(1,4)
     BA_2[Block(1,2)] = a_2
     @test BA_2[Block(1,2)] == a_2
@@ -289,7 +289,7 @@ end
     @test A[1,1] == 1
     @test A[Block(2,3)] == ones(2,3)
 
-    A = BlockArray(undef_blocks, Matrix{Matrix{Float64}}, 1:3, 1:3)
+    A = BlockArray(undef_blocks, Matrix{Float64}, 1:3, 1:3)
     A[Block(2,3)] = ones(2,3)
     @test A[Block(2,3)] == ones(2,3)
 end

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -278,10 +278,10 @@ end
 
 replstrmime(x) = stringmime("text/plain", x)
 @testset "replstring" begin
-    @test replstrmime(BlockArray(collect(reshape(1:16, 4, 4)), [1,3], [2,2])) == "4×4 BlockArray{Int64,2,Array{Array{Int64,2},2},BlockSizes{2,Array{Int64,1}}}:\n 1  5  │   9  13\n ──────┼────────\n 2  6  │  10  14\n 3  7  │  11  15\n 4  8  │  12  16"
+    @test replstrmime(BlockArray(collect(reshape(1:16, 4, 4)), [1,3], [2,2])) == "2×2-blocked 4×4 BlockArray{Int64,2}:\n 1  5  │   9  13\n ──────┼────────\n 2  6  │  10  14\n 3  7  │  11  15\n 4  8  │  12  16"
     design = zeros(Int16,6,9);
     A = BlockArray(design,[6],[4,5])
-    @test replstrmime(A) == "6×9 BlockArray{Int16,2,Array{Array{Int16,2},2},BlockSizes{2,Array{Int64,1}}}:\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0"
+    @test replstrmime(A) == "1×2-blocked 6×9 BlockArray{Int16,2}:\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0"
 end
 
 @testset "AbstractVector{Int} blocks" begin

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -266,7 +266,7 @@ end
     A = BlockArray(rand(4, 5), [1,3], [2,3]);
     buf = IOBuffer()
     Base.showerror(buf, BlockBoundsError(A, (3,2)))
-    @test String(take!(buf)) == "BlockBoundsError: attempt to access 2×2-blocked 4×5 BlockArray{Float64,2,Array{Array{Float64,2},2}} at block index [3,2]"
+    @test String(take!(buf)) == "BlockBoundsError: attempt to access 2×2-blocked 4×5 BlockArray{Float64,2,Array{Array{Float64,2},2},BlockSizes{2,Array{Int64,1}}} at block index [3,2]"
 end
 
 if isdefined(Base, :flatten)
@@ -278,10 +278,10 @@ end
 
 replstrmime(x) = stringmime("text/plain", x)
 @testset "replstring" begin
-    @test replstrmime(BlockArray(collect(reshape(1:16, 4, 4)), [1,3], [2,2])) == "4×4 BlockArray{Int64,2,Array{Array{Int64,2},2}}:\n 1  5  │   9  13\n ──────┼────────\n 2  6  │  10  14\n 3  7  │  11  15\n 4  8  │  12  16"
+    @test replstrmime(BlockArray(collect(reshape(1:16, 4, 4)), [1,3], [2,2])) == "4×4 BlockArray{Int64,2,Array{Array{Int64,2},2},BlockSizes{2,Array{Int64,1}}}:\n 1  5  │   9  13\n ──────┼────────\n 2  6  │  10  14\n 3  7  │  11  15\n 4  8  │  12  16"
     design = zeros(Int16,6,9);
     A = BlockArray(design,[6],[4,5])
-    @test replstrmime(A) == "6×9 BlockArray{Int16,2,Array{Array{Int16,2},2}}:\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0"
+    @test replstrmime(A) == "6×9 BlockArray{Int16,2,Array{Array{Int16,2},2},BlockSizes{2,Array{Int64,1}}}:\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0"
 end
 
 @testset "AbstractVector{Int} blocks" begin

--- a/test/test_blockindices.jl
+++ b/test/test_blockindices.jl
@@ -1,5 +1,10 @@
 import BlockArrays: BlockIndex, globalrange, nblocks, global2blockindex, blockindex2global
 
+@testset "Blocks" begin
+    @test Int(Block(2)) === Integer(Block(2)) === Number(Block(2)) === 2
+    @test Block((Block(3), Block(4))) === Block(3,4)
+end
+
 #=
 [1,1  1,2] | [1,3  1,4  1,5]
 --------------------------
@@ -11,9 +16,9 @@ import BlockArrays: BlockIndex, globalrange, nblocks, global2blockindex, blockin
 [6,1  6,2] | [6,3  6,4  6,5]
 =#
 
-block_size = BlockArrays.BlockSizes([1,2,3], [2, 3])
-
 @testset "BlockSizes / BlockIndices" begin
+    block_size = BlockArrays.BlockSizes([1,2,3], [2, 3])
+
     @test nblocks(block_size) == (3,2)
     @test nblocks(block_size, 1) == 3
     @test nblocks(block_size, 2) == 2

--- a/test/test_blockindices.jl
+++ b/test/test_blockindices.jl
@@ -1,4 +1,4 @@
-import BlockArrays: BlockSizes, BlockIndex, globalrange, nblocks, global2blockindex, blockindex2global
+import BlockArrays: BlockIndex, globalrange, nblocks, global2blockindex, blockindex2global
 
 #=
 [1,1  1,2] | [1,3  1,4  1,5]
@@ -11,41 +11,43 @@ import BlockArrays: BlockSizes, BlockIndex, globalrange, nblocks, global2blockin
 [6,1  6,2] | [6,3  6,4  6,5]
 =#
 
-block_size = BlockSizes([1,2,3], [2, 3])
+block_size = BlockArrays.BlockSizes([1,2,3], [2, 3])
 
 @testset "BlockSizes / BlockIndices" begin
-@test nblocks(block_size) == (3,2)
-@test nblocks(block_size, 1) == 3
-@test nblocks(block_size, 2) == 2
+    @test nblocks(block_size) == (3,2)
+    @test nblocks(block_size, 1) == 3
+    @test nblocks(block_size, 2) == 2
 
-@test @inferred(globalrange(block_size, (1,1))) == (1:1, 1:2)
-@test @inferred(globalrange(block_size, (1,2))) == (1:1, 3:5)
-@test @inferred(globalrange(block_size, (2,1))) == (2:3, 1:2)
-@test @inferred(globalrange(block_size, (2,2))) == (2:3, 3:5)
+    @test @inferred(globalrange(block_size, (1,1))) == (1:1, 1:2)
+    @test @inferred(globalrange(block_size, (1,2))) == (1:1, 3:5)
+    @test @inferred(globalrange(block_size, (2,1))) == (2:3, 1:2)
+    @test @inferred(globalrange(block_size, (2,2))) == (2:3, 3:5)
 
-# Test for allocations inside a function to avoid noise due to global 
-# variable references
-wrapped_allocations = (bs, i) -> @allocated(globalrange(bs, i))
-@test wrapped_allocations(block_size, (1, 1)) == 0
+    # Test for allocations inside a function to avoid noise due to global 
+    # variable references
+    wrapped_allocations = (bs, i) -> @allocated(globalrange(bs, i))
+    @test wrapped_allocations(block_size, (1, 1)) == 0
 
-@test @inferred(global2blockindex(block_size, (3, 1))) == BlockIndex((2,1), (2,1))
-@test @inferred(global2blockindex(block_size, (1, 4))) == BlockIndex((1,2), (1,2))
-@test @inferred(global2blockindex(block_size, (4, 5))) == BlockIndex((3,2), (1,3))
+    @test @inferred(global2blockindex(block_size, (3, 1))) == BlockIndex((2,1), (2,1))
+    @test @inferred(global2blockindex(block_size, (1, 4))) == BlockIndex((1,2), (1,2))
+    @test @inferred(global2blockindex(block_size, (4, 5))) == BlockIndex((3,2), (1,3))
 
-wrapped_allocations = (bs, i) -> @allocated(global2blockindex(bs, i))
-@test wrapped_allocations(block_size, (3, 1)) == 0
+    wrapped_allocations = (bs, i) -> @allocated(global2blockindex(bs, i))
+    @test wrapped_allocations(block_size, (3, 1)) == 0
 
-@test @inferred(blockindex2global(block_size, BlockIndex((2,1), (2,1)))) == (3, 1)
-@test @inferred(blockindex2global(block_size, BlockIndex((1,2), (1,2)))) == (1, 4)
-@test @inferred(blockindex2global(block_size, BlockIndex((3,2), (1,3)))) == (4, 5)
+    @test @inferred(blockindex2global(block_size, BlockIndex((2,1), (2,1)))) == (3, 1)
+    @test @inferred(blockindex2global(block_size, BlockIndex((1,2), (1,2)))) == (1, 4)
+    @test @inferred(blockindex2global(block_size, BlockIndex((3,2), (1,3)))) == (4, 5)
 
-wrapped_allocations = (bs, i) -> @allocated(blockindex2global(bs, i))
-@test wrapped_allocations(block_size, BlockIndex((2,1), (2,1))) == 0
+    wrapped_allocations = (bs, i) -> @allocated(blockindex2global(bs, i))
+    @test wrapped_allocations(block_size, BlockIndex((2,1), (2,1))) == 0
 
-@test block_size == BlockSizes(1:3, 2:3)
+    @test block_size == BlockArrays.BlockSizes(1:3, 2:3)
 
-buf = IOBuffer()
-print(buf, block_size)
-@test String(take!(buf)) == "[1, 2, 3] × [2, 3]"
+    buf = IOBuffer()
+    print(buf, block_size)
+    @test String(take!(buf)) == "[1, 2, 3] × [2, 3]"
 
+    @test BlockArrays.searchlinear([1,2,3], 5) == 3
+    @test Base.dataids(block_size) == Base.dataids(block_size)
 end

--- a/test/test_blockviews.jl
+++ b/test/test_blockviews.jl
@@ -127,23 +127,23 @@ end
     @test PseudoBlockArray(V) isa PseudoBlockArray
     @test BlockArray(V) isa BlockArray
     @test PseudoBlockArray(V) == BlockArray(V) == V
-    @test blocksizes(V) == BlockSizes([2],[3])
+    @test blocksizes(V) == BlockArrays.BlockSizes([2],[3])
 
     V = view(A, Block(2), Block.(2:3))
     @test PseudoBlockArray(V) isa PseudoBlockArray
     @test BlockArray(V) isa BlockArray
     @test PseudoBlockArray(V) == BlockArray(V) == V
-    @test blocksizes(V) == BlockSizes([2],[2,3])
+    @test blocksizes(V) == BlockArrays.BlockSizes([2],[2,3])
 
     V = view(A, Block.(2:3), Block(3))
     @test PseudoBlockArray(V) isa PseudoBlockArray
     @test BlockArray(V) isa BlockArray
     @test PseudoBlockArray(V) == BlockArray(V) == V
-    @test blocksizes(V) == BlockSizes([2,3],[3])
+    @test blocksizes(V) == BlockArrays.BlockSizes([2,3],[3])
 
     V = view(A, Block.(2:3), Block.(1:2))
     @test PseudoBlockArray(V) isa PseudoBlockArray
     @test BlockArray(V) isa BlockArray
     @test PseudoBlockArray(V) == BlockArray(V) == V
-    @test blocksizes(V) == BlockSizes([2,3],[1,2])
+    @test blocksizes(V) == BlockArrays.BlockSizes([2,3],[1,2])
 end


### PR DESCRIPTION
This allows general backends for BlockArray. For example:
```julia
julia> BlockArrays._BlockArray(Fill([1,2],5), Fill(2,5))
10-element BlockArray{Int64,1,Fill{Array{Int64,1},1,Tuple{Base.OneTo{Int64}}}}:
 1
 2
 ─
 1
 2
 ─
 1
 2
 ─
 1
 2
 ─
 1
 2
```