### PR TITLE
Generalise A[::BlockIndex{1}, ::BlockIndex{1}]

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BlockArrays"
 uuid = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
-version = "0.12.1"
+version = "0.12.2"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/blockarray.jl
+++ b/src/blockarray.jl
@@ -331,9 +331,6 @@ end
     _blockindex_getindex(block_arr, blockindex)
 @inline Base.getindex(block_arr::BlockVector{T}, blockindex::BlockIndex{1}) where {T} =
     _blockindex_getindex(block_arr, blockindex)
-@inline Base.getindex(block_arr::BlockArray{T,N}, blockindex::Vararg{BlockIndex{1},N}) where {T,N} =
-    block_arr[BlockIndex(blockindex)]
-
 
 ###########################
 # AbstractArray Interface #

--- a/src/blockaxis.jl
+++ b/src/blockaxis.jl
@@ -1,9 +1,15 @@
 
 # interface
+
 @inline getindex(b::AbstractVector, K::BlockIndex{1}) = b[Block(K.I[1])][K.α[1]]
-@inline Base.getindex(b::AbstractArray{T,N}, blockindex::Vararg{BlockIndex{1},N}) where {T,N} =
-    b[BlockIndex(blockindex)]
-@inline getindex(b::AbstractVector, K::BlockIndexRange{1}) = b[K.block][K.indices[1]]
+@inline getindex(b::AbstractArray{T,N}, K::BlockIndex{N}) where {T,N} =
+    b[block(K)][K.α...]
+@inline getindex(b::AbstractArray{T,N}, K::Vararg{BlockIndex{1},N}) where {T,N} =
+    b[BlockIndex(K)]
+
+@inline getindex(b::AbstractArray{T,N}, K::BlockIndexRange{N}) where {T,N} = 
+    b[block(K)][K.indices...]    
+
 
 function findblockindex(b::AbstractVector, k::Integer)
     K = findblock(b, k)

--- a/src/blockaxis.jl
+++ b/src/blockaxis.jl
@@ -1,7 +1,9 @@
 
 # interface
-getindex(b::AbstractVector, K::BlockIndex{1}) = b[Block(K.I[1])][K.α[1]]
-getindex(b::AbstractVector, K::BlockIndexRange{1}) = b[K.block][K.indices[1]]
+@inline getindex(b::AbstractVector, K::BlockIndex{1}) = b[Block(K.I[1])][K.α[1]]
+@inline Base.getindex(b::AbstractArray{T,N}, blockindex::Vararg{BlockIndex{1},N}) where {T,N} =
+    b[BlockIndex(blockindex)]
+@inline getindex(b::AbstractVector, K::BlockIndexRange{1}) = b[K.block][K.indices[1]]
 
 function findblockindex(b::AbstractVector, k::Integer)
     K = findblock(b, k)

--- a/src/blockindices.jl
+++ b/src/blockindices.jl
@@ -173,6 +173,8 @@ BlockIndexRange(block::Block{N}, inds::NTuple{N,AbstractUnitRange{Int}}) where {
 BlockIndexRange(block::Block{N}, inds::Vararg{AbstractUnitRange{Int},N}) where {N} =
     BlockIndexRange(block,inds)
 
+block(R::BlockIndexRange) = R.block
+
 getindex(B::Block{N}, inds::Vararg{Int,N}) where N = BlockIndex(B,inds)
 getindex(B::Block{N}, inds::Vararg{AbstractUnitRange{Int},N}) where N = BlockIndexRange(B,inds)
 getindex(B::Block{1}, inds::Colon) = B

--- a/src/pseudo_blockarray.jl
+++ b/src/pseudo_blockarray.jl
@@ -169,12 +169,19 @@ end
 # Indexing #
 ############
 
-@inline function Base.getindex(block_arr::PseudoBlockArray{T,N}, blockindex::BlockIndex{N}) where {T,N}
+@inline function _pseudoblockindex_getindex(block_arr, blockindex)
     I = getindex.(axes(block_arr), getindex.(Block.(blockindex.I), blockindex.α))
     @boundscheck checkbounds(block_arr.blocks, I...)
     @inbounds v = block_arr.blocks[I...]
     return v
 end
+
+@inline Base.getindex(block_arr::PseudoBlockArray{T,N}, blockindex::BlockIndex{N}) where {T,N} =
+    _pseudoblockindex_getindex(block_arr, blockindex)
+
+
+@inline Base.getindex(block_arr::PseudoBlockVector{T}, blockindex::BlockIndex{1}) where T =
+    _pseudoblockindex_getindex(block_arr, blockindex)
 
 @inline function getblock(block_arr::PseudoBlockArray{T,N}, block::Vararg{Integer, N}) where {T,N}
     range = getindex.(axes(block_arr), Block.(block))

--- a/src/views.jl
+++ b/src/views.jl
@@ -1,18 +1,51 @@
 ### Views
-to_index(::BlockIndexRange) = throw(ArgumentError("BlockIndexRange must be converted by to_indices(...)"))
 
+"""
+    unblock(block_sizes, inds, I)
+
+Returns the indices associated with a block as a `BlockSlice`.
+"""
+function unblock(A, inds, I)
+    B = first(I)
+    if length(inds) == 0
+        # Allow `ones(2)[Block(1)[1:1], Block(1)[1:1]]` which is
+        # similar to `ones(2)[1:1, 1:1]`.
+        BlockSlice(B,Base.OneTo(1))
+    else
+        BlockSlice(B,inds[1][B])
+    end
+end
+
+to_index(::Block) = throw(ArgumentError("Block must be converted by to_indices(...)"))
+to_index(::BlockIndex) = throw(ArgumentError("BlockIndex must be converted by to_indices(...)"))
+to_index(::BlockIndexRange) = throw(ArgumentError("BlockIndexRange must be converted by to_indices(...)"))
+to_index(::BlockRange) = throw(ArgumentError("BlockRange must be converted by to_indices(...)"))
+
+
+@inline to_indices(A, inds, I::Tuple{Block{1}, Vararg{Any}}) =
+    (unblock(A, inds, I), to_indices(A, _maybetail(inds), tail(I))...)
+@inline to_indices(A, inds, I::Tuple{BlockRange{1,R}, Vararg{Any}}) where R =
+    (unblock(A, inds, I), to_indices(A, _maybetail(inds), tail(I))...)
+@inline to_indices(A, inds, I::Tuple{BlockIndex{1}, Vararg{Any}}) where R =
+    (inds[1][I[1]], to_indices(A, _maybetail(inds), tail(I))...)
 @inline to_indices(A, inds, I::Tuple{BlockIndexRange{1,R}, Vararg{Any}}) where R =
     (unblock(A, inds, I), to_indices(A, _maybetail(inds), tail(I))...)
 
 # splat out higher dimensional blocks
 # this mimics view of a CartesianIndex
+@inline to_indices(A, inds, I::Tuple{Block, Vararg{Any}}) =
+    to_indices(A, inds, (Block.(I[1].n)..., tail(I)...))
+@inline to_indices(A, inds, I::Tuple{BlockIndex, Vararg{Any}}) =
+    to_indices(A, inds, (BlockIndex.(I[1].I, I[1].α)..., tail(I)...))
 @inline to_indices(A, inds, I::Tuple{BlockIndexRange, Vararg{Any}}) =
-    to_indices(A, inds, (BlockRange.(Block.(I[1].block.n), tuple.(I[1].indices))..., tail(I)...))
-
+    to_indices(A, inds, (BlockIndexRange.(Block.(I[1].block.n), tuple.(I[1].indices))..., tail(I)...))
+@inline to_indices(A, inds, I::Tuple{BlockRange, Vararg{Any}}) =
+    to_indices(A, inds, (BlockRange.(tuple.(I[1].indices))..., tail(I)...))
 
 # In 0.7, we need to override to_indices to avoid calling linearindices
-@inline to_indices(A, I::Tuple{BlockIndexRange, Vararg{Any}}) =
-    to_indices(A, axes(A), I)
+@inline to_indices(A, I::Tuple{BlockIndexRange, Vararg{Any}}) = to_indices(A, axes(A), I)
+@inline to_indices(A, I::Tuple{Block, Vararg{Any}}) = to_indices(A, axes(A), I)
+@inline to_indices(A, I::Tuple{BlockRange, Vararg{Any}}) = to_indices(A, axes(A), I)
 
 if VERSION >= v"1.2-"  # See also `reindex` definitions in views.jl
     reindex(idxs::Tuple{BlockSlice{<:BlockRange}, Vararg{Any}},
@@ -68,96 +101,46 @@ end
 end
 
 
-"""
-    unblock(block_sizes, inds, I)
-
-Returns the indices associated with a block as a `BlockSlice`.
-"""
-function unblock(A, inds, I)
-    B = first(I)
-    if length(inds) == 0
-        # Allow `ones(2)[Block(1)[1:1], Block(1)[1:1]]` which is
-        # similar to `ones(2)[1:1, 1:1]`.
-        BlockSlice(B,Base.OneTo(1))
-    else
-        BlockSlice(B,inds[1][B])
-    end
-end
-
-
-to_index(::Block) = throw(ArgumentError("Block must be converted by to_indices(...)"))
-to_index(::BlockIndex) = throw(ArgumentError("BlockIndex must be converted by to_indices(...)"))
-to_index(::BlockRange) = throw(ArgumentError("BlockRange must be converted by to_indices(...)"))
-
-@inline to_indices(A, inds, I::Tuple{Block{1}, Vararg{Any}}) =
-    (unblock(A, inds, I), to_indices(A, _maybetail(inds), tail(I))...)
-
-# splat out higher dimensional blocks
-# this mimics view of a CartesianIndex
-@inline to_indices(A, inds, I::Tuple{Block, Vararg{Any}}) =
-    to_indices(A, inds, (Block.(I[1].n)..., tail(I)...))
-
-@inline to_indices(A, inds, I::Tuple{BlockRange{1,R}, Vararg{Any}}) where R =
-    (unblock(A, inds, I), to_indices(A, _maybetail(inds), tail(I))...)
-
-# splat out higher dimensional blocks
-# this mimics view of a CartesianIndex
-@inline to_indices(A, inds, I::Tuple{BlockRange, Vararg{Any}}) =
-    to_indices(A, inds, (BlockRange.(tuple.(I[1].indices))..., tail(I)...))
-
-
-# In 0.7, we need to override to_indices to avoid calling linearindices
-@inline to_indices(A, I::Tuple{Block, Vararg{Any}}) =
-    to_indices(A, axes(A), I)
-
-@inline to_indices(A, I::Tuple{BlockRange, Vararg{Any}}) =
-    to_indices(A, axes(A), I)
-
-
 # The first argument for `reindex` is removed as of
 # https://github.com/JuliaLang/julia/pull/30789 in Julia `Base`.  So,
 # we define 2-arg `reindex` for Julia 1.2 and later.
 if VERSION >= v"1.2-"
+    # BlockSlices map the blocks and the indices
+    # this is loosely based on Slice reindex in subarray.jl
+    reindex(idxs::Tuple{BlockSlice{<:BlockRange}, Vararg{Any}},
+            subidxs::Tuple{BlockSlice{<:BlockRange}, Vararg{Any}}) =
+        (@_propagate_inbounds_meta; (BlockSlice(BlockRange(idxs[1].block.indices[1][Int.(subidxs[1].block)]),
+                                                idxs[1].indices[subidxs[1].indices]),
+                                    reindex(tail(idxs), tail(subidxs))...))
 
-# BlockSlices map the blocks and the indices
-# this is loosely based on Slice reindex in subarray.jl
-reindex(idxs::Tuple{BlockSlice{<:BlockRange}, Vararg{Any}},
-        subidxs::Tuple{BlockSlice{<:BlockRange}, Vararg{Any}}) =
-    (@_propagate_inbounds_meta; (BlockSlice(BlockRange(idxs[1].block.indices[1][Int.(subidxs[1].block)]),
-                                            idxs[1].indices[subidxs[1].indices]),
-                                 reindex(tail(idxs), tail(subidxs))...))
+    reindex(idxs::Tuple{BlockSlice{BlockRange{1,Tuple{UnitRange{Int}}}}, Vararg{Any}},
+            subidxs::Tuple{BlockSlice{Block{1,Int}}, Vararg{Any}}) =
+        (@_propagate_inbounds_meta; (BlockSlice(Block(idxs[1].block.indices[1][Int(subidxs[1].block)]),
+                                                idxs[1].indices[subidxs[1].indices]),
+                                    reindex(tail(idxs), tail(subidxs))...))
 
-reindex(idxs::Tuple{BlockSlice{BlockRange{1,Tuple{UnitRange{Int}}}}, Vararg{Any}},
-        subidxs::Tuple{BlockSlice{Block{1,Int}}, Vararg{Any}}) =
-    (@_propagate_inbounds_meta; (BlockSlice(Block(idxs[1].block.indices[1][Int(subidxs[1].block)]),
-                                            idxs[1].indices[subidxs[1].indices]),
-                                 reindex(tail(idxs), tail(subidxs))...))
-
-function reindex(idxs::Tuple{BlockSlice{Block{1,Int}}, Vararg{Any}},
-        subidxs::Tuple{BlockSlice{Block{1,Int}}, Vararg{Any}})
-    (idxs[1], reindex(tail(idxs), tail(subidxs))...)
-end
-
+    function reindex(idxs::Tuple{BlockSlice{Block{1,Int}}, Vararg{Any}},
+            subidxs::Tuple{BlockSlice{Block{1,Int}}, Vararg{Any}})
+            (idxs[1], reindex(tail(idxs), tail(subidxs))...)
+    end
 else  # if VERSION >= v"1.2-"
+    reindex(V, idxs::Tuple{BlockSlice{<:BlockRange}, Vararg{Any}},
+            subidxs::Tuple{BlockSlice{<:BlockRange}, Vararg{Any}}) =
+        (@_propagate_inbounds_meta; (BlockSlice(BlockRange(idxs[1].block.indices[1][Int.(subidxs[1].block)]),
+                                                idxs[1].indices[subidxs[1].indices]),
+                                        reindex(V, tail(idxs), tail(subidxs))...))
 
-reindex(V, idxs::Tuple{BlockSlice{<:BlockRange}, Vararg{Any}},
-        subidxs::Tuple{BlockSlice{<:BlockRange}, Vararg{Any}}) =
-    (@_propagate_inbounds_meta; (BlockSlice(BlockRange(idxs[1].block.indices[1][Int.(subidxs[1].block)]),
-                                            idxs[1].indices[subidxs[1].indices]),
-                                    reindex(V, tail(idxs), tail(subidxs))...))
+    reindex(V, idxs::Tuple{BlockSlice{BlockRange{1,Tuple{UnitRange{Int}}}}, Vararg{Any}},
+            subidxs::Tuple{BlockSlice{Block{1,Int}}, Vararg{Any}}) =
+        (@_propagate_inbounds_meta; (BlockSlice(Block(idxs[1].block.indices[1][Int(subidxs[1].block)]),
+                                                idxs[1].indices[subidxs[1].indices]),
+                                        reindex(V, tail(idxs), tail(subidxs))...))
 
-reindex(V, idxs::Tuple{BlockSlice{BlockRange{1,Tuple{UnitRange{Int}}}}, Vararg{Any}},
-        subidxs::Tuple{BlockSlice{Block{1,Int}}, Vararg{Any}}) =
-    (@_propagate_inbounds_meta; (BlockSlice(Block(idxs[1].block.indices[1][Int(subidxs[1].block)]),
-                                            idxs[1].indices[subidxs[1].indices]),
-                                    reindex(V, tail(idxs), tail(subidxs))...))
-
-function reindex(V, idxs::Tuple{BlockSlice{Block{1,Int}}, Vararg{Any}},
-        subidxs::Tuple{BlockSlice{Block{1,Int}}, Vararg{Any}})
-    subidxs[1].block == Block(1) || throw(BoundsError(V, subidxs[1].block))
-    (idxs[1], reindex(V, tail(idxs), tail(subidxs))...)
-end
-
+    function reindex(V, idxs::Tuple{BlockSlice{Block{1,Int}}, Vararg{Any}},
+            subidxs::Tuple{BlockSlice{Block{1,Int}}, Vararg{Any}})
+        subidxs[1].block == Block(1) || throw(BoundsError(V, subidxs[1].block))
+        (idxs[1], reindex(V, tail(idxs), tail(subidxs))...)
+    end
 end  # if VERSION >= v"1.2-"
 
 

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -473,6 +473,10 @@ end
 @testset "Blockindex" begin
     a = PseudoBlockArray(randn(3), [1,2])
     @test a[Block(1)[1]] == a[1]
+    @test a[Block(1)[1:1]] == a[1:1]
     A = PseudoBlockArray(randn(3,3), [1,2], [1,2])
-    @test A[Block(1)[1], Block(1)[1]] == A[1,1]
+    @test A[Block(1)[1], Block(1)[1]] == A[Block(1,1)[1,1]] == A[1,1]
+    @test A[Block(1)[1:1], Block(1)[1:1]] == A[Block(1,1)[1:1,1:1]] == A[1:1,1:1]
+    @test A[Block(1)[1:1], Block(1)[1]] == BlockArray(A)[Block(1)[1:1], Block(1)[1]] == A[1:1,1] 
+    @test A[Block(1)[1], Block(1)[1:1]] == BlockArray(A)[Block(1)[1], Block(1)[1:1]] == A[1,1:1] 
 end

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -469,3 +469,10 @@ end
     @test Ã*b isa PseudoBlockVector{Float64}
     @test A*b ≈ Ã*b ≈ Matrix(A)*b 
 end
+
+@testset "Blockindex" begin
+    a = PseudoBlockArray(randn(3), [1,2])
+    @test a[Block(1)[1]] == a[1]
+    A = PseudoBlockArray(randn(3,3), [1,2], [1,2])
+    @test A[Block(1)[1], Block(1)[1]] == A[1,1]
+end


### PR DESCRIPTION
This fixes some bugs in indexing with `BlockIndex`