### PR TITLE
Add zeros/ones for BlockedUnitRange, Avoid calling axes for subarrays

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ docs/site/
 benchmark/*.md
 src/.DS_Store
 /Manifest.toml
+.DS_Store

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BlockArrays"
 uuid = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
-version = "0.13"
+version = "0.12.9"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BlockArrays"
 uuid = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
-version = "0.12.8"
+version = "0.13"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/BlockArrays.jl
+++ b/src/BlockArrays.jl
@@ -27,7 +27,8 @@ import Base: @propagate_inbounds, Array, to_indices, to_index,
             @_inline_meta, _maybetail, tail, @_propagate_inbounds_meta, reindex,
             RangeIndex, Int, Integer, Number,
             +, -, *, /, \, min, max, isless, in, copy, copyto!, axes, @deprecate,
-            BroadcastStyle, checkbounds, throw_boundserror
+            BroadcastStyle, checkbounds, throw_boundserror, 
+            ones, zeros
 using Base: ReshapedArray, dataids
 
 

--- a/src/blockarrayinterface.jl
+++ b/src/blockarrayinterface.jl
@@ -1,5 +1,18 @@
 
 getindex(a::Number, ::Block{0}) = a
 
+function _sym_axes(A)
+    ax = axes(parent(A),2)
+    (ax, ax)
+end
+
+axes(A::HermOrSym{<:Any,<:AbstractBlockMatrix}) = _sym_axes(A)
+axes(A::HermOrSym{<:Any,<:SubArray{<:Any,2,<:AbstractBlockMatrix}}) = _sym_axes(A)
+
 axes(A::AbstractTriangular{<:Any,<:AbstractBlockMatrix}) = axes(parent(A))
-axes(A::HermOrSym{<:Any,<:AbstractBlockMatrix}) = axes(parent(A))
+axes(A::AbstractTriangular{<:Any,<:SubArray{<:Any,2,<:AbstractBlockMatrix}}) = axes(parent(A))
+
+blocksize(A::AbstractTriangular) = blocksize(parent(A))
+blocksize(A::AbstractTriangular, i::Int) = blocksize(parent(A), i)
+blockaxes(A::AbstractTriangular) = blockaxes(parent(A))
+hasmatchingblocks(A::AbstractTriangular) = hasmatchingblocks(parent(A))

--- a/src/blockarrayinterface.jl
+++ b/src/blockarrayinterface.jl
@@ -6,18 +6,6 @@ function _sym_axes(A)
     (ax, ax)
 end
 
-function _sym_blocksize(A)
-    ax = blocksize(parent(A),2)
-    (ax, ax)
-end
-
-function _sym_blockaxes(A)
-    ax = blockaxes(parent(A),2)
-    (ax, ax)
-end
-
-
-
 # Symmetric and Triangular should inherit blocks from parent
 axes(A::HermOrSym{<:Any,<:AbstractBlockMatrix}) = _sym_axes(A)
 axes(A::HermOrSym{<:Any,<:SubArray{<:Any,2,<:AbstractBlockMatrix}}) = _sym_axes(A)

--- a/src/blockarrayinterface.jl
+++ b/src/blockarrayinterface.jl
@@ -6,13 +6,27 @@ function _sym_axes(A)
     (ax, ax)
 end
 
+function _sym_blocksize(A)
+    ax = blocksize(parent(A),2)
+    (ax, ax)
+end
+
+function _sym_blockaxes(A)
+    ax = blockaxes(parent(A),2)
+    (ax, ax)
+end
+
+
+
+# Symmetric and Triangular should inherit blocks from parent
 axes(A::HermOrSym{<:Any,<:AbstractBlockMatrix}) = _sym_axes(A)
 axes(A::HermOrSym{<:Any,<:SubArray{<:Any,2,<:AbstractBlockMatrix}}) = _sym_axes(A)
-
 axes(A::AbstractTriangular{<:Any,<:AbstractBlockMatrix}) = axes(parent(A))
 axes(A::AbstractTriangular{<:Any,<:SubArray{<:Any,2,<:AbstractBlockMatrix}}) = axes(parent(A))
 
 blocksize(A::AbstractTriangular) = blocksize(parent(A))
 blocksize(A::AbstractTriangular, i::Int) = blocksize(parent(A), i)
 blockaxes(A::AbstractTriangular) = blockaxes(parent(A))
+
 hasmatchingblocks(A::AbstractTriangular) = hasmatchingblocks(parent(A))
+hasmatchingblocks(A::HermOrSym) = true

--- a/src/pseudo_blockarray.jl
+++ b/src/pseudo_blockarray.jl
@@ -329,3 +329,11 @@ Base.unsafe_convert(::Type{Ptr{T}}, A::PseudoBlockArray) where T = Base.unsafe_c
 
 colsupport(A::PseudoBlockArray, j) = colsupport(A.blocks, j)
 rowsupport(A::PseudoBlockArray, j) = rowsupport(A.blocks, j)
+
+###
+# zeros/ones
+###
+
+for op in (:zeros, :ones)
+    @eval $op(::Type{T}, axs::Tuple{BlockedUnitRange,Vararg{Any}}) where T = PseudoBlockArray($op(T, map(length,axs)...), axs)
+end

--- a/src/views.jl
+++ b/src/views.jl
@@ -188,4 +188,13 @@ _sub_blocksize(ind::Integer, inds...) = _sub_blocksize(inds...)
 blocksize(V::SubArray) = _sub_blocksize(parentindices(V)...)
 blocksize(V::SubArray, i::Int) = _sub_blocksize(parentindices(V)[i])[1]
 
-hasmatchingblocks(V::SubArray{<:Any,2}) = hasmatchingblocks(parent(V)) && ==(parentindices(V)...)
+function hasmatchingblocks(V::SubArray{<:Any,2,<:Any,<:NTuple{2,BlockSlice{<:BlockRange{1}}}})
+    a,b = axes(parent(V))
+    kr,jr = parentindices(V)
+    KR,JR = (kr.block),(jr.block)
+    length(KR) == length(JR) || return false
+    for (K,J) in zip(KR,JR)
+        length(a[K]) == length(b[J]) || return false
+    end
+    true
+end

--- a/test/test_blockarrayinterface.jl
+++ b/test/test_blockarrayinterface.jl
@@ -53,6 +53,9 @@ end
         if VERSION ≥ v"1.2"
             @test stringmime("text/plain", UpperTriangular(A)) == "10×10 UpperTriangular{Complex{Float64},PseudoBlockArray{Complex{Float64},2,Array{Complex{Float64},2},Tuple{BlockedUnitRange{Array{Int64,1}},BlockedUnitRange{Array{Int64,1}}}}} with indices 1:1:10×1:1:10:\n 1.0+0.0im  │  11.0+0.0im  21.0+0.0im  │  31.0+0.0im  41.0+0.0im  51.0+0.0im  │  61.0+0.0im  71.0+0.0im  81.0+0.0im   91.0+0.0im\n ───────────┼──────────────────────────┼──────────────────────────────────────┼─────────────────────────────────────────────────\n     ⋅      │  12.0+0.0im  22.0+0.0im  │  32.0+0.0im  42.0+0.0im  52.0+0.0im  │  62.0+0.0im  72.0+0.0im  82.0+0.0im   92.0+0.0im\n     ⋅      │       ⋅      23.0+0.0im  │  33.0+0.0im  43.0+0.0im  53.0+0.0im  │  63.0+0.0im  73.0+0.0im  83.0+0.0im   93.0+0.0im\n ───────────┼──────────────────────────┼──────────────────────────────────────┼─────────────────────────────────────────────────\n     ⋅      │       ⋅           ⋅      │  34.0+0.0im  44.0+0.0im  54.0+0.0im  │  64.0+0.0im  74.0+0.0im  84.0+0.0im   94.0+0.0im\n     ⋅      │       ⋅           ⋅      │       ⋅      45.0+0.0im  55.0+0.0im  │  65.0+0.0im  75.0+0.0im  85.0+0.0im   95.0+0.0im\n     ⋅      │       ⋅           ⋅      │       ⋅           ⋅      56.0+0.0im  │  66.0+0.0im  76.0+0.0im  86.0+0.0im   96.0+0.0im\n ───────────┼──────────────────────────┼──────────────────────────────────────┼─────────────────────────────────────────────────\n     ⋅      │       ⋅           ⋅      │       ⋅           ⋅           ⋅      │  67.0+0.0im  77.0+0.0im  87.0+0.0im   97.0+0.0im\n     ⋅      │       ⋅           ⋅      │       ⋅           ⋅           ⋅      │       ⋅      78.0+0.0im  88.0+0.0im   98.0+0.0im\n     ⋅      │       ⋅           ⋅      │       ⋅           ⋅           ⋅      │       ⋅           ⋅      89.0+0.0im   99.0+0.0im\n     ⋅      │       ⋅           ⋅      │       ⋅           ⋅           ⋅      │       ⋅           ⋅           ⋅      100.0+0.0im"
         end
+
+        V = view(A, Block.(1:2), Block.(1:2))
+        @test blockisequal(axes(Symmetric(V)), axes(view(A,Block.(1:2), Block.(1:2))))
     end
 
     @testset "rect blocks" begin
@@ -68,7 +71,7 @@ end
         @test blocksize(U) == (blocksize(U,1),blocksize(U,2)) == blocksize(A)
         @test blockaxes(S) == (blockaxes(S,1),blockaxes(S,2)) == (Block.(1:2), Block.(1:2))
         @test blockaxes(U) == (blockaxes(U,1),blockaxes(U,2)) == blockaxes(A)
-
+        
         @test U[Block(2,2)] == A[Block(2,2)]
         @test U[Block(3,2)] == triu(A[Block(3,2)])
         @test U[Block(3,1)] == zeros(3,3)

--- a/test/test_blockarrayinterface.jl
+++ b/test/test_blockarrayinterface.jl
@@ -30,21 +30,58 @@ end
 end
 
 @testset "Triangular/Symmetric/Hermitian block arrays" begin
-    A = PseudoBlockArray{ComplexF64}(undef, (1:4), (1:4))
-    A .= reshape(1:length(A), size(A))
+    @testset "square blocks" begin
+        A = PseudoBlockArray{ComplexF64}(undef, 1:4, 1:4)
+        A .= reshape(1:length(A), size(A))
+        U = UpperTriangular(A)
+        S = Symmetric(A)
+        H = Hermitian(A)
 
-    @test blocksize(UpperTriangular(A)) == blocksize(Symmetric(A)) == blocksize(A)
-    @test UpperTriangular(A)[Block(2,2)] == UpperTriangular(A[2:3,2:3])
-    @test UpperTriangular(A)[Block(2,3)] == A[2:3,4:6]
-    @test UpperTriangular(A)[Block(3,2)] == zeros(3,2)
-    @test Symmetric(A)[Block(2,2)] == Symmetric(A[2:3,2:3])
-    @test Symmetric(A)[Block(2,3)] == A[2:3,4:6]
-    @test Symmetric(A)[Block(3,2)] == transpose(A[2:3,4:6])
-    @test Hermitian(A)[Block(2,2)] == Hermitian(A[2:3,2:3])
-    @test Hermitian(A)[Block(2,3)] == A[2:3,4:6]
-    @test Hermitian(A)[Block(3,2)] == A[2:3,4:6]'
-    if VERSION ≥ v"1.2"
-        @test stringmime("text/plain", UpperTriangular(A)) == "10×10 UpperTriangular{Complex{Float64},PseudoBlockArray{Complex{Float64},2,Array{Complex{Float64},2},Tuple{BlockedUnitRange{Array{Int64,1}},BlockedUnitRange{Array{Int64,1}}}}} with indices 1:1:10×1:1:10:\n 1.0+0.0im  │  11.0+0.0im  21.0+0.0im  │  31.0+0.0im  41.0+0.0im  51.0+0.0im  │  61.0+0.0im  71.0+0.0im  81.0+0.0im   91.0+0.0im\n ───────────┼──────────────────────────┼──────────────────────────────────────┼─────────────────────────────────────────────────\n     ⋅      │  12.0+0.0im  22.0+0.0im  │  32.0+0.0im  42.0+0.0im  52.0+0.0im  │  62.0+0.0im  72.0+0.0im  82.0+0.0im   92.0+0.0im\n     ⋅      │       ⋅      23.0+0.0im  │  33.0+0.0im  43.0+0.0im  53.0+0.0im  │  63.0+0.0im  73.0+0.0im  83.0+0.0im   93.0+0.0im\n ───────────┼──────────────────────────┼──────────────────────────────────────┼─────────────────────────────────────────────────\n     ⋅      │       ⋅           ⋅      │  34.0+0.0im  44.0+0.0im  54.0+0.0im  │  64.0+0.0im  74.0+0.0im  84.0+0.0im   94.0+0.0im\n     ⋅      │       ⋅           ⋅      │       ⋅      45.0+0.0im  55.0+0.0im  │  65.0+0.0im  75.0+0.0im  85.0+0.0im   95.0+0.0im\n     ⋅      │       ⋅           ⋅      │       ⋅           ⋅      56.0+0.0im  │  66.0+0.0im  76.0+0.0im  86.0+0.0im   96.0+0.0im\n ───────────┼──────────────────────────┼──────────────────────────────────────┼─────────────────────────────────────────────────\n     ⋅      │       ⋅           ⋅      │       ⋅           ⋅           ⋅      │  67.0+0.0im  77.0+0.0im  87.0+0.0im   97.0+0.0im\n     ⋅      │       ⋅           ⋅      │       ⋅           ⋅           ⋅      │       ⋅      78.0+0.0im  88.0+0.0im   98.0+0.0im\n     ⋅      │       ⋅           ⋅      │       ⋅           ⋅           ⋅      │       ⋅           ⋅      89.0+0.0im   99.0+0.0im\n     ⋅      │       ⋅           ⋅      │       ⋅           ⋅           ⋅      │       ⋅           ⋅           ⋅      100.0+0.0im"
+        @test blocksize(U) == blocksize(S) == blocksize(A)
+        @test blockaxes(U) == blockaxes(S) == blockaxes(A)
+
+        @test U[Block(2,2)] == UpperTriangular(A[2:3,2:3])
+        @test U[Block(2,3)] == A[2:3,4:6]
+        @test U[Block(3,2)] == zeros(3,2)
+        @test S[Block(2,2)] == Symmetric(A[2:3,2:3])
+        @test S[Block(2,3)] == A[2:3,4:6]
+        @test S[Block(3,2)] == transpose(A[2:3,4:6])
+        @test H[Block(2,2)] == Hermitian(A[2:3,2:3])
+        @test H[Block(2,3)] == A[2:3,4:6]
+        @test H[Block(3,2)] == A[2:3,4:6]'
+
+        if VERSION ≥ v"1.2"
+            @test stringmime("text/plain", UpperTriangular(A)) == "10×10 UpperTriangular{Complex{Float64},PseudoBlockArray{Complex{Float64},2,Array{Complex{Float64},2},Tuple{BlockedUnitRange{Array{Int64,1}},BlockedUnitRange{Array{Int64,1}}}}} with indices 1:1:10×1:1:10:\n 1.0+0.0im  │  11.0+0.0im  21.0+0.0im  │  31.0+0.0im  41.0+0.0im  51.0+0.0im  │  61.0+0.0im  71.0+0.0im  81.0+0.0im   91.0+0.0im\n ───────────┼──────────────────────────┼──────────────────────────────────────┼─────────────────────────────────────────────────\n     ⋅      │  12.0+0.0im  22.0+0.0im  │  32.0+0.0im  42.0+0.0im  52.0+0.0im  │  62.0+0.0im  72.0+0.0im  82.0+0.0im   92.0+0.0im\n     ⋅      │       ⋅      23.0+0.0im  │  33.0+0.0im  43.0+0.0im  53.0+0.0im  │  63.0+0.0im  73.0+0.0im  83.0+0.0im   93.0+0.0im\n ───────────┼──────────────────────────┼──────────────────────────────────────┼─────────────────────────────────────────────────\n     ⋅      │       ⋅           ⋅      │  34.0+0.0im  44.0+0.0im  54.0+0.0im  │  64.0+0.0im  74.0+0.0im  84.0+0.0im   94.0+0.0im\n     ⋅      │       ⋅           ⋅      │       ⋅      45.0+0.0im  55.0+0.0im  │  65.0+0.0im  75.0+0.0im  85.0+0.0im   95.0+0.0im\n     ⋅      │       ⋅           ⋅      │       ⋅           ⋅      56.0+0.0im  │  66.0+0.0im  76.0+0.0im  86.0+0.0im   96.0+0.0im\n ───────────┼──────────────────────────┼──────────────────────────────────────┼─────────────────────────────────────────────────\n     ⋅      │       ⋅           ⋅      │       ⋅           ⋅           ⋅      │  67.0+0.0im  77.0+0.0im  87.0+0.0im   97.0+0.0im\n     ⋅      │       ⋅           ⋅      │       ⋅           ⋅           ⋅      │       ⋅      78.0+0.0im  88.0+0.0im   98.0+0.0im\n     ⋅      │       ⋅           ⋅      │       ⋅           ⋅           ⋅      │       ⋅           ⋅      89.0+0.0im   99.0+0.0im\n     ⋅      │       ⋅           ⋅      │       ⋅           ⋅           ⋅      │       ⋅           ⋅           ⋅      100.0+0.0im"
+        end
+    end
+
+    @testset "rect blocks" begin
+        A = PseudoBlockArray{ComplexF64}(undef, 1:3, fill(3,2))
+        A .= randn(6,6) .+ im * randn(6,6)
+        U = UpperTriangular(A)
+        S = Symmetric(A)
+        H = Hermitian(A)
+       
+        @test blockisequal(axes(S), (axes(A,2),axes(A,2)))
+        @test blockisequal(axes(U), axes(A))
+        @test blocksize(S) == (blocksize(S,1),blocksize(S,2)) == (2,2)
+        @test blocksize(U) == (blocksize(U,1),blocksize(U,2)) == blocksize(A)
+        @test blockaxes(S) == (blockaxes(S,1),blockaxes(S,2)) == (Block.(1:2), Block.(1:2))
+        @test blockaxes(U) == (blockaxes(U,1),blockaxes(U,2)) == blockaxes(A)
+
+        @test U[Block(2,2)] == A[Block(2,2)]
+        @test U[Block(3,2)] == triu(A[Block(3,2)])
+        @test U[Block(3,1)] == zeros(3,3)
+        @test S[Block(2,2)] == Symmetric(A[4:6,4:6])
+        @test S[Block(1,2)] == A[1:3,4:6]
+        @test S[Block(2,1)] == transpose(A[1:3,4:6])
+        @test H[Block(2,2)] == Hermitian(A[4:6,4:6])
+        @test H[Block(1,2)] == A[1:3,4:6]
+        @test H[Block(2,1)] == A[1:3,4:6]'
+        
+        @test !BlockArrays.hasmatchingblocks(U)
+        @test BlockArrays.hasmatchingblocks(S)
+        @test BlockArrays.hasmatchingblocks(H)
     end
 end
 

--- a/test/test_blockviews.jl
+++ b/test/test_blockviews.jl
@@ -174,4 +174,37 @@ using BlockArrays, Test, Base64
         @test A[Block.(2:3)] isa PseudoBlockArray
         @test A[Block.(2:3)] == A[2:end]
     end
+
+    @testset "non-allocation blocksize" begin
+        A = BlockArray(randn(5050), 1:100)
+        @test blocksize(A) == (100,)
+        @test @allocated(blocksize(A)) ≤ 20
+        V = view(A, Block(3))
+        @test blocksize(V) == (1,)
+        @test @allocated(blocksize(V)) ≤ 20
+        V = view(A, Block.(1:30))
+        @test blocksize(V) == (30,)
+        @test @allocated(blocksize(V)) ≤ 20
+        V = view(A, 3:43)
+        @test blocksize(V) == (1,)
+        V = view(A, 5)
+        @test blocksize(V) == ()
+
+        A = BlockArray(randn(5050,21), 1:100, 1:6)
+        @test blocksize(A) == (100,6)
+        @test @allocated(blocksize(A)) ≤ 40
+        V = view(A, Block(3,2))
+        @test blocksize(V) == (1,1)
+        @test @allocated(blocksize(V)) ≤ 20
+        V = view(A, Block.(1:30), Block(3))
+        @test blocksize(V) == (30,1)
+        @test @allocated(blocksize(V)) ≤ 40
+        V = view(A, Block.(1:30), Block.(1:3))
+        @test blocksize(V) == (30,3)
+        @test @allocated(blocksize(V)) ≤ 40
+        V = view(A, 3:43,1:3)
+        @test blocksize(V) == (1,1)
+        V = view(A, 5, 1:3)
+        @test blocksize(V) == (1,)
+    end
 end

--- a/test/test_blockviews.jl
+++ b/test/test_blockviews.jl
@@ -178,13 +178,13 @@ using BlockArrays, Test, Base64
     @testset "non-allocation blocksize" begin
         A = BlockArray(randn(5050), 1:100)
         @test blocksize(A) == (100,)
-        @test @allocated(blocksize(A)) ≤ 20
+        @test @allocated(blocksize(A)) ≤ 40
         V = view(A, Block(3))
         @test blocksize(V) == (1,)
-        @test @allocated(blocksize(V)) ≤ 20
+        @test @allocated(blocksize(V)) ≤ 40
         V = view(A, Block.(1:30))
         @test blocksize(V) == (30,)
-        @test @allocated(blocksize(V)) ≤ 20
+        @test @allocated(blocksize(V)) ≤ 40
         V = view(A, 3:43)
         @test blocksize(V) == (1,)
         V = view(A, 5)
@@ -195,7 +195,7 @@ using BlockArrays, Test, Base64
         @test @allocated(blocksize(A)) ≤ 40
         V = view(A, Block(3,2))
         @test blocksize(V) == (1,1)
-        @test @allocated(blocksize(V)) ≤ 20
+        @test @allocated(blocksize(V)) ≤ 40
         V = view(A, Block.(1:30), Block(3))
         @test blocksize(V) == (30,1)
         @test @allocated(blocksize(V)) ≤ 40

--- a/test/test_blockviews.jl
+++ b/test/test_blockviews.jl
@@ -207,4 +207,18 @@ using BlockArrays, Test, Base64
         V = view(A, 5, 1:3)
         @test blocksize(V) == (1,)
     end
+
+    @testset "hasmatchingblocks" begin
+        A = BlockArray{Int}(undef, 1:20, 1:20)
+        B = BlockArray{Int}(undef, 1:3, fill(3,2))
+        V = view(A,Block.(1:10),Block.(1:10))
+
+        @test BlockArrays.hasmatchingblocks(A)
+        @test BlockArrays.hasmatchingblocks(V)
+        @test @allocated(BlockArrays.hasmatchingblocks(V)) == 0
+        @test !BlockArrays.hasmatchingblocks(view(A,Block.(1:2),1:3))
+        @test !BlockArrays.hasmatchingblocks(view(A,Block.(1:2),Block.(2:3)))
+
+        @test BlockArrays.hasmatchingblocks(view(B,Block.(3:3),Block.(2:2)))
+    end
 end


### PR DESCRIPTION
At the moment `axes(::SubArray)` allocates for block arrays, and I'm not sure how to avoid this. This adds fast-paths for some routines so `axes` can be avoided.

It also adds support for things like `zeros(blockedrange([1,2,3]))` to construct blocked zero arrays.