### PR TITLE
More general printing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,10 +4,11 @@ version = "0.12.6"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
+FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
-ArrayLayouts = "0.3"
+ArrayLayouts = "0.3.2"
 julia = "1.1"
 
 [extras]

--- a/src/BlockArrays.jl
+++ b/src/BlockArrays.jl
@@ -35,7 +35,8 @@ import LinearAlgebra: lmul!, rmul!, AbstractTriangular, HermOrSym, AdjOrTrans,
                         StructuredMatrixStyle
 import ArrayLayouts: _fill_lmul!, MatMulVecAdd, MatMulMatAdd, MatLmulVec, MatLdivVec,
                         materialize!, MemoryLayout, sublayout, transposelayout, conjlayout, 
-                        triangularlayout, triangulardata, _inv
+                        triangularlayout, triangulardata, _inv, _copyto!, layout_print_matrix_row,
+                        colsupport, rowsupport
 
 include("blockindices.jl")                        
 include("blockaxis.jl")
@@ -43,10 +44,10 @@ include("abstractblockarray.jl")
 include("blockarray.jl")
 include("pseudo_blockarray.jl")
 include("views.jl")
-include("show.jl")
 include("blockarrayinterface.jl")
 include("blockbroadcast.jl")
 include("blocklinalg.jl")
 include("blockproduct.jl")
+include("show.jl")
 
 end # module

--- a/src/BlockArrays.jl
+++ b/src/BlockArrays.jl
@@ -35,7 +35,7 @@ import LinearAlgebra: lmul!, rmul!, AbstractTriangular, HermOrSym, AdjOrTrans,
                         StructuredMatrixStyle
 import ArrayLayouts: _fill_lmul!, MatMulVecAdd, MatMulMatAdd, MatLmulVec, MatLdivVec,
                         materialize!, MemoryLayout, sublayout, transposelayout, conjlayout, 
-                        triangularlayout, triangulardata, _inv, _copyto!, layout_print_matrix_row,
+                        triangularlayout, triangulardata, _inv, _copyto!, axes_print_matrix_row,
                         colsupport, rowsupport
 
 include("blockindices.jl")                        

--- a/src/BlockArrays.jl
+++ b/src/BlockArrays.jl
@@ -24,7 +24,7 @@ import Base: @propagate_inbounds, Array, to_indices, to_index,
             broadcast, eltype, convert, similar,
             @_inline_meta, _maybetail, tail, @_propagate_inbounds_meta, reindex,
             RangeIndex, Int, Integer, Number,
-            +, -, min, max, *, isless, in, copy, copyto!, axes, @deprecate,
+            +, -, *, /, \, min, max, isless, in, copy, copyto!, axes, @deprecate,
             BroadcastStyle, checkbounds, throw_boundserror
 using Base: ReshapedArray, dataids
 

--- a/src/BlockArrays.jl
+++ b/src/BlockArrays.jl
@@ -21,7 +21,7 @@ export blockappend!, blockpush!, blockpushfirst!, blockpop!, blockpopfirst!
 import Base: @propagate_inbounds, Array, to_indices, to_index,
             unsafe_indices, first, last, size, length, unsafe_length,
             unsafe_convert,
-            getindex, show,
+            getindex, ndims, show,
             step, 
             broadcast, eltype, convert, similar,
             @_inline_meta, _maybetail, tail, @_propagate_inbounds_meta, reindex,
@@ -31,8 +31,8 @@ import Base: @propagate_inbounds, Array, to_indices, to_index,
 using Base: ReshapedArray, dataids
 
 
-import Base: (:), IteratorSize, iterate, axes1, strides
-import Base.Broadcast: broadcasted, DefaultArrayStyle, AbstractArrayStyle, Broadcasted
+import Base: (:), IteratorSize, iterate, axes1, strides, isempty
+import Base.Broadcast: broadcasted, DefaultArrayStyle, AbstractArrayStyle, Broadcasted, broadcastable
 import LinearAlgebra: lmul!, rmul!, AbstractTriangular, HermOrSym, AdjOrTrans,
                         StructuredMatrixStyle
 import ArrayLayouts: _fill_lmul!, MatMulVecAdd, MatMulMatAdd, MatLmulVec, MatLdivVec,

--- a/src/blockarray.jl
+++ b/src/blockarray.jl
@@ -66,12 +66,12 @@ struct BlockArray{T, N, R <: AbstractArray{<:AbstractArray{T,N},N}, BS<:NTuple{N
     blocks::R
     axes::BS
 
-    global _BlockArray(blocks::R, block_sizes::BS) where {T, N, R<:AbstractArray{<:AbstractArray{T,N},N}, BS<:NTuple{N,AbstractUnitRange{Int}}} =
+    global @inline _BlockArray(blocks::R, block_sizes::BS) where {T, N, R<:AbstractArray{<:AbstractArray{T,N},N}, BS<:NTuple{N,AbstractUnitRange{Int}}} =
         new{T, N, R, BS}(blocks, block_sizes)
 end
 
 # Auxilary outer constructors
-_BlockArray(blocks::R, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R<:AbstractArray{<:AbstractArray{T,N},N}} =
+@inline _BlockArray(blocks::R, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R<:AbstractArray{<:AbstractArray{T,N},N}} =
     _BlockArray(blocks, map(blockedrange, block_sizes))
 
 # support non-concrete eltypes in blocks

--- a/src/blockarray.jl
+++ b/src/blockarray.jl
@@ -208,17 +208,6 @@ BlockMatrix(λ::UniformScaling, block_sizes::Vararg{AbstractVector{Int},2}) = Bl
 BlockMatrix{T}(λ::UniformScaling, baxes::NTuple{2,AbstractUnitRange{Int}}) where T = BlockArray{T}(λ, baxes)
 BlockMatrix{T}(λ::UniformScaling, block_sizes::Vararg{AbstractVector{Int},2}) where T = BlockArray{T}(λ, block_sizes...)
 
-
-"""
-   blocks(A::AbstractArray)
-
-returns a matrix of the blocks of `A`.
-"""
-blocks(A::BlockArray) = A.blocks
-
-blocks(A::Adjoint) = adjoint(blocks(parent(A)))
-blocks(A::Transpose) = transpose(blocks(parent(A)))
-
 """
     mortar(blocks::AbstractArray)
     mortar(blocks::AbstractArray{R, N}, sizes_1, sizes_2, ..., sizes_N)

--- a/src/blockarray.jl
+++ b/src/blockarray.jl
@@ -212,6 +212,14 @@ BlockMatrix(λ::UniformScaling, block_sizes::Vararg{AbstractVector{Int},2}) = Bl
 BlockMatrix{T}(λ::UniformScaling, baxes::NTuple{2,AbstractUnitRange{Int}}) where T = BlockArray{T}(λ, baxes)
 BlockMatrix{T}(λ::UniformScaling, block_sizes::Vararg{AbstractVector{Int},2}) where T = BlockArray{T}(λ, block_sizes...)
 
+
+"""
+   blocks(A::AbstractArray)
+
+returns a matrix of the blocks of `A`.
+"""
+blocks(A::BlockArray) = A.blocks
+
 """
     mortar(blocks::AbstractArray)
     mortar(blocks::AbstractArray{R, N}, sizes_1, sizes_2, ..., sizes_N)

--- a/src/blockarray.jl
+++ b/src/blockarray.jl
@@ -220,8 +220,8 @@ returns a matrix of the blocks of `A`.
 """
 blocks(A::BlockArray) = A.blocks
 
-blocks(A::Adjoint) = transpose(map(adjoint,blocks(parent(A))))
-blocks(A::Transpose) = transpose(map(transpose,blocks(parent(A))))
+blocks(A::Adjoint) = adjoint(blocks(parent(A)))
+blocks(A::Transpose) = transpose(blocks(parent(A)))
 
 """
     mortar(blocks::AbstractArray)

--- a/src/blockarray.jl
+++ b/src/blockarray.jl
@@ -220,6 +220,9 @@ returns a matrix of the blocks of `A`.
 """
 blocks(A::BlockArray) = A.blocks
 
+blocks(A::Adjoint) = transpose(map(adjoint,blocks(parent(A))))
+blocks(A::Transpose) = transpose(map(transpose,blocks(parent(A))))
+
 """
     mortar(blocks::AbstractArray)
     mortar(blocks::AbstractArray{R, N}, sizes_1, sizes_2, ..., sizes_N)

--- a/src/blockarrayinterface.jl
+++ b/src/blockarrayinterface.jl
@@ -3,12 +3,3 @@ getindex(a::Number, ::Block{0}) = a
 
 axes(A::AbstractTriangular{<:Any,<:AbstractBlockMatrix}) = axes(parent(A))
 axes(A::HermOrSym{<:Any,<:AbstractBlockMatrix}) = axes(parent(A))
-
-Base.print_matrix_row(io::IO,
-        X::Union{AbstractTriangular{<:Any,<:AbstractBlockMatrix},
-                 Symmetric{<:Any,<:AbstractBlockMatrix},
-                 Hermitian{<:Any,<:AbstractBlockMatrix},
-                 Adjoint{<:Any,<:AbstractBlockMatrix},
-                 Transpose{<:Any,<:AbstractBlockMatrix}}, A::Vector,
-        i::Integer, cols::AbstractVector, sep::AbstractString) =
-        _blockarray_print_matrix_row(io, X, A, i, cols, sep)

--- a/src/blockbroadcast.jl
+++ b/src/blockbroadcast.jl
@@ -214,6 +214,13 @@ for op in (:+, :-, :*, :/, :\)
     end
 end
 
+# exploit special cases for *, for example, *(::Number, ::Diagonal)
+for op in (:*, :/) 
+    @eval @inline $op(A::BlockArray, x::Number) = _BlockArray($op(blocks(A),x), axes(A))
+end
+for op in (:*, :\)
+    @eval @inline $op(x::Number, A::BlockArray) = _BlockArray($op(x,blocks(A)), axes(A))
+end
 
 ###
 # SubViews

--- a/src/blockbroadcast.jl
+++ b/src/blockbroadcast.jl
@@ -147,10 +147,8 @@ end
     return copyto!(dest, Base.Broadcast.instantiate(Base.Broadcast.Broadcasted{BS}(bc.f, bc.args, combine_blockaxes.(axes(dest),axes(bc)))))
 end
 
-@generated function copyto!(
-        dest::AbstractArray,
-        bc::Broadcasted{<:AbstractBlockStyle{NDims}, <:Any, <:Any, Args},
-        ) where {NDims, Args <: Tuple}
+@generated function copyto!(dest::AbstractArray,
+                            bc::Broadcasted{<:AbstractBlockStyle{NDims}, <:Any, <:Any, Args}) where {NDims, Args <: Tuple}
 
     NArgs = length(Args.parameters)
 
@@ -190,29 +188,40 @@ end
     end
 end
 
-@inline function Broadcast.instantiate(
-        bc::Broadcasted{Style}) where {Style <:AbstractBlockStyle}
-    bcf = Broadcast.flatten(Broadcasted{Nothing}(bc.f, bc.args, bc.axes))
+@inline function Broadcast.instantiate(bc::Broadcasted{Style}) where {Style <:AbstractBlockStyle}
+    bcf = Broadcast.instantiate(Broadcast.flatten(Broadcasted{Nothing}(bc.f, bc.args, bc.axes)))
     return Broadcasted{Style}(bcf.f, bcf.args, bcf.axes)
 end
 
 
 for op in (:+, :-, :*)
-    @eval function copy(bc::Broadcasted{BlockStyle{N},<:Any,typeof($op),<:Tuple{<:BlockArray{<:Number,N}}}) where N
+    @eval function copy(bc::Broadcasted{BlockStyle{N},<:Any,typeof($op),<:Tuple{<:AbstractArray{<:Number,N}}}) where N
         (A,) = bc.args
-        _BlockArray(broadcast(a -> broadcast($op, a), A.blocks), axes(A))
+        _BlockArray(broadcast(a -> broadcast($op, a), blocks(A)), axes(A))
     end
 end
 
 for op in (:+, :-, :*, :/, :\)
     @eval begin
-        function copy(bc::Broadcasted{BlockStyle{N},<:Any,typeof($op),<:Tuple{<:Number,<:BlockArray{<:Number,N}}}) where N
+        function copy(bc::Broadcasted{BlockStyle{N},<:Any,typeof($op),<:Tuple{<:Number,<:AbstractArray{<:Number,N}}}) where N
             x,A = bc.args
-            _BlockArray(broadcast((x,a) -> broadcast($op, x, a), x, A.blocks), axes(A))
+            _BlockArray(broadcast((x,a) -> broadcast($op, x, a), x, blocks(A)), axes(A))
         end
-        function copy(bc::Broadcasted{BlockStyle{N},<:Any,typeof($op),<:Tuple{<:BlockArray{<:Number,N},<:Number}}) where N
+        function copy(bc::Broadcasted{BlockStyle{N},<:Any,typeof($op),<:Tuple{<:AbstractArray{<:Number,N},<:Number}}) where N
             A,x = bc.args
-            _BlockArray(broadcast((a,x) -> broadcast($op, a, x), A.blocks,x), axes(A))
+            _BlockArray(broadcast((a,x) -> broadcast($op, a, x), blocks(A),x), axes(A))
         end
     end
 end
+
+
+###
+# SubViews
+###
+
+_blocktype(::Type{<:BlockArray{<:Any,N,<:AbstractArray{R,N}}}) where {N,R} = R
+
+BroadcastStyle(::Type{<:SubArray{T,N,Arr,<:NTuple{N,BlockSlice1},false}}) where {T,N,Arr<:BlockArray} = 
+    BroadcastStyle(_blocktype(Arr))
+BroadcastStyle(::Type{<:SubArray{T,N,Arr,<:NTuple{N,BlockSlice{BlockRange{1,Tuple{II}}}},false}}) where {T,N,Arr<:BlockArray,II} = 
+    BroadcastStyle(Arr)

--- a/src/blockindices.jl
+++ b/src/blockindices.jl
@@ -37,6 +37,7 @@ end
 
 # iterate and broadcast like Number
 length(b::Block) = 1
+size(b::Block) = ()
 iterate(x::Block) = (x, nothing)
 iterate(x::Block, ::Any) = nothing
 isempty(x::Block) = false
@@ -44,6 +45,7 @@ broadcastable(x::Block) = x
 ndims(::Type{<:Block}) = 0
 ndims(::Block) = 0
 eltype(::Type{B}) where B<:Block = B
+getindex(B::Block, ::CartesianIndex{0}) = B
 
 # The following code is taken from CartesianIndex
 @inline (+)(index::Block{N}) where {N} = Block{N}(map(+, index.n))

--- a/src/blockindices.jl
+++ b/src/blockindices.jl
@@ -35,6 +35,13 @@ Block(n::NTuple{N, T}) where {N,T} = Block{N, T}(n)
     Block{N, T}(ntuple(i -> blocks[i].n[1], Val(N)))
 end
 
+# iterate and broadcast like Number
+length(b::Block) = 1
+iterate(x::Block) = (x, nothing)
+iterate(x::Block, ::Any) = nothing
+isempty(x::Block) = false
+broadcastable(x::Block) = x
+ndims(::Type{<:Block}) = 0
 
 # The following code is taken from CartesianIndex
 @inline (+)(index::Block{N}) where {N} = Block{N}(map(+, index.n))
@@ -295,6 +302,7 @@ BlockRange(inds::Vararg{AbstractUnitRange{Int},N}) where {N} =
 Base.BroadcastStyle(::Type{<:BlockRange{1}}) = DefaultArrayStyle{1}()
 broadcasted(::DefaultArrayStyle{1}, ::Type{Block}, r::AbstractUnitRange) = Block(first(r)):Block(last(r))
 broadcasted(::DefaultArrayStyle{1}, ::Type{Int}, block_range::BlockRange{1}) = first(block_range.indices)
+broadcasted(::DefaultArrayStyle{0}, ::Type{Int}, block::Block{1}) = Int(block)
 
 
 # AbstractArray implementation

--- a/src/blockindices.jl
+++ b/src/blockindices.jl
@@ -42,6 +42,8 @@ iterate(x::Block, ::Any) = nothing
 isempty(x::Block) = false
 broadcastable(x::Block) = x
 ndims(::Type{<:Block}) = 0
+ndims(::Block) = 0
+eltype(::Type{B}) where B<:Block = B
 
 # The following code is taken from CartesianIndex
 @inline (+)(index::Block{N}) where {N} = Block{N}(map(+, index.n))

--- a/src/blocklinalg.jl
+++ b/src/blocklinalg.jl
@@ -7,7 +7,7 @@ gives an iterator containing the possible non-zero blocks in the k-th block-row 
 blockrowsupport(A, k) = blockrowsupport(MemoryLayout(A), A, k)
 blockrowsupport(A) = blockrowsupport(A, blockaxes(A,1))
 
-blockcolsupport(_, A, j) = blockaxes(A,1)
+blockcolsupport(_, A, j) = Block.(colsupport(blocks(A), Int.(j)))
 
 """"
     blockcolsupport(A, j)

--- a/src/blocklinalg.jl
+++ b/src/blocklinalg.jl
@@ -31,12 +31,14 @@ abstract type AbstractBlockLayout <: MemoryLayout end
 struct BlockLayout{ArrLay,BlockLay} <: AbstractBlockLayout end
 
 function colsupport(::BlockLayout, A, j)
-    KR = colsupport(blocks(A), Int(findblock(axes(A,2), j)))
+    JR = Int(findblock(axes(A,2), minimum(j))):Int(findblock(axes(A,2), maximum(j)))
+    KR = colsupport(blocks(A), JR)
     axes(A,1)[Block.(KR)]
 end
 
 function rowsupport(::BlockLayout, A, k)
-    JR = rowsupport(blocks(A), Int(findblock(axes(A,1), k)))
+    KR = Int(findblock(axes(A,1), minimum(k))):Int(findblock(axes(A,1), maximum(k)))
+    JR = rowsupport(blocks(A), KR)
     axes(A,2)[Block.(JR)]
 end
 

--- a/src/blocklinalg.jl
+++ b/src/blocklinalg.jl
@@ -64,14 +64,6 @@ conjlayout(::Type{T}, ::BlockLayout{MLAY,BLAY}) where {T<:Real,MLAY,BLAY} = Bloc
 transposelayout(::BlockLayout{MLAY,BLAY}) where {MLAY,BLAY} =
     BlockLayout{typeof(transposelayout(MLAY())),typeof(transposelayout(BLAY()))}()
 
-# convert a tuple of BlockRange to a tuple of `AbstractUnitRange{Int}`
-_blockrange2int() = ()
-_blockrange2int(A, B...) = tuple(Int.(A.block), _blockrange2int(B...)...)
-
-blocks(A::SubArray{<:Any,N,<:Any,<:NTuple{N,BlockSlice}}) where N =
-    view(blocks(parent(A)), _blockrange2int(parentindices(A)...)...)
-
-
 #############
 # BLAS overrides
 #############

--- a/src/blocks.jl
+++ b/src/blocks.jl
@@ -52,8 +52,10 @@ blocks(A::Adjoint) = adjoint(blocks(parent(A)))
 blocks(A::Transpose) = transpose(blocks(parent(A)))
 
 # convert a tuple of BlockRange to a tuple of `AbstractUnitRange{Int}`
+_block2int(B::Block{1}) = Int(B):Int(B)
+_block2int(B::BlockRange{1}) = Int.(B)
 _blockrange2int() = ()
-_blockrange2int(A, B...) = tuple(Int.(A.block), _blockrange2int(B...)...)
+_blockrange2int(A, B...) = tuple(_block2int(A.block), _blockrange2int(B...)...)
 
 blocks(A::SubArray{<:Any,N,<:Any,<:NTuple{N,BlockSlice}}) where N =
     view(blocks(parent(A)), _blockrange2int(parentindices(A)...)...)

--- a/src/pseudo_blockarray.jl
+++ b/src/pseudo_blockarray.jl
@@ -310,3 +310,11 @@ Base.reshape(parent::PseudoBlockArray, dims::Tuple{Int,Vararg{Int}}) =
 Base.strides(A::PseudoBlockArray) = strides(A.blocks)
 Base.stride(A::PseudoBlockArray, i::Integer) = stride(A.blocks, i)
 Base.unsafe_convert(::Type{Ptr{T}}, A::PseudoBlockArray) where T = Base.unsafe_convert(Ptr{T}, A.blocks)
+
+
+###
+# col/rowsupport
+###
+
+colsupport(A::PseudoBlockArray, j) = colsupport(A.blocks, j)
+rowsupport(A::PseudoBlockArray, j) = rowsupport(A.blocks, j)

--- a/src/show.jl
+++ b/src/show.jl
@@ -102,6 +102,10 @@ axes_print_matrix_row(::Tuple{BlockedUnitRange}, io, X, A, i, cols, sep) =
         _blockarray_print_matrix_row(io, X, A, i, cols, sep)
 axes_print_matrix_row(::NTuple{2,BlockedUnitRange}, io, X, A, i, cols, sep) =
         _blockarray_print_matrix_row(io, X, A, i, cols, sep)
+axes_print_matrix_row(::Tuple{AbstractUnitRange,BlockedUnitRange}, io, X, A, i, cols, sep) =
+        _blockarray_print_matrix_row(io, X, A, i, cols, sep)
+axes_print_matrix_row(::Tuple{BlockedUnitRange,AbstractUnitRange}, io, X, A, i, cols, sep) =
+        _blockarray_print_matrix_row(io, X, A, i, cols, sep)
 
 # Need to handled BlockedUnitRange, which is not a LayoutVector
 Base.print_matrix_row(io::IO, X::BlockedUnitRange, A::Vector, i::Integer, cols::AbstractVector, sep::AbstractString) =

--- a/src/show.jl
+++ b/src/show.jl
@@ -98,9 +98,9 @@ function _show_typeof(io::IO, a::BlockArray{T,N,Array{Array{T,N},N},NTuple{N,Def
 end
 
 # LayoutArray with blocked axes will dispatch to here
-layout_print_matrix_row(::Tuple{BlockedUnitRange}, io, X, A, i, cols, sep) =
+axes_print_matrix_row(::Tuple{BlockedUnitRange}, io, X, A, i, cols, sep) =
         _blockarray_print_matrix_row(io, X, A, i, cols, sep)
-layout_print_matrix_row(::NTuple{2,BlockedUnitRange}, io, X, A, i, cols, sep) =
+axes_print_matrix_row(::NTuple{2,BlockedUnitRange}, io, X, A, i, cols, sep) =
         _blockarray_print_matrix_row(io, X, A, i, cols, sep)
 
 # Need to handled BlockedUnitRange, which is not a LayoutVector

--- a/src/show.jl
+++ b/src/show.jl
@@ -97,9 +97,14 @@ function _show_typeof(io::IO, a::BlockArray{T,N,Array{Array{T,N},N},NTuple{N,Def
     print(io, '}')
 end
 
+# LayoutArray with blocked axes will dispatch to here
 layout_print_matrix_row(::Tuple{BlockedUnitRange}, io, X, A, i, cols, sep) =
         _blockarray_print_matrix_row(io, X, A, i, cols, sep)
 layout_print_matrix_row(::NTuple{2,BlockedUnitRange}, io, X, A, i, cols, sep) =
+        _blockarray_print_matrix_row(io, X, A, i, cols, sep)
+
+# Need to handled BlockedUnitRange, which is not a LayoutVector
+Base.print_matrix_row(io::IO, X::BlockedUnitRange, A::Vector, i::Integer, cols::AbstractVector, sep::AbstractString) =
         _blockarray_print_matrix_row(io, X, A, i, cols, sep)
 
 function _show_typeof(io::IO, a::PseudoBlockArray{T,N,Array{T,N},NTuple{N,DefaultBlockAxis}}) where {T,N}

--- a/src/show.jl
+++ b/src/show.jl
@@ -88,12 +88,6 @@ function _blockarray_print_matrix_row(io::IO,
     end
 end
 
-
-Base.print_matrix_row(io::IO,
-        X::AbstractBlockVecOrMat, A::Vector,
-        i::Integer, cols::AbstractVector, sep::AbstractString) =
-        _blockarray_print_matrix_row(io, X, A, i, cols, sep)
-
 function _show_typeof(io::IO, a::BlockArray{T,N,Array{Array{T,N},N},NTuple{N,DefaultBlockAxis}}) where {T,N}
     Base.show_type_name(io, typeof(a).name)
     print(io, '{')
@@ -102,6 +96,11 @@ function _show_typeof(io::IO, a::BlockArray{T,N,Array{Array{T,N},N},NTuple{N,Def
     show(io, N)
     print(io, '}')
 end
+
+layout_print_matrix_row(::Tuple{BlockedUnitRange}, io, X, A, i, cols, sep) =
+        _blockarray_print_matrix_row(io, X, A, i, cols, sep)
+layout_print_matrix_row(::NTuple{2,BlockedUnitRange}, io, X, A, i, cols, sep) =
+        _blockarray_print_matrix_row(io, X, A, i, cols, sep)
 
 function _show_typeof(io::IO, a::PseudoBlockArray{T,N,Array{T,N},NTuple{N,DefaultBlockAxis}}) where {T,N}
     Base.show_type_name(io, typeof(a).name)
@@ -112,13 +111,7 @@ function _show_typeof(io::IO, a::PseudoBlockArray{T,N,Array{T,N},NTuple{N,Defaul
     print(io, '}')
 end
 
-
 ## Cumsum
-
-Base.print_matrix_row(io::IO,
-        X::BlockedUnitRange, A::Vector,
-        i::Integer, cols::AbstractVector, sep::AbstractString) =
-        _blockarray_print_matrix_row(io, X, A, i, cols, sep)
 
 Base.show(io::IO, mimetype::MIME"text/plain", a::BlockedUnitRange) = 
     Base.invoke(show, Tuple{typeof(io),MIME"text/plain",AbstractArray},io, mimetype, a)

--- a/test/test_blockarrayinterface.jl
+++ b/test/test_blockarrayinterface.jl
@@ -86,10 +86,15 @@ end
     @test_broken A[Block(1)] isa Fill
     @test_broken A[Block.(1:2)] isa Fill
     @test_broken 2A
+    @test stringmime("text/plain", A) == "5-element Fill{Int64,1,Tuple{BlockedUnitRange{Array{Int64,1}}}} with indices 1:1:5:\n 2\n ─\n 2\n 2\n ─\n 2\n 2"
 
-    B = Eye((blockedrange([1,2,2]),))
+    B = Eye((blockedrange([1,2]),))
     @test B[Block(2,2)] == Matrix(I,2,2)
+    @test stringmime("text/plain", B) == "3×3 Diagonal{Float64,Ones{Float64,1,Tuple{BlockedUnitRange{Array{Int64,1}}}}} with indices 1:1:3×1:1:3:\n 1.0  │   ⋅    ⋅ \n ─────┼──────────\n  ⋅   │  1.0   ⋅ \n  ⋅   │   ⋅   1.0"
 
     C = Eye((blockedrange([1,2,2]),blockedrange([2,2])))
     @test C[Block(2,2)] == [0 0; 1.0 0]
+
+    U = UpperTriangular(Ones((blockedrange([1,2]),blockedrange([2,1]))))
+    @test stringmime("text/plain", U) == "3×3 UpperTriangular{Float64,Ones{Float64,2,Tuple{BlockedUnitRange{Array{Int64,1}},BlockedUnitRange{Array{Int64,1}}}}} with indices 1:1:3×1:1:3:\n 1.0  1.0  │  1.0\n ──────────┼─────\n  ⋅   1.0  │  1.0\n  ⋅    ⋅   │  1.0"
 end

--- a/test/test_blockarrayinterface.jl
+++ b/test/test_blockarrayinterface.jl
@@ -86,15 +86,19 @@ end
     @test_broken A[Block(1)] isa Fill
     @test_broken A[Block.(1:2)] isa Fill
     @test_broken 2A
-    @test stringmime("text/plain", A) == "5-element Fill{Int64,1,Tuple{BlockedUnitRange{Array{Int64,1}}}} with indices 1:1:5:\n 2\n ─\n 2\n 2\n ─\n 2\n 2"
+
 
     B = Eye((blockedrange([1,2]),))
     @test B[Block(2,2)] == Matrix(I,2,2)
-    @test stringmime("text/plain", B) == "3×3 Diagonal{Float64,Ones{Float64,1,Tuple{BlockedUnitRange{Array{Int64,1}}}}} with indices 1:1:3×1:1:3:\n 1.0  │   ⋅    ⋅ \n ─────┼──────────\n  ⋅   │  1.0   ⋅ \n  ⋅   │   ⋅   1.0"
 
     C = Eye((blockedrange([1,2,2]),blockedrange([2,2])))
     @test C[Block(2,2)] == [0 0; 1.0 0]
 
     U = UpperTriangular(Ones((blockedrange([1,2]),blockedrange([2,1]))))
-    @test stringmime("text/plain", U) == "3×3 UpperTriangular{Float64,Ones{Float64,2,Tuple{BlockedUnitRange{Array{Int64,1}},BlockedUnitRange{Array{Int64,1}}}}} with indices 1:1:3×1:1:3:\n 1.0  1.0  │  1.0\n ──────────┼─────\n  ⋅   1.0  │  1.0\n  ⋅    ⋅   │  1.0"
+
+    if VERSION ≥ v"1.2"
+        @test stringmime("text/plain", A) == "5-element Fill{Int64,1,Tuple{BlockedUnitRange{Array{Int64,1}}}} with indices 1:1:5:\n 2\n ─\n 2\n 2\n ─\n 2\n 2"
+        @test stringmime("text/plain", B) == "3×3 Diagonal{Float64,Ones{Float64,1,Tuple{BlockedUnitRange{Array{Int64,1}}}}} with indices 1:1:3×1:1:3:\n 1.0  │   ⋅    ⋅ \n ─────┼──────────\n  ⋅   │  1.0   ⋅ \n  ⋅   │   ⋅   1.0"
+        @test stringmime("text/plain", U) == "3×3 UpperTriangular{Float64,Ones{Float64,2,Tuple{BlockedUnitRange{Array{Int64,1}},BlockedUnitRange{Array{Int64,1}}}}} with indices 1:1:3×1:1:3:\n 1.0  1.0  │  1.0\n ──────────┼─────\n  ⋅   1.0  │  1.0\n  ⋅    ⋅   │  1.0"
+    end
 end

--- a/test/test_blockarrayinterface.jl
+++ b/test/test_blockarrayinterface.jl
@@ -1,4 +1,4 @@
-using BlockArrays, LinearAlgebra, Base64
+using BlockArrays, LinearAlgebra, FillArrays, Base64
 
 struct PartiallyImplementedBlockVector <: AbstractBlockArray{Float64,1} end
 
@@ -79,3 +79,17 @@ end
     @test A isa BlockMatrix{Int,Matrix{Matrix{Int}},Tuple{BlockedUnitRange{StepRange{Int64,Int64}},BlockedUnitRange{Vector{Int}}}}
 end
 
+@testset "block Fill" begin
+    A = Fill(2,(blockedrange([1,2,2]),))
+    @test A[Block(1)] == [2]
+    @test A[Block.(1:2)] == [2,2,2]
+    @test_broken A[Block(1)] isa Fill
+    @test_broken A[Block.(1:2)] isa Fill
+    @test_broken 2A
+
+    B = Eye((blockedrange([1,2,2]),))
+    @test B[Block(2,2)] == Matrix(I,2,2)
+
+    C = Eye((blockedrange([1,2,2]),blockedrange([2,2])))
+    @test C[Block(2,2)] == [0 0; 1.0 0]
+end

--- a/test/test_blockbroadcast.jl
+++ b/test/test_blockbroadcast.jl
@@ -119,4 +119,16 @@ using BlockArrays, FillArrays, Test
         C = BlockArray(randn(6), (BlockArrays._BlockedUnitRange(1,2:6),))
         @test axes(A+C,1) === BlockArrays._BlockedUnitRange(1,1:6)
     end
+
+    @testset "Views" begin
+        A = BlockArray(randn(6), 1:3)
+        @test Base.BroadcastStyle(typeof(view(A, Block(2)))) isa Base.Broadcast.DefaultArrayStyle{1}
+        V = view(A, Block.(2:3))
+        @test Base.BroadcastStyle(typeof(V)) isa BlockArrays.BlockStyle{1}
+        @test V .+ 1 isa BlockArray
+        @test 1 .+ V isa BlockArray
+        @test V .+ 1 == 1 .+ V == A[Block.(2:3)] .+ 1
+        @test -V isa BlockArray
+        @test -V == -A[Block.(2:3)]
+    end
 end

--- a/test/test_blockindices.jl
+++ b/test/test_blockindices.jl
@@ -6,10 +6,15 @@ import BlockArrays: BlockIndex, BlockIndexRange, BlockSlice
     @test Block((Block(3), Block(4))) === Block(3,4)
 
     @testset "Block iterator" begin
-        @test eltype(Block(3)) == Block{1,Int}
-        @test ndims(Block(3)) == ndims(Block{1,Int}) == 0
-        @test !isempty(Block(3))
-        @test collect(Block(3)) == [Block(3)]
+        B = Block(3)
+        @test length(B) == 1
+        @test eltype(B) == eltype(typeof(B)) == Block{1,Int}
+        @test ndims(B) == ndims(Block{1,Int}) == 0
+        @test !isempty(B)
+        @test collect(B) == [B]
+        @test B .+ 1 == Block(4)
+        @test iterate(B) == (B, nothing)
+        @test Int.(B) == 3
     end
 
     @testset "Block arithmetic" begin

--- a/test/test_blockindices.jl
+++ b/test/test_blockindices.jl
@@ -5,6 +5,13 @@ import BlockArrays: BlockIndex, BlockIndexRange, BlockSlice
     @test Int(Block(2)) === Integer(Block(2)) === Number(Block(2)) === 2
     @test Block((Block(3), Block(4))) === Block(3,4)
 
+    @testset "Block iterator" begin
+        @test eltype(Block(3)) == Block{1,Int}
+        @test ndims(Block(3)) == ndims(Block{1,Int}) == 0
+        @test !isempty(Block(3))
+        @test collect(Block(3)) == [Block(3)]
+    end
+
     @testset "Block arithmetic" begin
         @test +(Block(1)) == Block(1)
         @test -(Block(1)) == Block(-1)

--- a/test/test_blocklinalg.jl
+++ b/test/test_blocklinalg.jl
@@ -1,12 +1,12 @@
 using BlockArrays, ArrayLayouts, LinearAlgebra, Test
 import BlockArrays: BlockLayout
-import ArrayLayouts: DenseRowMajor
+import ArrayLayouts: DenseRowMajor, ColumnMajor, StridedLayout
 
 @testset "Linear Algebra" begin
     @testset "BlockArray matrix * vector" begin
         A = BlockArray{Float64}(randn(6,6), fill(2,3), 1:3)
         b = randn(6)
-        @test MemoryLayout(A) isa BlockLayout{DenseColumnMajor}
+        @test MemoryLayout(A) isa BlockLayout{DenseColumnMajor,DenseColumnMajor}
         V = view(A,Block(2,3))
         @test MemoryLayout(V) isa DenseColumnMajor
         @test strides(V) == (1,2)
@@ -21,17 +21,17 @@ import ArrayLayouts: DenseRowMajor
         @test all(A*b .=== A*PseudoBlockVector(b,1:3))
 
         V = view(A, Block.(1:2), Block(3))
-        @test MemoryLayout(V) isa BlockLayout{DenseColumnMajor}
+        @test MemoryLayout(V) isa BlockLayout{DenseColumnMajor,DenseColumnMajor}
         @test all(V*view(b,4:6) .=== V*b[4:6])
         @test V*b[4:6] ≈ Matrix(V)*b[4:6]
 
         V = view(A, Block(3), Block.(1:2))
-        @test MemoryLayout(V) isa BlockLayout{DenseColumnMajor}
+        @test MemoryLayout(V) isa BlockLayout{StridedLayout,DenseColumnMajor}
         @test all(V*view(b,4:6) .=== V*b[4:6])
         @test V*b[4:6] ≈ Matrix(V)*b[4:6]
 
         V = view(A, Block.(2:3), Block.(1:2))
-        @test MemoryLayout(V) isa BlockLayout{DenseColumnMajor}
+        @test MemoryLayout(V) isa BlockLayout{ColumnMajor,DenseColumnMajor}
         @test all(V*view(b,4:6) .=== V*b[4:6])
         @test V*b[4:6] ≈ Matrix(V)*b[4:6]  
 
@@ -92,8 +92,8 @@ import ArrayLayouts: DenseRowMajor
         C = BlockArray(randn(6,6) + im*randn(6,6), fill(2,3), 1:3)
         b = randn(6)
         c = randn(6) .+ im*randn(6)
-        @test MemoryLayout(A') isa BlockLayout{DenseRowMajor}
-        @test MemoryLayout(C') isa BlockLayout{ConjLayout{DenseRowMajor}}
+        @test MemoryLayout(A') isa BlockLayout{DenseRowMajor,DenseRowMajor}
+        @test MemoryLayout(C') isa BlockLayout{DenseRowMajor,ConjLayout{DenseRowMajor}}
 
         @test getblock(A', 2, 3) == getblock(A, 3,2)'
         @test getblock(transpose(A), 2, 3) == transpose(getblock(A, 3,2))
@@ -137,7 +137,7 @@ import ArrayLayouts: DenseRowMajor
         A = BlockArray(randn(6,6), 1:3, 1:3) 
         B = BlockArray(randn(6,6), fill(2,3), 1:3) 
         b = randn(6)
-        @test MemoryLayout(UpperTriangular(A)) isa TriangularLayout{'U','N',BlockLayout{DenseColumnMajor}}
+        @test MemoryLayout(UpperTriangular(A)) isa TriangularLayout{'U','N',BlockLayout{DenseColumnMajor,DenseColumnMajor}}
         @test UpperTriangular(A) == UpperTriangular(Matrix(A))
         V = view(A, Block(2,2))
         @test MemoryLayout(UpperTriangular(V)) isa TriangularLayout{'U','N',DenseColumnMajor}
@@ -190,5 +190,10 @@ import ArrayLayouts: DenseRowMajor
         A = BlockArray{Float64}(randn(6,6), fill(2,3), 1:3)
         @test inv(A) isa BlockArray
         @test inv(A)*A ≈ Matrix(I,6,6)
+    end
+
+    @testset "Block Diagonal" begin
+        D = mortar(Diagonal([randn(2,2),randn(2,2)]))
+        @test MemoryLayout(D) isa BlockLayout{DiagonalLayout{DenseColumnMajor},DenseColumnMajor} 
     end
 end

--- a/test/test_blocklinalg.jl
+++ b/test/test_blocklinalg.jl
@@ -3,6 +3,12 @@ import BlockArrays: BlockLayout
 import ArrayLayouts: DenseRowMajor, ColumnMajor, StridedLayout
 
 @testset "Linear Algebra" begin
+    @testset "BlockArray scalar * matrix" begin
+        A = BlockArray{Float64}(randn(6,6), fill(2,3), 1:3)
+        @test 2A == A*2 == 2Matrix(A)
+        @test blockisequal(axes(2A),axes(A))
+    end
+
     @testset "BlockArray matrix * vector" begin
         A = BlockArray{Float64}(randn(6,6), fill(2,3), 1:3)
         b = randn(6)

--- a/test/test_blockviews.jl
+++ b/test/test_blockviews.jl
@@ -157,9 +157,12 @@ using BlockArrays, Test, Base64
     @testset "Block-BlockRange blocks" begin
         A = BlockArray([1 2 3; 4 5 6; 7 8 9], 1:2, 1:2)
         V = view(A,Block(1),Block.(1:2))
+        W = view(A,Block.(1:2),Block(1))
+        @test blocks(V) == blocks(A)[1:1,1:2]
+        @test blocks(W) == blocks(A)[1:2,1:1]
         if VERSION ≥ v"1.2"
             @test stringmime("text/plain", V) == "1×3 view(::BlockArray{$Int,2,Array{Array{$Int,2},2},Tuple{BlockedUnitRange{Array{$Int,1}},BlockedUnitRange{Array{$Int,1}}}}, BlockSlice(Block(1),1:1), BlockSlice(Block{1,$Int}[Block(1), Block(2)],1:1:3)) with eltype $Int with indices Base.OneTo(1)×1:1:3:\n 1  │  2  3"
+            @test stringmime("text/plain", W) == "3×1 view(::BlockArray{$Int,2,Array{Array{$Int,2},2},Tuple{BlockedUnitRange{Array{$Int,1}},BlockedUnitRange{Array{$Int,1}}}}, BlockSlice(Block{1,$Int}[Block(1), Block(2)],1:1:3), BlockSlice(Block(1),1:1)) with eltype $Int with indices 1:1:3×Base.OneTo(1):\n 1\n ─\n 4\n 7"
         end
-        @test blocks(V) == blocks(A)[1:1,1:2]
     end
 end

--- a/test/test_blockviews.jl
+++ b/test/test_blockviews.jl
@@ -157,7 +157,9 @@ using BlockArrays, Test, Base64
     @testset "Block-BlockRange blocks" begin
         A = BlockArray([1 2 3; 4 5 6; 7 8 9], 1:2, 1:2)
         V = view(A,Block(1),Block.(1:2))
-        @test stringmime("text/plain", V) == "1×3 view(::BlockArray{$Int,2,Array{Array{$Int,2},2},Tuple{BlockedUnitRange{Array{$Int,1}},BlockedUnitRange{Array{$Int,1}}}}, BlockSlice(Block(1),1:1), BlockSlice(Block{1,$Int}[Block(1), Block(2)],1:1:3)) with eltype $Int with indices Base.OneTo(1)×1:1:3:\n 1  │  2  3"
+        if VERSION ≥ v"1.2"
+            @test stringmime("text/plain", V) == "1×3 view(::BlockArray{$Int,2,Array{Array{$Int,2},2},Tuple{BlockedUnitRange{Array{$Int,1}},BlockedUnitRange{Array{$Int,1}}}}, BlockSlice(Block(1),1:1), BlockSlice(Block{1,$Int}[Block(1), Block(2)],1:1:3)) with eltype $Int with indices Base.OneTo(1)×1:1:3:\n 1  │  2  3"
+        end
         @test blocks(V) == blocks(A)[1:1,1:2]
     end
 end

--- a/test/test_blockviews.jl
+++ b/test/test_blockviews.jl
@@ -1,154 +1,163 @@
-using BlockArrays, Test
+using BlockArrays, Test, Base64
 
-@testset "block slice" begin
-    A = BlockArray(1:6,1:3)
-    b = parentindices(view(A, Block(2)))[1] # A BlockSlice
+@testset "Block Views" begin
+    @testset "block slice" begin
+        A = BlockArray(1:6,1:3)
+        b = parentindices(view(A, Block(2)))[1] # A BlockSlice
 
-    @test first(b) == 2
-    @test last(b) == 3
-    @test length(b) == 2
-    @test step(b) == 1
-    @test Base.unsafe_length(b) == 2
-    @test axes(b) == (Base.OneTo(2),)
-    @test Base.axes1(b) == Base.OneTo(2)
-    @test Base.unsafe_indices(b) == (Base.OneTo(2),)
-    @test size(b) == (2,)
-    @test collect(b) == [2,3]
-    @test b[1] == 2
-    @test b[1:2] == 2:3
-end
+        @test first(b) == 2
+        @test last(b) == 3
+        @test length(b) == 2
+        @test step(b) == 1
+        @test Base.unsafe_length(b) == 2
+        @test axes(b) == (Base.OneTo(2),)
+        @test Base.axes1(b) == Base.OneTo(2)
+        @test Base.unsafe_indices(b) == (Base.OneTo(2),)
+        @test size(b) == (2,)
+        @test collect(b) == [2,3]
+        @test b[1] == 2
+        @test b[1:2] == 2:3
+    end
 
-@testset "block view" begin
-    A = BlockArray(collect(1:6), 1:3)
-    @test view(A, Block(2)) == [2,3]
-    view(A, Block(2))[2] = -1
-    @test A[3] == -1
+    @testset "block view" begin
+        A = BlockArray(collect(1:6), 1:3)
+        @test view(A, Block(2)) == [2,3]
+        view(A, Block(2))[2] = -1
+        @test A[3] == -1
 
-    # backend tests
-    @test_throws ArgumentError Base.to_index(A, Block(1))
+        # backend tests
+        @test_throws ArgumentError Base.to_index(A, Block(1))
 
-    A = PseudoBlockArray(collect(1:6), 1:3)
-    @test view(A, Block(2)) == [2,3]
-    view(A, Block(2))[2] = -1
-    @test A[3] == -1
-
-
-    # backend tests
-    @test_throws ArgumentError Base.to_index(A, Block(1))
-
-    A = BlockArray(reshape(collect(1:(6*12)),6,12), 1:3, 3:5)
-    V = view(A, Block(2), Block(3))
-    @test size(V) == (2, 5)
-    V[1,1] = -1
-    @test A[2,8] == -1
-
-    V = view(A, Block(3, 2))
-    @test size(V) == (3, 4)
-    V[2,1] = -2
-    @test A[5,4] == -2
-
-    # test mixed blocks and other indices
-    @test view(A, Block(2), 2) == [8,9]
-    @test similar(A, (Base.OneTo(5), axes(A,2))) isa BlockArray{Int}
-    @test view(A, Block(2), :) == A[2:3,:]
-
-    @test view(A, 2, Block(1)) == [2,8,14]
-    @test view(A, :, Block(1)) == A[:,1:3]
-
-    @test view(V, Block(1, 1)) ≡ V
-
-    @test_throws BlockBoundsError view(V, Block(1,2))
-    @test_throws BlockBoundsError view(V, Block(2,1))
+        A = PseudoBlockArray(collect(1:6), 1:3)
+        @test view(A, Block(2)) == [2,3]
+        view(A, Block(2))[2] = -1
+        @test A[3] == -1
 
 
-    A = BlockArray(reshape(collect(1:(6^3)),6,6,6), 1:3, 1:3, 1:3)
-    V = view(A, Block(2), Block(3), Block(1))
-    @test size(V) == (2, 3, 1)
-    V[1,1,1] = -3
-    @test A[2,4,1] == -3
+        # backend tests
+        @test_throws ArgumentError Base.to_index(A, Block(1))
 
-    V = view(A,Block(1,1,1))
-    @test size(V) == (1,1,1)
-    V[1,1,1] = -4
-    @test A[1,1,1] == -4
+        A = BlockArray(reshape(collect(1:(6*12)),6,12), 1:3, 3:5)
+        V = view(A, Block(2), Block(3))
+        @test size(V) == (2, 5)
+        V[1,1] = -1
+        @test A[2,8] == -1
 
-    # blocks mimic CartesianIndex in views
-    V = view(A,Block(1,1),Block(2))
-    @test size(V) == (1,1,2)
-    V[1,1,1] = -5
-    @test A[1,1,2] == -5
+        V = view(A, Block(3, 2))
+        @test size(V) == (3, 4)
+        V[2,1] = -2
+        @test A[5,4] == -2
 
-    V = view(A,Block(2),Block(1,1))
-    @test size(V) == (2,1,1)
-    V[1,1,1] = -6
-    @test A[2,1,1] == -6
+        # test mixed blocks and other indices
+        @test view(A, Block(2), 2) == [8,9]
+        @test similar(A, (Base.OneTo(5), axes(A,2))) isa BlockArray{Int}
+        @test view(A, Block(2), :) == A[2:3,:]
 
-    # test mixed blocks and other indices
-    @test view(A, Block(1), Block(2), 1) == A[1:1,2:3,1]
-    @test view(A, Block(1,2), 1) == A[1:1,2:3,1]
-    @test view(A, Block(1), 2, 1) == A[1:1,2,1]
-    @test view(A, 1, Block(2), 1) == A[1,2:3,1]
-    @test view(A, 1, 2, Block(2)) == A[1,2,2:3]
-end
+        @test view(A, 2, Block(1)) == [2,8,14]
+        @test view(A, :, Block(1)) == A[:,1:3]
 
-@testset "block view pointers" begin
-    A = BlockArray(reshape(Vector{Float64}(1:(6^2)),6,6), 1:3, 1:3)
+        @test view(V, Block(1, 1)) ≡ V
 
-    V = view(A, Block(1,2))
-    @test Base.unsafe_convert(Ptr{Float64}, V) == Base.unsafe_convert(Ptr{Float64}, A.blocks[1,2])
-    @test unsafe_load(pointer(V)) == V[1,1]
+        @test_throws BlockBoundsError view(V, Block(1,2))
+        @test_throws BlockBoundsError view(V, Block(2,1))
 
 
-    A = PseudoBlockArray(reshape(Vector{Float64}(1:(6^2)),6,6), 1:3, 1:3)
+        A = BlockArray(reshape(collect(1:(6^3)),6,6,6), 1:3, 1:3, 1:3)
+        V = view(A, Block(2), Block(3), Block(1))
+        @test size(V) == (2, 3, 1)
+        V[1,1,1] = -3
+        @test A[2,4,1] == -3
 
-    V = view(A, Block(1,2))
-    @test Base.unsafe_convert(Ptr{Float64}, V) == Base.unsafe_convert(Ptr{Float64}, view(A.blocks, 1:1, 2:3))
-    @test unsafe_load(pointer(V)) == V[1,1]
+        V = view(A,Block(1,1,1))
+        @test size(V) == (1,1,1)
+        V[1,1,1] = -4
+        @test A[1,1,1] == -4
 
-    V = view(A, Block(2), 2:3)
-    @test Base.unsafe_convert(Ptr{Float64}, V) == Base.unsafe_convert(Ptr{Float64}, view(A.blocks, 2:3, 2:3))
-    @test unsafe_load(pointer(V)) == V[1,1]
+        # blocks mimic CartesianIndex in views
+        V = view(A,Block(1,1),Block(2))
+        @test size(V) == (1,1,2)
+        V[1,1,1] = -5
+        @test A[1,1,2] == -5
 
-    V = view(A, 2:3, Block(2))
-    @test Base.unsafe_convert(Ptr{Float64}, V) == Base.unsafe_convert(Ptr{Float64}, view(A.blocks, 2:3, 2:3))
-    @test unsafe_load(pointer(V)) == V[1,1]
-end
+        V = view(A,Block(2),Block(1,1))
+        @test size(V) == (2,1,1)
+        V[1,1,1] = -6
+        @test A[2,1,1] == -6
 
-@testset "block indx range of block range" begin
-    A = PseudoBlockArray(collect(1:6), 1:3)
-    V = view(A, Block.(1:2))
-    @test V == 1:3
-    @test axes(V,1) isa BlockArrays.BlockedUnitRange
-    @test blockaxes(V,1) == Block.(1:2)
-    @test view(V, Block(2)[1:2]) == [2,3]
-    V = view(A, Block.(2:3))
-    @test V == 2:6
-    @test view(V, Block(2)[1:2]) == [4,5] 
-end
+        # test mixed blocks and other indices
+        @test view(A, Block(1), Block(2), 1) == A[1:1,2:3,1]
+        @test view(A, Block(1,2), 1) == A[1:1,2:3,1]
+        @test view(A, Block(1), 2, 1) == A[1:1,2,1]
+        @test view(A, 1, Block(2), 1) == A[1,2:3,1]
+        @test view(A, 1, 2, Block(2)) == A[1,2,2:3]
+    end
 
-@testset "subarray implements block interface" begin
-    A = PseudoBlockArray(reshape(Vector{Float64}(1:(6^2)),6,6), 1:3, 1:3)
+    @testset "block view pointers" begin
+        A = BlockArray(reshape(Vector{Float64}(1:(6^2)),6,6), 1:3, 1:3)
 
-    V = view(A, Block(2,3))
-    @test PseudoBlockArray(V) isa PseudoBlockArray
-    @test BlockArray(V) isa BlockArray
-    @test PseudoBlockArray(V) == BlockArray(V) == V
+        V = view(A, Block(1,2))
+        @test Base.unsafe_convert(Ptr{Float64}, V) == Base.unsafe_convert(Ptr{Float64}, A.blocks[1,2])
+        @test unsafe_load(pointer(V)) == V[1,1]
 
-    V = view(A, Block(2), Block.(2:3))
-    @test PseudoBlockArray(V) isa PseudoBlockArray
-    @test BlockArray(V) isa BlockArray
-    @test PseudoBlockArray(V) == BlockArray(V) == V
-    @test blocksize(V) == (1,2)
 
-    V = view(A, Block.(2:3), Block(3))
-    @test PseudoBlockArray(V) isa PseudoBlockArray
-    @test BlockArray(V) isa BlockArray
-    @test PseudoBlockArray(V) == BlockArray(V) == V
-    @test blocksize(V) == (2,1)
+        A = PseudoBlockArray(reshape(Vector{Float64}(1:(6^2)),6,6), 1:3, 1:3)
 
-    V = view(A, Block.(2:3), Block.(1:2))
-    @test PseudoBlockArray(V) isa PseudoBlockArray
-    @test BlockArray(V) isa BlockArray
-    @test PseudoBlockArray(V) == BlockArray(V) == V
-    @test blocksize(V) == (2,2)
+        V = view(A, Block(1,2))
+        @test Base.unsafe_convert(Ptr{Float64}, V) == Base.unsafe_convert(Ptr{Float64}, view(A.blocks, 1:1, 2:3))
+        @test unsafe_load(pointer(V)) == V[1,1]
+
+        V = view(A, Block(2), 2:3)
+        @test Base.unsafe_convert(Ptr{Float64}, V) == Base.unsafe_convert(Ptr{Float64}, view(A.blocks, 2:3, 2:3))
+        @test unsafe_load(pointer(V)) == V[1,1]
+
+        V = view(A, 2:3, Block(2))
+        @test Base.unsafe_convert(Ptr{Float64}, V) == Base.unsafe_convert(Ptr{Float64}, view(A.blocks, 2:3, 2:3))
+        @test unsafe_load(pointer(V)) == V[1,1]
+    end
+
+    @testset "block indx range of block range" begin
+        A = PseudoBlockArray(collect(1:6), 1:3)
+        V = view(A, Block.(1:2))
+        @test V == 1:3
+        @test axes(V,1) isa BlockArrays.BlockedUnitRange
+        @test blockaxes(V,1) == Block.(1:2)
+        @test view(V, Block(2)[1:2]) == [2,3]
+        V = view(A, Block.(2:3))
+        @test V == 2:6
+        @test view(V, Block(2)[1:2]) == [4,5]
+    end
+
+    @testset "subarray implements block interface" begin
+        A = PseudoBlockArray(reshape(Vector{Float64}(1:(6^2)),6,6), 1:3, 1:3)
+
+        V = view(A, Block(2,3))
+        @test PseudoBlockArray(V) isa PseudoBlockArray
+        @test BlockArray(V) isa BlockArray
+        @test PseudoBlockArray(V) == BlockArray(V) == V
+
+        V = view(A, Block(2), Block.(2:3))
+        @test PseudoBlockArray(V) isa PseudoBlockArray
+        @test BlockArray(V) isa BlockArray
+        @test PseudoBlockArray(V) == BlockArray(V) == V
+        @test blocksize(V) == (1,2)
+
+        V = view(A, Block.(2:3), Block(3))
+        @test PseudoBlockArray(V) isa PseudoBlockArray
+        @test BlockArray(V) isa BlockArray
+        @test PseudoBlockArray(V) == BlockArray(V) == V
+        @test blocksize(V) == (2,1)
+
+        V = view(A, Block.(2:3), Block.(1:2))
+        @test PseudoBlockArray(V) isa PseudoBlockArray
+        @test BlockArray(V) isa BlockArray
+        @test PseudoBlockArray(V) == BlockArray(V) == V
+        @test blocksize(V) == (2,2)
+    end
+
+    @testset "Block-BlockRange blocks" begin
+        A = BlockArray([1 2 3; 4 5 6; 7 8 9], 1:2, 1:2)
+        V = view(A,Block(1),Block.(1:2))
+        @test stringmime("text/plain", V) == "1×3 view(::BlockArray{$Int,2,Array{Array{$Int,2},2},Tuple{BlockedUnitRange{Array{$Int,1}},BlockedUnitRange{Array{$Int,1}}}}, BlockSlice(Block(1),1:1), BlockSlice(Block{1,$Int}[Block(1), Block(2)],1:1:3)) with eltype $Int with indices Base.OneTo(1)×1:1:3:\n 1  │  2  3"
+        @test blocks(V) == blocks(A)[1:1,1:2]
+    end
 end


### PR DESCRIPTION
This generalises block-printing to include, for example, views of `BlockArray`:
```julia
julia> B = BlockMatrix(randn(6,6), 1:3, 1:3)
3×3-blocked 6×6 BlockArray{Float64,2}:
  0.145757  │   0.246326    0.534004  │  -0.76561    1.14499   -1.96236  
 ───────────┼─────────────────────────┼──────────────────────────────────
 -0.494542  │  -1.02236     0.7017    │  -1.17902   -1.16601   -0.904528 
  0.832341  │  -0.0572088  -0.984644  │  -0.730904   0.433201  -1.39913  
 ───────────┼─────────────────────────┼──────────────────────────────────
 -1.08485   │  -0.522733    0.429331  │   2.43006   -2.25876    0.40058  
  0.269436  │   0.879403   -0.224948  │   1.83561    0.466786   0.0546217
  1.16865   │  -0.685722    2.06924   │   0.377139  -2.12384   -0.303557 

julia> view(B,Block.(1:2),Block.(1:2))
3×3 view(::BlockArray{Float64,2,Array{Array{Float64,2},2},Tuple{BlockedUnitRange{Array{Int64,1}},BlockedUnitRange{Array{Int64,1}}}}, BlockSlice(Block{1,Int64}[Block(1), Block(2)],1:1:3), BlockSlice(Block{1,Int64}[Block(1), Block(2)],1:1:3)) with eltype Float64 with indices 1:1:3×1:1:3:
  0.145757  │   0.246326    0.534004
 ───────────┼───────────────────────
 -0.494542  │  -1.02236     0.7017  
  0.832341  │  -0.0572088  -0.984644

julia> B'
6×6 Adjoint{Float64,BlockArray{Float64,2,Array{Array{Float64,2},2},Tuple{BlockedUnitRange{Array{Int64,1}},BlockedUnitRange{Array{Int64,1}}}}} with indices 1:1:6×1:1:6:
  0.145757  │  -0.494542   0.832341   │  -1.08485    0.269436    1.16865 
 ───────────┼─────────────────────────┼──────────────────────────────────
  0.246326  │  -1.02236   -0.0572088  │  -0.522733   0.879403   -0.685722
  0.534004  │   0.7017    -0.984644   │   0.429331  -0.224948    2.06924 
 ───────────┼─────────────────────────┼──────────────────────────────────
 -0.76561   │  -1.17902   -0.730904   │   2.43006    1.83561     0.377139
  1.14499   │  -1.16601    0.433201   │  -2.25876    0.466786   -2.12384 
 -1.96236   │  -0.904528  -1.39913    │   0.40058    0.0546217  -0.303557
```
Note it automatically works with LazyArrays.jl:
```julia
julia> BroadcastMatrix(exp,B)
6×6 BroadcastArray{Float64,2,typeof(exp),Tuple{BlockArray{Float64,2,Array{Array{Float64,2},2},Tuple{BlockedUnitRange{Array{Int64,1}},BlockedUnitRange{Array{Int64,1}}}}}} with indices 1:1:6×1:1:6:
 1.15692   │  1.27932   1.70575   │   0.46505   3.14242   0.140527
 ──────────┼──────────────────────┼───────────────────────────────
 0.60985   │  0.359745  2.01718   │   0.30758   0.311606  0.404733
 2.29869   │  0.944397  0.373572  │   0.481474  1.54219   0.24681 
 ──────────┼──────────────────────┼───────────────────────────────
 0.337951  │  0.592898  1.53623   │  11.3596    0.10448   1.49269 
 1.30923   │  2.40946   0.798557  │   6.26895   1.59486   1.05614 
 3.21765   │  0.503726  7.91876   │   1.45811   0.119572  0.738188
```