### PR TITLE
Support inv via QR

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,7 @@ ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
-ArrayLayouts = "0.2.7"
+ArrayLayouts = "0.3"
 julia = "1.1"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -7,7 +7,7 @@ ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
-ArrayLayouts = "0.2.4"
+ArrayLayouts = "0.2.7"
 julia = "1.1"
 
 [extras]

--- a/src/BlockArrays.jl
+++ b/src/BlockArrays.jl
@@ -35,7 +35,7 @@ import LinearAlgebra: lmul!, rmul!, AbstractTriangular, HermOrSym, AdjOrTrans,
                         StructuredMatrixStyle
 import ArrayLayouts: _fill_lmul!, MatMulVecAdd, MatMulMatAdd, MatLmulVec, MatLdivVec,
                         materialize!, MemoryLayout, sublayout, transposelayout, conjlayout, 
-                        triangularlayout, triangulardata
+                        triangularlayout, triangulardata, _inv
 
 include("blockindices.jl")                        
 include("blockaxis.jl")

--- a/src/blockarray.jl
+++ b/src/blockarray.jl
@@ -452,7 +452,3 @@ function rmul!(block_array::BlockArray, α::Number)
     end
     block_array
 end
-
-# Temporary work around
-Base.reshape(block_array::BlockArray, axes::NTuple{N,AbstractUnitRange{Int}}) where N = 
-    reshape(PseudoBlockArray(block_array), axes)

--- a/src/blockarray.jl
+++ b/src/blockarray.jl
@@ -74,11 +74,11 @@ end
 _BlockArray(blocks::R, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R<:AbstractArray{<:AbstractArray{T,N},N}} =
     _BlockArray(blocks, map(blockedrange, block_sizes))
 
-# support non-concrete eltypes in blocks    
+# support non-concrete eltypes in blocks
 _BlockArray(blocks::R, block_axes::BS) where {T, N, R<:AbstractArray{<:AbstractArray{V,N} where V,N}, BS<:NTuple{N,AbstractUnitRange{Int}}} =
     _BlockArray(convert(AbstractArray{AbstractArray{mapreduce(eltype,promote_type,blocks),N},N}, blocks), block_axes)
 _BlockArray(blocks::R, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R<:AbstractArray{<:AbstractArray{V,N} where V,N}} =
-    _BlockArray(convert(AbstractArray{AbstractArray{mapreduce(eltype,promote_type,blocks),N},N}, blocks), block_sizes...)    
+    _BlockArray(convert(AbstractArray{AbstractArray{mapreduce(eltype,promote_type,blocks),N},N}, blocks), block_sizes...)
 
 const BlockMatrix{T, R <: AbstractMatrix{<:AbstractMatrix{T}}} = BlockArray{T, 2, R}
 const BlockVector{T, R <: AbstractVector{<:AbstractVector{T}}} = BlockArray{T, 1, R}
@@ -165,7 +165,7 @@ initialized_blocks_BlockArray(::Type{R}, block_sizes::Vararg{AbstractVector{Int}
 
 
 @inline BlockArray{T,N,R,BS}(::UndefInitializer, sizes::NTuple{N,Int}) where {T, N, R<:AbstractArray{<:AbstractArray{T,N},N}, BS<:NTuple{N,AbstractUnitRange{Int}}} =
-    BlockArray{T,N,R,BS}(undef, convert(BS, map(Base.OneTo, sizes)))    
+    BlockArray{T,N,R,BS}(undef, convert(BS, map(Base.OneTo, sizes)))
 
 function BlockArray{T}(arr::AbstractArray{V, N}, block_sizes::Vararg{AbstractVector{Int}, N}) where {T,V,N}
     for i in 1:N
@@ -176,7 +176,7 @@ function BlockArray{T}(arr::AbstractArray{V, N}, block_sizes::Vararg{AbstractVec
     BlockArray{T}(arr, map(blockedrange,block_sizes))
 end
 
-BlockArray(arr::AbstractArray{T, N}, block_sizes::Vararg{AbstractVector{Int}, N}) where {T,N} = 
+BlockArray(arr::AbstractArray{T, N}, block_sizes::Vararg{AbstractVector{Int}, N}) where {T,N} =
     BlockArray{T}(arr, block_sizes...)
 
 @generated function BlockArray{T}(arr::AbstractArray{T, N}, baxes::NTuple{N,AbstractUnitRange{Int}}) where {T,N}
@@ -347,22 +347,22 @@ end
 
 
 @inline Base.similar(block_array::AbstractArray, ::Type{T}, axes::Tuple{BlockedUnitRange,Vararg{AbstractUnitRange{Int}}}) where T =
-    BlockArray{T}(undef, axes)   
+    BlockArray{T}(undef, axes)
 @inline Base.similar(block_array::AbstractArray, ::Type{T}, axes::Tuple{BlockedUnitRange,BlockedUnitRange,Vararg{AbstractUnitRange{Int}}}) where T =
-    BlockArray{T}(undef, axes)   
+    BlockArray{T}(undef, axes)
 @inline Base.similar(block_array::AbstractArray, ::Type{T}, axes::Tuple{AbstractUnitRange{Int},BlockedUnitRange,Vararg{AbstractUnitRange{Int}}}) where T =
-    BlockArray{T}(undef, axes)   
-          
+    BlockArray{T}(undef, axes)
+
 @inline Base.similar(block_array::Type{<:AbstractArray{T}}, axes::Tuple{BlockedUnitRange,Vararg{AbstractUnitRange{Int}}}) where T =
-    BlockArray{T}(undef, axes)  
+    BlockArray{T}(undef, axes)
 @inline Base.similar(block_array::Type{<:AbstractArray{T}}, axes::Tuple{BlockedUnitRange,BlockedUnitRange,Vararg{AbstractUnitRange{Int}}}) where T =
-    BlockArray{T}(undef, axes)          
+    BlockArray{T}(undef, axes)
 @inline Base.similar(block_array::Type{<:AbstractArray{T}}, axes::Tuple{AbstractUnitRange{Int},BlockedUnitRange,Vararg{AbstractUnitRange{Int}}}) where T =
-    BlockArray{T}(undef, axes) 
-    
+    BlockArray{T}(undef, axes)
+
 const OffsetAxis = Union{Integer, UnitRange, Base.OneTo, Base.IdentityUnitRange, Colon}
 
-# avoid ambiguities    
+# avoid ambiguities
 @inline Base.similar(block_array::BlockArray, ::Type{T}, dims::NTuple{N,Int}) where {T,N} =
     Array{T}(undef, dims)
 @inline Base.similar(block_array::BlockArray, ::Type{T}, axes::Tuple{OffsetAxis,Vararg{OffsetAxis}}) where T =
@@ -452,3 +452,13 @@ function rmul!(block_array::BlockArray, α::Number)
     end
     block_array
 end
+
+# Temporary work around
+Base.reshape(block_array::BlockArray, axes::NTuple{N,AbstractUnitRange{Int}}) where N =
+    reshape(PseudoBlockArray(block_array), axes)
+Base.reshape(block_array::BlockArray, dims::Tuple{Int,Vararg{Int}}) =
+    reshape(PseudoBlockArray(block_array), dims)
+Base.reshape(block_array::BlockArray, axes::Tuple{Union{Integer,Base.OneTo}, Vararg{Union{Integer,Base.OneTo}}}) =
+    reshape(PseudoBlockArray(block_array), axes)
+Base.reshape(block_array::BlockArray, dims::Tuple{Vararg{Union{Int,Colon}}}) =
+    reshape(PseudoBlockArray(block_array), dims)

--- a/src/blocklinalg.jl
+++ b/src/blocklinalg.jl
@@ -255,3 +255,6 @@ for UNIT in ('U', 'N')
         end
     end
 end
+
+# For now, use PseudoBlockArray
+_inv(::AbstractBlockLayout, axes, A) = BlockArray(inv(PseudoBlockArray(A)))

--- a/src/pseudo_blockarray.jl
+++ b/src/pseudo_blockarray.jl
@@ -297,8 +297,8 @@ end
 _pseudo_reshape(block_array, axes) = PseudoBlockArray(reshape(block_array.blocks,map(length,axes)),axes)
 Base.reshape(block_array::PseudoBlockArray, axes::NTuple{N,AbstractUnitRange{Int}}) where N =
     _pseudo_reshape(block_array, axes)
-Base.reshape(block_array::PseudoBlockArray, axes::Tuple{Union{Integer,Base.OneTo}, Vararg{Union{Integer,Base.OneTo}}}) where N =
-    _pseudo_reshape(block_array, axes)
+Base.reshape(parent::PseudoBlockArray, shp::Tuple{Union{Integer,Base.OneTo}, Vararg{Union{Integer,Base.OneTo}}}) where N =
+    reshape(parent, Base.to_shape(shp))
 Base.reshape(parent::PseudoBlockArray, dims::Tuple{Int,Vararg{Int}}) =
     Base._reshape(parent, dims)
 

--- a/src/pseudo_blockarray.jl
+++ b/src/pseudo_blockarray.jl
@@ -298,7 +298,9 @@ _pseudo_reshape(block_array, axes) = PseudoBlockArray(reshape(block_array.blocks
 Base.reshape(block_array::PseudoBlockArray, axes::NTuple{N,AbstractUnitRange{Int}}) where N =
     _pseudo_reshape(block_array, axes)
 Base.reshape(block_array::PseudoBlockArray, axes::Tuple{Union{Integer,Base.OneTo}, Vararg{Union{Integer,Base.OneTo}}}) where N =
-_pseudo_reshape(block_array, axes)
+    _pseudo_reshape(block_array, axes)
+Base.reshape(parent::PseudoBlockArray, dims::Tuple{Int,Vararg{Int}}) =
+    Base._reshape(parent, dims)
 
 
 ###########################

--- a/src/pseudo_blockarray.jl
+++ b/src/pseudo_blockarray.jl
@@ -30,9 +30,9 @@ julia> A = PseudoBlockArray(rand(2,3), [1,1], [2,1])
 
 julia> A = PseudoBlockArray(sprand(6, 0.5), [3,2,1])
 3-blocked 6-element PseudoBlockArray{Float64,1,SparseVector{Float64,Int64},Tuple{BlockedUnitRange{Array{Int64,1}}}}:
- 0.0                
+ 0.0
  0.5865981007905481
- 0.0                
+ 0.0
  ───────────────────
  0.05016684053503706
  0.0
@@ -56,22 +56,22 @@ const PseudoBlockVecOrMat{T} = Union{PseudoBlockMatrix{T}, PseudoBlockVector{T}}
     PseudoBlockArray{T, N, R,BS}(blocks, baxes)
 
 @inline PseudoBlockArray{T}(blocks::R, baxes::BS) where {T,N,R<:AbstractArray{T,N},BS<:NTuple{N,AbstractUnitRange{Int}}} =
-    PseudoBlockArray{T, N, R,BS}(blocks, baxes)  
-    
+    PseudoBlockArray{T, N, R,BS}(blocks, baxes)
+
 @inline PseudoBlockArray{T}(blocks::AbstractArray{<:Any,N}, baxes::NTuple{N,AbstractUnitRange{Int}}) where {T,N} =
-    PseudoBlockArray{T}(convert(AbstractArray{T,N}, blocks), baxes)      
+    PseudoBlockArray{T}(convert(AbstractArray{T,N}, blocks), baxes)
 
 @inline PseudoBlockArray(blocks::PseudoBlockArray, baxes::BS) where {N,BS<:NTuple{N,AbstractUnitRange{Int}}} =
     PseudoBlockArray(blocks.blocks, baxes)
 
 @inline PseudoBlockArray{T}(blocks::PseudoBlockArray, baxes::BS) where {T,N,BS<:NTuple{N,AbstractUnitRange{Int}}} =
-    PseudoBlockArray{T}(blocks.blocks, baxes)    
+    PseudoBlockArray{T}(blocks.blocks, baxes)
 
 PseudoBlockArray(blocks::AbstractArray{T, N}, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N} =
     PseudoBlockArray(blocks, map(blockedrange,block_sizes))
 
 PseudoBlockArray{T}(blocks::AbstractArray{<:Any, N}, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N} =
-    PseudoBlockArray{T}(blocks, map(blockedrange,block_sizes))    
+    PseudoBlockArray{T}(blocks, map(blockedrange,block_sizes))
 
 @inline PseudoBlockArray{T,N,R,BS}(::UndefInitializer, baxes::NTuple{N,AbstractUnitRange{Int}}) where {T,N,R,BS<:NTuple{N,AbstractUnitRange{Int}}} =
     PseudoBlockArray{T,N,R,BS}(R(undef, length.(baxes)), convert(BS, baxes))
@@ -117,7 +117,7 @@ convert(::Type{PseudoBlockArray{T,N}}, A::PseudoBlockArray{T,N}) where {T,N} = A
 convert(::Type{PseudoBlockArray{T}}, A::PseudoBlockArray{T}) where {T} = A
 convert(::Type{PseudoBlockArray}, A::PseudoBlockArray) = A
 
-convert(::Type{PseudoBlockArray{T,N,R,BS}}, A::PseudoBlockArray) where {T,N,R,BS} = 
+convert(::Type{PseudoBlockArray{T,N,R,BS}}, A::PseudoBlockArray) where {T,N,R,BS} =
     PseudoBlockArray{T,N,R,BS}(convert(R, A.blocks), convert(BS, A.axes))
 
 
@@ -144,18 +144,25 @@ function Base.similar(block_array::PseudoBlockArray{T,N}, ::Type{T2}) where {T,N
 end
 
 @inline Base.similar(block_array::Type{<:Array{T}}, axes::Tuple{BlockedUnitRange,Vararg{AbstractUnitRange{Int}}}) where T =
-    PseudoBlockArray{T}(undef, axes)  
+    PseudoBlockArray{T}(undef, axes)
 @inline Base.similar(block_array::Type{<:Array{T}}, axes::Tuple{BlockedUnitRange,BlockedUnitRange,Vararg{AbstractUnitRange{Int}}}) where T =
-    PseudoBlockArray{T}(undef, axes)          
+    PseudoBlockArray{T}(undef, axes)
 @inline Base.similar(block_array::Type{<:Array{T}}, axes::Tuple{AbstractUnitRange{Int},BlockedUnitRange,Vararg{AbstractUnitRange{Int}}}) where T =
-    PseudoBlockArray{T}(undef, axes)     
+    PseudoBlockArray{T}(undef, axes)
 
 @inline Base.similar(block_array::Array, ::Type{T}, axes::Tuple{BlockedUnitRange,Vararg{AbstractUnitRange{Int}}}) where T =
-    PseudoBlockArray{T}(undef, axes)  
+    PseudoBlockArray{T}(undef, axes)
 @inline Base.similar(block_array::Array, ::Type{T}, axes::Tuple{BlockedUnitRange,BlockedUnitRange,Vararg{AbstractUnitRange{Int}}}) where T =
-    PseudoBlockArray{T}(undef, axes)          
+    PseudoBlockArray{T}(undef, axes)
 @inline Base.similar(block_array::Array, ::Type{T}, axes::Tuple{AbstractUnitRange{Int},BlockedUnitRange,Vararg{AbstractUnitRange{Int}}}) where T =
-    PseudoBlockArray{T}(undef, axes)         
+    PseudoBlockArray{T}(undef, axes)
+
+@inline Base.similar(block_array::PseudoBlockArray, ::Type{T}, axes::Tuple{BlockedUnitRange,Vararg{AbstractUnitRange{Int}}}) where T =
+    PseudoBlockArray{T}(undef, axes)
+@inline Base.similar(block_array::PseudoBlockArray, ::Type{T}, axes::Tuple{BlockedUnitRange,BlockedUnitRange,Vararg{AbstractUnitRange{Int}}}) where T =
+    PseudoBlockArray{T}(undef, axes)
+@inline Base.similar(block_array::PseudoBlockArray, ::Type{T}, axes::Tuple{AbstractUnitRange{Int},BlockedUnitRange,Vararg{AbstractUnitRange{Int}}}) where T =
+    PseudoBlockArray{T}(undef, axes)
 
 @inline function Base.getindex(block_arr::PseudoBlockArray{T, N}, i::Vararg{Integer, N}) where {T,N}
     @boundscheck checkbounds(block_arr, i...)
@@ -287,9 +294,11 @@ function rmul!(block_array::PseudoBlockArray, α::Number)
     block_array
 end
 
+_pseudo_reshape(block_array, axes) = PseudoBlockArray(reshape(block_array.blocks,map(length,axes)),axes)
 Base.reshape(block_array::PseudoBlockArray, axes::NTuple{N,AbstractUnitRange{Int}}) where N =
-    PseudoBlockArray(reshape(block_array.blocks,map(length,axes)),axes)
-
+    _pseudo_reshape(block_array, axes)
+Base.reshape(block_array::PseudoBlockArray, axes::Tuple{Union{Integer,Base.OneTo}, Vararg{Union{Integer,Base.OneTo}}}) where N =
+_pseudo_reshape(block_array, axes)
 
 
 ###########################

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -105,6 +105,7 @@ end
         @test similar(Array{Float64}, axes(ret)) isa PseudoBlockArray
         @test similar(Vector{Float64}, axes(ret)) isa PseudoBlockArray
         @test similar(randn(5,5), Float64, axes(ret)) isa PseudoBlockArray
+        @test similar(ret, Float64, (Base.IdentityUnitRange(1:3),)) isa BlockArray
 
         ret = BlockArray{Float64}(undef, 1:3, 1:3)
         @test similar(typeof(ret), axes(ret)) isa BlockArray
@@ -371,6 +372,11 @@ end
     C = convert(PseudoBlockArray{Float32, 2}, A)
     @test C ≈ A ≈ PseudoBlockArray(A)
     @test eltype(C) == Float32
+
+    @test convert(BlockArray, A) === A
+    @test convert(BlockArray{Float64}, A) === A
+    @test convert(BlockMatrix{Float64}, A) === A
+    @test convert(BlockMatrix{Float64,Matrix{Matrix{Float64}}}, A) === A
 end
 
 @testset "string" begin
@@ -495,11 +501,15 @@ end
     @test reshape(A, Val(2)) isa PseudoBlockArray{Int64,2,Array{Int64,2},Tuple{BlockedUnitRange{Array{Int64,1}},Base.OneTo{Int64}}}
     @test reshape(A, Val(2)) == PseudoBlockArray(reshape(1:6,6,1), (blockedrange(1:3), Base.OneTo(1)))
     @test reshape(A, (blockedrange(Fill(2,3)),))[Block(1)] == 1:2
+    @test reshape(A, 2, 3) == reshape(A, Base.OneTo(2), 3) == reshape(Vector(A), 2, 3)
+
+    @test_throws DimensionMismatch reshape(A,3)
 
     A = PseudoBlockArray(1:6, 1:3)
     @test reshape(A, Val(2)) isa typeof(PseudoBlockArray(reshape(1:6,6,1), (blockedrange(1:3), Base.OneTo(1))))
     @test reshape(A, Val(2)) == PseudoBlockArray(reshape(1:6,6,1), (blockedrange(1:3), Base.OneTo(1)))
     @test reshape(A, (blockedrange(Fill(2,3)),))[Block(1)] == 1:2
+    @test reshape(A, 2, 3) == reshape(A, Base.OneTo(2), 3) == reshape(Vector(A), 2, 3)
 end
 
 @testset "*" begin

--- a/test/test_blocklinalg.jl
+++ b/test/test_blocklinalg.jl
@@ -172,6 +172,23 @@ import ArrayLayouts: DenseRowMajor
             @test UnitLowerTriangular(B) \ b ≈ UnitLowerTriangular(Matrix(B)) \ b
         end
     end
+
+    @testset "inv" begin
+        A = PseudoBlockArray{Float64}(randn(6,6), fill(2,3), 1:3)
+        F = factorize(A)
+        # Defaults to QR for generality
+        @test F isa LinearAlgebra.QRCompactWY
+        B = randn(6,6)
+        @test ldiv!(F, copy(B)) ≈ Matrix(A) \ B
+        B̃ = PseudoBlockArray(copy(B),1:3,fill(2,3))
+        @test ldiv!(F, B̃) ≈ A\B ≈ Matrix(A) \ B
+
+        @test inv(A) isa PseudoBlockArray
+        @test inv(A) ≈ inv(Matrix(A))
+        @test inv(A)*A ≈ I(6)
+
+        A = BlockArray{Float64}(randn(6,6), fill(2,3), 1:3)
+        @test inv(A) isa BlockArray
+        @test inv(A)*A ≈ I(6)
+    end
 end
-
-

--- a/test/test_blocklinalg.jl
+++ b/test/test_blocklinalg.jl
@@ -185,10 +185,10 @@ import ArrayLayouts: DenseRowMajor
 
         @test inv(A) isa PseudoBlockArray
         @test inv(A) ≈ inv(Matrix(A))
-        @test inv(A)*A ≈ I(6)
+        @test inv(A)*A ≈ Matrix(I,6,6)
 
         A = BlockArray{Float64}(randn(6,6), fill(2,3), 1:3)
         @test inv(A) isa BlockArray
-        @test inv(A)*A ≈ I(6)
+        @test inv(A)*A ≈ Matrix(I,6,6)
     end
 end


### PR DESCRIPTION
This adds support for `inv`, returning a block array. For simplicity we just use QR for now, though this may change to LU in the future.