### PR TITLE
Loosen some type constraints `Int` -> `Integer`

### DIFF
--- a/src/abstractblockarray.jl
+++ b/src/abstractblockarray.jl
@@ -24,7 +24,7 @@ const AbstractBlockVecOrMat{T} = Union{AbstractBlockMatrix{T}, AbstractBlockVect
 block2string(b, s) = string(join(map(string,b), '×'), "-blocked ", Base.dims2string(s))
 Base.summary(a::AbstractBlockArray) = string(block2string(nblocks(a), size(a)), " ", typeof(a))
 _show_typeof(io, a) = show(io, typeof(a))
-function Base.summary(io::IO, a::AbstractBlockArray) 
+function Base.summary(io::IO, a::AbstractBlockArray)
     print(io, block2string(nblocks(a), size(a)))
     print(io, ' ')
     _show_typeof(io, a)
@@ -51,11 +51,10 @@ julia> nblocks(A, 3, 2)
 (4, 3)
 ```
 """
-nblocks(block_array::AbstractArray, i::Int) = nblocks(block_array)[i]
+nblocks(block_array::AbstractArray, i::Integer) = nblocks(block_array)[i]
 
-nblocks(block_array::AbstractArray, i::Vararg{Int, N}) where {N} =
+nblocks(block_array::AbstractArray, i::Vararg{Integer, N}) where {N} =
     nblocks(blocksizes(block_array), i...)
-
 
 
 """
@@ -154,10 +153,9 @@ julia> A[Block(1, 2)]
  5
 ```
 """
-function getblock(A::AbstractBlockArray{T,N}, ::Vararg{Int, N}) where {T,N}
+function getblock(A::AbstractBlockArray{T,N}, ::Vararg{Integer, N}) where {T,N}
     throw(error("getblock for ", typeof(A), " is not implemented"))
 end
-
 
 
 """
@@ -182,7 +180,7 @@ julia> x
  1.0  1.0
 ```
 """
-getblock!(X, A::AbstractBlockArray{T,N}, ::Vararg{Int, N}) where {T,N} = throw(error("getblock! for ", typeof(A), " is not implemented"))
+getblock!(X, A::AbstractBlockArray{T,N}, ::Vararg{Integer, N}) where {T,N} = throw(error("getblock! for ", typeof(A), " is not implemented"))
 
 @inline getblock!(X, A::AbstractBlockArray{T,N}, block::Block{N}) where {T,N}             = getblock!(X, A, block.n...)
 @inline getblock!(X, A::AbstractBlockVector, block::Block{1})                       = getblock!(X, A, block.n[1])
@@ -208,7 +206,7 @@ julia> A
  3.0  4.0  │  0.0
 ```
 """
-setblock!(A::AbstractBlockArray{T,N}, v, ::Vararg{Int, N}) where {T,N} = throw(error("setblock! for ", typeof(A), " is not implemented"))
+setblock!(A::AbstractBlockArray{T,N}, v, ::Vararg{Integer, N}) where {T,N} = throw(error("setblock! for ", typeof(A), " is not implemented"))
 
 @inline setblock!(A::AbstractBlockArray{T, N}, v, block::Block{N}) where {T,N}      = setblock!(A, v, block.n...)
 @inline setblock!(A::AbstractBlockVector, v, block::Block{1})                       = setblock!(A, v, block.n[1])
@@ -256,7 +254,7 @@ ERROR: BlockBoundsError: attempt to access 2×2-blocked 2×3 BlockArray{Float64,
 [...]
 ```
 """
-@inline function blockcheckbounds(A::AbstractBlockArray{T, N}, i::Vararg{Int, N}) where {T,N}
+@inline function blockcheckbounds(A::AbstractBlockArray{T, N}, i::Vararg{Integer, N}) where {T,N}
     if blockcheckbounds(Bool, A, i...)
         return
     else
@@ -264,7 +262,7 @@ ERROR: BlockBoundsError: attempt to access 2×2-blocked 2×3 BlockArray{Float64,
     end
 end
 
-@inline function blockcheckbounds(::Type{Bool}, A::AbstractBlockArray{T, N}, i::Vararg{Int, N}) where {T,N}
+@inline function blockcheckbounds(::Type{Bool}, A::AbstractBlockArray{T, N}, i::Vararg{Integer, N}) where {T,N}
     n = nblocks(A)
     k = 0
     for idx in 1:N # using enumerate here will allocate

--- a/src/blockarray.jl
+++ b/src/blockarray.jl
@@ -129,7 +129,6 @@ end
 end
 
 
-
 @generated function initialized_blocks_BlockArray(::Type{R}, block_sizes::BlockSizes{N}) where R<:AbstractArray{V,N} where {T,N,V<:AbstractArray{T,N}}
     return quote
         block_arr = _BlockArray(R, block_sizes)
@@ -208,7 +207,7 @@ julia> blocks = permutedims(reshape([
                   3ones(2, 3), 4ones(2, 2),
               ], (2, 2)))
 2×2 Array{Array{Float64,2},2}:
- [1.0 1.0 1.0]               [2.0 2.0]         
+ [1.0 1.0 1.0]               [2.0 2.0]
  [3.0 3.0 3.0; 3.0 3.0 3.0]  [4.0 4.0; 4.0 4.0]
 
 julia> mortar(blocks)
@@ -303,7 +302,7 @@ copy(A::BlockArray) = _BlockArray(copy.(A.blocks), copy(A.block_sizes))
 ################################
 @inline blocksizes(block_array::BlockArray) = block_array.block_sizes
 
-@inline function getblock(block_arr::BlockArray{T,N}, block::Vararg{Int, N}) where {T,N}
+@inline function getblock(block_arr::BlockArray{T,N}, block::Vararg{Integer, N}) where {T,N}
     @boundscheck blockcheckbounds(block_arr, block...)
     block_arr.blocks[block...]
 end
@@ -325,13 +324,13 @@ end
     _BlockArray(similar(block_array.blocks, Array{T2, N}), copy(blocksizes(block_array)))
 end
 
-@inline function Base.getindex(block_arr::BlockArray{T, N}, i::Vararg{Int, N}) where {T,N}
+@inline function Base.getindex(block_arr::BlockArray{T, N}, i::Vararg{Integer, N}) where {T,N}
     @boundscheck checkbounds(block_arr, i...)
     @inbounds v = block_arr[global2blockindex(blocksizes(block_arr), i)]
     return v
 end
 
-@inline function Base.setindex!(block_arr::BlockArray{T, N}, v, i::Vararg{Int, N}) where {T,N}
+@inline function Base.setindex!(block_arr::BlockArray{T, N}, v, i::Vararg{Integer, N}) where {T,N}
     @boundscheck checkbounds(block_arr, i...)
     @inbounds block_arr[global2blockindex(blocksizes(block_arr), i)] = v
     return block_arr
@@ -341,7 +340,7 @@ end
 # Indexing #
 ############
 
-function _check_setblock!(block_arr::BlockArray{T, N}, v, block::NTuple{N, Int}) where {T,N}
+function _check_setblock!(block_arr::BlockArray{T, N}, v, block::NTuple{N, Integer}) where {T,N}
     for i in 1:N
         if size(v, i) != blocksize(block_arr, i, block[i])
             throw(DimensionMismatch(string("tried to assign $(size(v)) array to ", blocksize(block_arr, block), " block")))
@@ -350,7 +349,7 @@ function _check_setblock!(block_arr::BlockArray{T, N}, v, block::NTuple{N, Int})
 end
 
 
-@inline function setblock!(block_arr::BlockArray{T, N}, v, block::Vararg{Int, N}) where {T,N}
+@inline function setblock!(block_arr::BlockArray{T, N}, v, block::Vararg{Integer, N}) where {T,N}
     @boundscheck blockcheckbounds(block_arr, block...)
     @boundscheck _check_setblock!(block_arr, v, block)
     @inbounds block_arr.blocks[block...] = v

--- a/src/blockrange.jl
+++ b/src/blockrange.jl
@@ -33,11 +33,11 @@ broadcasted(::DefaultArrayStyle{1}, ::typeof(Int), block_range::BlockRange{1}) =
 # AbstractArray implementation
 axes(iter::BlockRange{N,R}) where {N,R} = map(axes1, iter.indices)
 Base.IndexStyle(::Type{BlockRange{N,R}}) where {N,R} = IndexCartesian()
-@inline function Base.getindex(iter::BlockRange{N,<:NTuple{N,Base.OneTo}}, I::Vararg{Int, N}) where {N}
+@inline function Base.getindex(iter::BlockRange{N,<:NTuple{N,Base.OneTo}}, I::Vararg{Integer, N}) where {N}
     @boundscheck checkbounds(iter, I...)
     Block(I)
 end
-@inline function Base.getindex(iter::BlockRange{N,R}, I::Vararg{Int, N}) where {N,R}
+@inline function Base.getindex(iter::BlockRange{N,R}, I::Vararg{Integer, N}) where {N,R}
     @boundscheck checkbounds(iter, I...)
     Block(I .- first.(axes1.(iter.indices)) .+ first.(iter.indices))
 end
@@ -58,7 +58,7 @@ end
 
 # increment & carry
 @inline inc(::Tuple{}, ::Tuple{}, ::Tuple{}) = ()
-@inline inc(state::Tuple{Int}, start::Tuple{Int}, stop::Tuple{Int}) = (state[1]+1,)
+@inline inc(state::Tuple{Integer}, start::Tuple{Integer}, stop::Tuple{Integer}) = (state[1]+1,)
 @inline function inc(state, start, stop)
     if state[1] < stop[1]
         return (state[1]+1,tail(state)...)

--- a/src/blocksizes.jl
+++ b/src/blocksizes.jl
@@ -49,7 +49,7 @@ end
     cumulsizes(block_sizes, i, j+1) - cumulsizes(block_sizes, i, j)
 
 # ntuple with Val was slow here. @generated it is!
-@generated function blocksize(block_sizes::AbstractBlockSizes{N}, i::NTuple{N, Int}) where {N}
+@generated function blocksize(block_sizes::AbstractBlockSizes{N}, i::NTuple{N, Integer}) where {N}
     exp = Expr(:tuple, [:(blocksize(block_sizes, $k, i[$k])) for k in 1:N]...)
     return exp
 end
@@ -91,7 +91,7 @@ end
 
 _find_block(bs::AbstractVector, i::Integer) = length(bs) > 10 ? last(searchsorted(bs, i)) : searchlinear(bs, i)
 
-@inline function _find_block(block_sizes::AbstractBlockSizes, dim::Int, i::Int)
+@inline function _find_block(block_sizes::AbstractBlockSizes, dim::Integer, i::Integer)
     bs = cumulsizes(block_sizes, dim)
     block = _find_block(bs, i)
     @inbounds cum_size = cumulsizes(block_sizes, dim, block) - 1
@@ -105,10 +105,10 @@ end
     end
 end
 
-@inline @propagate_inbounds nblocks(block_sizes::AbstractBlockSizes, i::Int) =
+@inline @propagate_inbounds nblocks(block_sizes::AbstractBlockSizes, i::Integer) =
     length(cumulsizes(block_sizes,i)) - 1
 
-function nblocks(block_sizes::AbstractBlockSizes, i::Vararg{Int, N}) where {N}
+function nblocks(block_sizes::AbstractBlockSizes, i::Vararg{Integer, N}) where {N}
     b = nblocks(block_sizes)
     return ntuple(k-> b[i[k]], Val(N))
 end
@@ -123,7 +123,7 @@ end
 end
 
 # Computes the global range of an Array that corresponds to a given block_index
-@generated function globalrange(block_sizes::AbstractBlockSizes{N}, block_index::NTuple{N, Int}) where {N}
+@generated function globalrange(block_sizes::AbstractBlockSizes{N}, block_index::NTuple{N, Integer}) where {N}
     indices_ex = Expr(:tuple, [:(cumulsizes(block_sizes, $i, block_index[$i]):cumulsizes(block_sizes, $i, block_index[$i] + 1) - 1) for i = 1:N]...)
     return quote
         $(Expr(:meta, :inline))
@@ -133,24 +133,23 @@ end
 end
 
 # I hate having these function definitions but the generated function above sometimes(!) generates bad code and starts to allocate
-@inline function globalrange(block_sizes::AbstractBlockSizes{1}, block_index::NTuple{1, Int})
+@inline function globalrange(block_sizes::AbstractBlockSizes{1}, block_index::NTuple{1, Integer})
     @inbounds v = (cumulsizes(block_sizes, 1, block_index[1]):cumulsizes(block_sizes, 1, block_index[1] + 1) - 1,)
     return v
 end
 
-@inline function globalrange(block_sizes::AbstractBlockSizes{2}, block_index::NTuple{2, Int})
+@inline function globalrange(block_sizes::AbstractBlockSizes{2}, block_index::NTuple{2, Integer})
     @inbounds v = (cumulsizes(block_sizes, 1, block_index[1]):cumulsizes(block_sizes, 1, block_index[1] + 1) - 1,
                    cumulsizes(block_sizes, 2, block_index[2]):cumulsizes(block_sizes, 2, block_index[2] + 1) - 1)
     return v
 end
 
-@inline function globalrange(block_sizes::AbstractBlockSizes{3}, block_index::NTuple{3, Int})
+@inline function globalrange(block_sizes::AbstractBlockSizes{3}, block_index::NTuple{3, Integer})
     @inbounds v = (cumulsizes(block_sizes, 1, block_index[1]):cumulsizes(block_sizes, 1, block_index[1] + 1) - 1,
                    cumulsizes(block_sizes, 2, block_index[2]):cumulsizes(block_sizes, 2, block_index[2] + 1) - 1,
                    cumulsizes(block_sizes, 3, block_index[3]):cumulsizes(block_sizes, 3, block_index[3] + 1) - 1)
     return v
 end
-
 
 
 """
@@ -178,10 +177,10 @@ julia> blocksize(A, (2, 1, 3))
 (4, 1, 2)
 ```
 """
-@inline blocksize(block_array::AbstractArray, i::Int...) =
+@inline blocksize(block_array::AbstractArray, i::Integer...) =
     blocksize(blocksizes(block_array), i...)
 
-@inline blocksize(block_array::AbstractArray{T,N}, i::NTuple{N, Int}) where {T, N} =
+@inline blocksize(block_array::AbstractArray{T,N}, i::NTuple{N, Integer}) where {T, N} =
     blocksize(blocksizes(block_array), i)
 
 @inline Base.size(arr::AbstractBlockArray) = size(blocksizes(arr))

--- a/src/pseudo_blockarray.jl
+++ b/src/pseudo_blockarray.jl
@@ -30,14 +30,14 @@ julia> A = PseudoBlockArray(rand(2,3), [1,1], [2,1])
 
 julia> A = PseudoBlockArray(sprand(6, 0.5), [3,2,1])
 3-blocked 6-element PseudoBlockArray{Float64,1,SparseVector{Float64,Int64},BlockArrays.BlockSizes{1,Array{Int64,1}}}:
- 0.0                
- 0.5865981007905481 
- 0.0                
+ 0.0
+ 0.5865981007905481
+ 0.0
  ───────────────────
  0.05016684053503706
- 0.0                
+ 0.0
  ───────────────────
- 0.0       
+ 0.0
 ```
 """
 struct PseudoBlockArray{T, N, R<:AbstractArray{T,N}, BS<:AbstractBlockSizes{N}} <: AbstractBlockArray{T, N}
@@ -62,7 +62,6 @@ end
 
 PseudoBlockArray(blocks::R, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R <: AbstractArray{T, N}} =
     PseudoBlockArray(blocks, Vector{Int}.(block_sizes)...)
-
 
 
 @inline function PseudoBlockArray{T}(::UndefInitializer, block_sizes::BlockSizes{N}) where {T, N}
@@ -118,14 +117,14 @@ function Base.similar(block_array::PseudoBlockArray{T,N}, ::Type{T2}) where {T,N
     PseudoBlockArray(similar(block_array.blocks, T2), copy(blocksizes(block_array)))
 end
 
-@inline function Base.getindex(block_arr::PseudoBlockArray{T, N}, i::Vararg{Int, N}) where {T,N}
+@inline function Base.getindex(block_arr::PseudoBlockArray{T, N}, i::Vararg{Integer, N}) where {T,N}
     @boundscheck checkbounds(block_arr, i...)
     @inbounds v = block_arr.blocks[i...]
     return v
 end
 
 
-@inline function Base.setindex!(block_arr::PseudoBlockArray{T, N}, v, i::Vararg{Int, N}) where {T,N}
+@inline function Base.setindex!(block_arr::PseudoBlockArray{T, N}, v, i::Vararg{Integer, N}) where {T,N}
     @boundscheck checkbounds(block_arr, i...)
     @inbounds block_arr.blocks[i...] = v
     return block_arr
@@ -147,12 +146,12 @@ end
     return v
 end
 
-@inline function getblock(block_arr::PseudoBlockArray{T,N}, block::Vararg{Int, N}) where {T,N}
+@inline function getblock(block_arr::PseudoBlockArray{T,N}, block::Vararg{Integer, N}) where {T,N}
     range = globalrange(blocksizes(block_arr), block)
     return block_arr.blocks[range...]
 end
 
-@inline function _check_getblock!(blockrange, x, block_arr::PseudoBlockArray{T,N}, block::NTuple{N, Int}) where {T,N}
+@inline function _check_getblock!(blockrange, x, block_arr::PseudoBlockArray{T,N}, block::NTuple{N, Integer}) where {T,N}
     for i in 1:N
         if size(x, i) != length(blockrange[i])
             throw(DimensionMismatch(string("tried to assign ", blocksize(block_arr, block), " block to $(size(x)) array")))
@@ -161,7 +160,7 @@ end
 end
 
 
-@generated function getblock!(x, block_arr::PseudoBlockArray{T,N}, block::Vararg{Int, N}) where {T,N}
+@generated function getblock!(x, block_arr::PseudoBlockArray{T,N}, block::Vararg{Integer, N}) where {T,N}
     return quote
         blockrange = globalrange(blocksizes(block_arr), block)
         @boundscheck _check_getblock!(blockrange, x, block_arr, block)
@@ -184,7 +183,7 @@ end
     return block_arr
 end
 
-@inline function _check_setblock!(blockrange, x, block_arr::PseudoBlockArray{T,N}, block::NTuple{N, Int}) where {T,N}
+@inline function _check_setblock!(blockrange, x, block_arr::PseudoBlockArray{T,N}, block::NTuple{N, Integer}) where {T,N}
     blocksizes = blocksize(block_arr, block)
     for i in 1:N
         if size(x, i) != blocksizes[i]
@@ -193,7 +192,7 @@ end
     end
 end
 
-@generated function setblock!(block_arr::PseudoBlockArray{T, N}, x, block::Vararg{Int, N}) where {T,N}
+@generated function setblock!(block_arr::PseudoBlockArray{T, N}, x, block::Vararg{Integer, N}) where {T,N}
     return quote
         blockrange = globalrange(blocksizes(block_arr), block)
         @boundscheck _check_setblock!(blockrange, x, block_arr, block)
@@ -206,7 +205,6 @@ end
         end
     end
 end
-
 
 
 ########
@@ -246,5 +244,5 @@ end
 ###########################
 
 Base.strides(A::PseudoBlockArray) = strides(A.blocks)
-Base.stride(A::PseudoBlockArray, i::Int) = stride(A.blocks, i)
+Base.stride(A::PseudoBlockArray, i::Integer) = stride(A.blocks, i)
 Base.unsafe_convert(::Type{Ptr{T}}, A::PseudoBlockArray) where T = Base.unsafe_convert(Ptr{T}, A.blocks)

--- a/src/views.jl
+++ b/src/views.jl
@@ -21,7 +21,7 @@ for f in (:axes, :unsafe_indices, :axes1, :first, :last, :size, :length,
     @eval $f(S::BlockSlice) = $f(S.indices)
 end
 
-getindex(S::BlockSlice, i::Int) = getindex(S.indices, i)
+getindex(S::BlockSlice, i::Integer) = getindex(S.indices, i)
 show(io::IO, r::BlockSlice) = print(io, "BlockSlice(", r.block, ",", r.indices, ")")
 next(S::BlockSlice, s) = next(S.indices, s)
 done(S::BlockSlice, s) = done(S.indices, s)
@@ -34,7 +34,6 @@ function _unblock(cum_sizes, I::Tuple{Block{1, T},Vararg{Any}}) where {T}
 
     BlockSlice(B, range)
 end
-
 
 
 function _unblock(cum_sizes, I::Tuple{BlockRange{1,R}, Vararg{Any}}) where {R}


### PR DESCRIPTION
Closes #82 (hopefully)

Doesn't touch any `AbstractArray{Int}` constraints so as not to affect `UnitRange`s, because `(1:3 isa AbstractArray{Integer}) == false`
