### PR TITLE
Add BlockVector and BlockMatrix constructors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.7
   - 1.0
   - 1.1
   - 1.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ julia:
   - 1.0
   - 1.1
   - 1.2
+  - 1.3
   - nightly
 matrix:
    allow_failures:

--- a/Project.toml
+++ b/Project.toml
@@ -1,12 +1,12 @@
 name = "BlockArrays"
 uuid = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
-version = "0.9.1"
+version = "0.10"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
-julia = "0.7, 1"
+julia = "1"
 
 [extras]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/BlockArrays.jl
+++ b/src/BlockArrays.jl
@@ -47,6 +47,5 @@ include("blockarrayinterface.jl")
 include("blockbroadcast.jl")
 # include("linalg.jl")
 
-include("deprecate.jl")
 
 end # module

--- a/src/BlockArrays.jl
+++ b/src/BlockArrays.jl
@@ -22,7 +22,7 @@ import Base: @propagate_inbounds, Array, to_indices, to_index,
             @_inline_meta, _maybetail, tail, @_propagate_inbounds_meta, reindex,
             RangeIndex, Int, Integer, Number,
             +, -, min, max, *, isless, in, copy, copyto!, axes, @deprecate,
-            BroadcastStyle
+            BroadcastStyle, checkbounds, throw_boundserror
 using Base: ReshapedArray, dataids
 
 

--- a/src/abstractblockarray.jl
+++ b/src/abstractblockarray.jl
@@ -254,7 +254,7 @@ ERROR: BlockBoundsError: attempt to access 2×2-blocked 2×3 BlockArray{Float64,
 [...]
 ```
 """
-@inline function blockcheckbounds(A::AbstractBlockArray{T, N}, i::Vararg{Integer, N}) where {T,N}
+@inline function blockcheckbounds(A::AbstractArray{T, N}, i::Vararg{Integer, N}) where {T,N}
     if blockcheckbounds(Bool, A, i...)
         return
     else
@@ -262,7 +262,7 @@ ERROR: BlockBoundsError: attempt to access 2×2-blocked 2×3 BlockArray{Float64,
     end
 end
 
-@inline function blockcheckbounds(::Type{Bool}, A::AbstractBlockArray{T, N}, i::Vararg{Integer, N}) where {T,N}
+@inline function blockcheckbounds(::Type{Bool}, A::AbstractArray{T, N}, i::Vararg{Integer, N}) where {T,N}
     n = nblocks(A)
     k = 0
     for idx in 1:N # using enumerate here will allocate
@@ -274,6 +274,8 @@ end
     end
     return true
 end
+
+blockcheckbounds(A::AbstractArray{T, N}, i::Block{N}) where {T,N} = blockcheckbounds(A, i.n...)
 
 # Convert to @generated...
 @propagate_inbounds Base.getindex( block_arr::AbstractBlockArray{T, N}, block::Block{N}) where {T,N}       =  getblock(block_arr, block.n...)

--- a/src/blockarray.jl
+++ b/src/blockarray.jl
@@ -300,7 +300,7 @@ copy(A::BlockArray) = _BlockArray(copy.(A.blocks), copy(A.block_sizes))
 end
 
 @inline function Base.getindex(block_arr::BlockArray{T,N}, blockindex::BlockIndex{N}) where {T,N}
-    @boundscheck checkbounds(block_arr.blocks, blockindex.I...)
+    @boundscheck blockcheckbounds(block_arr, Block(blockindex.I))
     @inbounds block = getblock(block_arr, blockindex.I...)
     @boundscheck checkbounds(block, blockindex.α...)
     @inbounds v = block[blockindex.α...]

--- a/src/blockarray.jl
+++ b/src/blockarray.jl
@@ -84,9 +84,8 @@ const BlockVecOrMat{T, R} = Union{BlockMatrix{T, R}, BlockVector{T, R}}
 # Constructors #
 ################
 
-@inline function _BlockArray(::Type{R}, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R<:AbstractArray{<:AbstractArray{T,N},N}}
+@inline _BlockArray(::Type{R}, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R<:AbstractArray{<:AbstractArray{T,N},N}} =
     _BlockArray(R, BlockSizes(block_sizes...))
-end
 
 function _BlockArray(::Type{R}, block_sizes::BlockSizes{N}) where {T, N, R<:AbstractArray{<:AbstractArray{T,N},N}}
     n_blocks = nblocks(block_sizes)
@@ -94,9 +93,8 @@ function _BlockArray(::Type{R}, block_sizes::BlockSizes{N}) where {T, N, R<:Abst
     _BlockArray(blocks, block_sizes)
 end
 
-@inline function undef_blocks_BlockArray(::Type{R}, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R<:AbstractArray{<:AbstractArray{T,N},N}}
+@inline undef_blocks_BlockArray(::Type{R}, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R<:AbstractArray{<:AbstractArray{T,N},N}} =
     _BlockArray(R, block_sizes...)
-end
 
 """
 Constructs a `BlockArray` with uninitialized blocks from a block type `R` with sizes defind by `block_sizes`.
@@ -112,21 +110,17 @@ julia> BlockArray(undef_blocks, Matrix{Float64}, [1,3], [2,2])
  #undef  │  #undef  #undef  #undef  │
 ```
 """
-@inline function BlockArray(::UndefBlocksInitializer, ::Type{R}, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R<:AbstractArray{T,N}}
+@inline BlockArray(::UndefBlocksInitializer, ::Type{R}, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R<:AbstractArray{T,N}} =
     undef_blocks_BlockArray(Array{R,N}, block_sizes...)
-end
 
-@inline function BlockArray{T}(::UndefBlocksInitializer, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N}
+@inline BlockArray{T}(::UndefBlocksInitializer, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N} =
     BlockArray(undef_blocks, Array{T,N}, block_sizes...)
-end
 
-@inline function BlockArray{T,N}(::UndefBlocksInitializer, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N}
+@inline BlockArray{T,N}(::UndefBlocksInitializer, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N} =
     BlockArray(undef_blocks, Array{T,N}, block_sizes...)
-end
 
-@inline function BlockArray{T,N,R}(::UndefBlocksInitializer, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R<:AbstractArray{<:AbstractArray{T,N},N}}
+@inline BlockArray{T,N,R}(::UndefBlocksInitializer, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R<:AbstractArray{<:AbstractArray{T,N},N}} =
     undef_blocks_BlockArray(R, block_sizes...)
-end
 
 
 @generated function initialized_blocks_BlockArray(::Type{R}, block_sizes::BlockSizes{N}) where R<:AbstractArray{V,N} where {T,N,V<:AbstractArray{T,N}}
@@ -142,33 +136,26 @@ end
 end
 
 
-function initialized_blocks_BlockArray(::Type{R}, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R<:AbstractArray{<:AbstractArray{T,N},N}}
+initialized_blocks_BlockArray(::Type{R}, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R<:AbstractArray{<:AbstractArray{T,N},N}} =
     initialized_blocks_BlockArray(R, BlockSizes(block_sizes...))
-end
 
-@inline function BlockArray{T}(::UndefInitializer, block_sizes::BlockSizes{N}) where {T, N}
+@inline BlockArray{T}(::UndefInitializer, block_sizes::BlockSizes{N}) where {T, N} =
     initialized_blocks_BlockArray(Array{Array{T,N},N}, block_sizes)
-end
 
-@inline function BlockArray{T, N}(::UndefInitializer, block_sizes::BlockSizes{N}) where {T, N}
+@inline BlockArray{T, N}(::UndefInitializer, block_sizes::BlockSizes{N}) where {T, N} =
     initialized_blocks_BlockArray(Array{Array{T,N},N}, block_sizes)
-end
 
-@inline function BlockArray{T, N, R}(::UndefInitializer, block_sizes::BlockSizes{N}) where {T, N, R<:AbstractArray{<:AbstractArray{T,N},N}}
+@inline BlockArray{T, N, R}(::UndefInitializer, block_sizes::BlockSizes{N}) where {T, N, R<:AbstractArray{<:AbstractArray{T,N},N}} =
     initialized_blocks_BlockArray(R, block_sizes)
-end
 
-@inline function BlockArray{T}(::UndefInitializer, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N}
+@inline BlockArray{T}(::UndefInitializer, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N} =
     initialized_blocks_BlockArray(Array{Array{T,N},N}, block_sizes...)
-end
 
-@inline function BlockArray{T, N}(::UndefInitializer, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N}
+@inline BlockArray{T, N}(::UndefInitializer, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N} =
     initialized_blocks_BlockArray(Array{Array{T,N},N}, block_sizes...)
-end
 
-@inline function BlockArray{T, N, R}(::UndefInitializer, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R<:AbstractArray{<:AbstractArray{T,N},N}}
+@inline BlockArray{T, N, R}(::UndefInitializer, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R<:AbstractArray{<:AbstractArray{T,N},N}} =
     initialized_blocks_BlockArray(R, block_sizes...)
-end
 
 function BlockArray(arr::AbstractArray{T, N}, block_sizes::Vararg{AbstractVector{Int}, N}) where {T,N}
     for i in 1:N
@@ -191,6 +178,11 @@ end
         return block_arr
     end
 end
+
+BlockVector(blocks::AbstractVector, block_sizes::AbstractBlockSizes{1}) = BlockArray(blocks, block_sizes)
+BlockVector(blocks::AbstractVector, block_sizes::AbstractVector{Int}) = BlockArray(blocks, block_sizes)
+BlockMatrix(blocks::AbstractMatrix, block_sizes::AbstractBlockSizes{2}) = BlockArray(blocks, block_sizes)
+BlockMatrix(blocks::AbstractMatrix, block_sizes::Vararg{AbstractVector{Int},2}) = BlockArray(blocks, block_sizes...)
 
 """
     mortar(blocks::AbstractArray)

--- a/src/blockindexrange.jl
+++ b/src/blockindexrange.jl
@@ -15,6 +15,7 @@ BlockIndexRange(block::Block{N}, inds::NTuple{N,AbstractUnitRange{Int}}) where {
 BlockIndexRange(block::Block{N}, inds::Vararg{AbstractUnitRange{Int},N}) where {N} =
     BlockIndexRange(block,inds)
 
+getindex(B::Block{N}, inds::Vararg{Int,N}) where N = BlockIndex(B,inds)
 getindex(B::Block{N}, inds::Vararg{AbstractUnitRange{Int},N}) where N = BlockIndexRange(B,inds)
 
 eltype(R::BlockIndexRange) = eltype(typeof(R))

--- a/src/blockindices.jl
+++ b/src/blockindices.jl
@@ -31,8 +31,11 @@ struct BlockIndex{N}
 end
 
 @inline BlockIndex(a::Int, b::Int) = BlockIndex((a,), (b,))
-@inline BlockIndex(a::NTuple, b::Int) = BlockIndex(a, (b,))
-@inline BlockIndex(a::Int, b::NTuple) = BlockIndex((a,), b)
+@inline BlockIndex(a::Tuple, b::Int) = BlockIndex(a, (b,))
+@inline BlockIndex(a::Int, b::Tuple) = BlockIndex((a,), b)
+
+@inline BlockIndex(a::Block, b::Tuple) = BlockIndex(a.n, b)
+@inline BlockIndex(a::Block, b::Int) = BlockIndex(a, (b,))
 
 @generated function BlockIndex(I::NTuple{N, Int}, α::NTuple{M, Int}) where {M,N}
     @assert M < N

--- a/src/blockindices.jl
+++ b/src/blockindices.jl
@@ -97,3 +97,18 @@ end
                   cumulsizes(block_sizes, 3, block_index.I[3]) + block_index.α[3] - 1)
     return v
 end
+
+
+##
+# checkindex
+##
+
+@inline checkbounds(::Type{Bool}, A::AbstractArray{<:Any,N}, I::Block{N}) where N = blockcheckbounds(Bool, A, I.n...)
+@inline function checkbounds(::Type{Bool}, A::AbstractArray{<:Any,N}, I::BlockIndex{N}) where N
+    checkbounds(Bool, A, Block(I.I)) || return false
+    @inbounds block = getblock(A, I.I...)
+    checkbounds(Bool, block, I.α...)
+end
+
+checkbounds(::Type{Bool}, A::AbstractArray{<:Any,N}, I::AbstractVector{BlockIndex{N}}) where N = 
+    all(checkbounds.(Bool, Ref(A), I))

--- a/src/pseudo_blockarray.jl
+++ b/src/pseudo_blockarray.jl
@@ -52,41 +52,38 @@ const PseudoBlockVector{T} = PseudoBlockArray{T, 1}
 const PseudoBlockVecOrMat{T} = Union{PseudoBlockMatrix{T}, PseudoBlockVector{T}}
 
 # Auxiliary outer constructors
-@inline function PseudoBlockArray(blocks::R, block_sizes::BS) where {T,N,R<:AbstractArray{T,N},BS<:AbstractBlockSizes{N}}
-    return PseudoBlockArray{T, N, R,BS}(blocks, block_sizes)
-end
+@inline PseudoBlockArray(blocks::R, block_sizes::BS) where {T,N,R<:AbstractArray{T,N},BS<:AbstractBlockSizes{N}} =
+    PseudoBlockArray{T, N, R,BS}(blocks, block_sizes)
 
-@inline function PseudoBlockArray(blocks::R, block_sizes::Vararg{Vector{Int}, N}) where {T,N,R <: AbstractArray{T, N}}
-    return PseudoBlockArray(blocks, BlockSizes(block_sizes...))
-end
+@inline PseudoBlockArray(blocks::AbstractArray{T, N}, block_sizes::Vararg{Vector{Int}, N}) where {T, N} =
+    PseudoBlockArray(blocks, BlockSizes(block_sizes...))
 
-PseudoBlockArray(blocks::R, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R <: AbstractArray{T, N}} =
+PseudoBlockArray(blocks::AbstractArray{T, N}, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N} =
     PseudoBlockArray(blocks, Vector{Int}.(block_sizes)...)
 
-
-@inline function PseudoBlockArray{T}(::UndefInitializer, block_sizes::BlockSizes{N}) where {T, N}
+@inline PseudoBlockArray{T}(::UndefInitializer, block_sizes::BlockSizes{N}) where {T, N} =
     PseudoBlockArray(similar(Array{T, N}, size(block_sizes)), block_sizes)
-end
 
-@inline function PseudoBlockArray{T, N}(::UndefInitializer, block_sizes::BlockSizes{N}) where {T, N}
+@inline PseudoBlockArray{T, N}(::UndefInitializer, block_sizes::BlockSizes{N}) where {T, N} =
     PseudoBlockArray{T}(undef, block_sizes)
-end
 
-@inline function PseudoBlockArray{T, N, R}(::UndefInitializer, block_sizes::BlockSizes{N}) where {T, N, R <: AbstractArray{T, N}}
+@inline PseudoBlockArray{T, N, R}(::UndefInitializer, block_sizes::BlockSizes{N}) where {T, N, R <: AbstractArray{T, N}} =
     PseudoBlockArray(similar(R, size(block_sizes)), block_sizes)
-end
 
-@inline function PseudoBlockArray{T}(::UndefInitializer, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N}
+@inline PseudoBlockArray{T}(::UndefInitializer, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N} =
     PseudoBlockArray{T}(undef, BlockSizes(block_sizes...))
-end
 
-@inline function PseudoBlockArray{T, N}(::UndefInitializer, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N}
+@inline PseudoBlockArray{T, N}(::UndefInitializer, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N} =
     PseudoBlockArray{T, N}(undef, BlockSizes(block_sizes...))
-end
 
-@inline function PseudoBlockArray{T, N, R}(::UndefInitializer, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R <: AbstractArray{T, N}}
+@inline PseudoBlockArray{T, N, R}(::UndefInitializer, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R <: AbstractArray{T, N}} =
     PseudoBlockArray{T, N, R}(undef, BlockSizes(block_sizes...))
-end
+
+
+PseudoBlockVector(blocks::AbstractVector, block_sizes::AbstractBlockSizes{1}) = PseudoBlockArray(blocks, block_sizes)
+PseudoBlockVector(blocks::AbstractVector, block_sizes::AbstractVector{Int}) = PseudoBlockArray(blocks, block_sizes)
+PseudoBlockMatrix(blocks::AbstractMatrix, block_sizes::AbstractBlockSizes{2}) = PseudoBlockArray(blocks, block_sizes)
+PseudoBlockMatrix(blocks::AbstractMatrix, block_sizes::Vararg{AbstractVector{Int},2}) = PseudoBlockArray(blocks, block_sizes...)
 
 # Convert AbstractArrays that conform to block array interface
 convert(::Type{PseudoBlockArray{T,N,R,BS}}, A::PseudoBlockArray{T,N,R,BS}) where {T,N,R,BS} = A

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -117,6 +117,42 @@ end
             (zeros(2, 3), zeros(111, 222)),
         )
     end
+
+    a_data = [1,2,3]
+    a = BlockVector(a_data,[1,2])
+    a[1] = 2
+    @test a == [2,2,3]
+    @test a_data == [1,2,3]
+    a = BlockVector(a_data,BlockArrays.BlockSizes([1,2]))
+    a[1] = 2
+    @test a == [2,2,3]
+    @test a_data == [1,2,3]
+    a = PseudoBlockVector(a_data,[1,2])
+    a[1] = 2
+    @test a == [2,2,3]
+    @test a_data == [2,2,3]
+    a = PseudoBlockVector(a_data,BlockArrays.BlockSizes([1,2]))
+    a[1] = 3
+    @test a == [3,2,3]
+    @test a_data == [3,2,3]
+
+    a_data = [1 2; 3 4]
+    a = BlockMatrix(a_data,[1,1],[2])
+    a[1] = 2
+    @test a == [2 2; 3 4]
+    @test a_data == [1 2; 3 4]
+    a = BlockMatrix(a_data,BlockArrays.BlockSizes([1,1],[2]))
+    a[1] = 2
+    @test a == [2 2; 3 4]
+    @test a_data == [1 2; 3 4]
+    a = PseudoBlockMatrix(a_data,[1,1],[2])
+    a[1] = 2
+    @test a == [2 2; 3 4]
+    @test a_data == [2 2; 3 4]
+    a = PseudoBlockMatrix(a_data,BlockArrays.BlockSizes([1,1],[2]))
+    a[1] = 3
+    @test a == [3 2; 3 4]
+    @test a_data == [3 2; 3 4]
 end
 
 @testset "block indexing" begin

--- a/test/test_blockindices.jl
+++ b/test/test_blockindices.jl
@@ -1,4 +1,4 @@
-import BlockArrays: BlockIndex, globalrange, nblocks, global2blockindex, blockindex2global
+import BlockArrays: BlockIndex, BlockIndexRange, globalrange, nblocks, global2blockindex, blockindex2global
 
 @testset "Blocks" begin
     @test Int(Block(2)) === Integer(Block(2)) === Number(Block(2)) === 2
@@ -55,4 +55,20 @@ end
 
     @test BlockArrays.searchlinear([1,2,3], 5) == 3
     @test Base.dataids(block_size) == Base.dataids(block_size)
+
+    @test Block(1)[1] == BlockIndex((1,),(1,))
+    @test Block(1)[1:2] == BlockIndexRange(Block(1),(1:2,))
+    @test Block(1,1)[1,1] == BlockIndex((1,1),(1,1))
+    @test Block(1,1)[1:2,1:2] == BlockIndexRange(Block(1,1),(1:2,1:2))
+
+    A = BlockVector([1,2,3],[1,2])
+    @test A[Block(2)[2]] == 3
+    @test A[Block(2)[1:2]] == [2,3]
+    @test A[getindex.(Block.(1:2), 1)] == [1,2]
+    
+    @test_throws BlockBoundsError A[Block(3)]
+    @test_throws BlockBoundsError A[Block(3)[1]]
+    @test_throws BoundsError A[Block(3)[1:1]] # this is likely an error
+    @test_throws BoundsError A[Block(2)[3]]
+    @test_throws BoundsError A[Block(2)[3:3]]
 end


### PR DESCRIPTION
This adds constructors `BlockVector` and `BlockMatrix` (Mostly because I keep trying to call them). It also adds support for the folloiwng:
```julia
A[getindex.(Block.(1:2), 1)]
```
which gets the first entry in the first two blocks.