### PR TITLE
fix blockisequalorscalar(ax, a) when a is Ref

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BlockArrays"
 uuid = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
-version = "0.14.3"
+version = "0.14.4"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/blockbroadcast.jl
+++ b/src/blockbroadcast.jl
@@ -209,7 +209,7 @@ _hasscalarlikevec(a, b...) = _hasscalarlikevec(b...)
 _hasscalarlikevec(a::AbstractVector, b...) = size(a,1) == 1 || _hasscalarlikevec(b...)
 
 blockisequalorscalar(ax, ::Number) = true
-blockisequalorscalar(ax, a) = blockisequal(ax, axes(a,1))
+blockisequalorscalar(ax, a) = blockisequal(ax, Base.axes1(a))
     
 function copyto!(dest::AbstractVector,
         bc::Broadcasted{<:AbstractBlockStyle{1}, <:Any, <:Any, Args}) where {Args <: Tuple}

--- a/test/test_blockbroadcast.jl
+++ b/test/test_blockbroadcast.jl
@@ -1,5 +1,5 @@
 using BlockArrays, FillArrays, LazyArrays, Test
-import BlockArrays: SubBlockIterator, BlockIndexRange
+import BlockArrays: SubBlockIterator, BlockIndexRange, Diagonal
 
 @testset "broadcast" begin
     @testset "BlockArray" begin

--- a/test/test_blockbroadcast.jl
+++ b/test/test_blockbroadcast.jl
@@ -115,6 +115,19 @@ import BlockArrays: SubBlockIterator, BlockIndexRange, Diagonal
         @test broadcast(*, 2, v) == 2Vector(v)
     end
 
+    @testset "BlockVector broadcast" begin
+        a = BlockArray(randn(3),[1,2])
+        b = broadcast(+, Ref(1), a)
+        @test b isa BlockArray{eltype(a),1}
+        @test Base.axes1(a) == Base.axes1(b)
+        @test Vector(b) == broadcast(+, Ref(1), Vector(a))
+        a = BlockArray(randn(16),[1,3,5,7])
+        b = broadcast(+, Ref(1), a)
+        @test b isa BlockArray{eltype(a),1}
+        @test Base.axes1(a) == Base.axes1(b)
+        @test Vector(b) == broadcast(+, Ref(1), Vector(a))
+    end
+
     @testset "special axes" begin
         A = BlockArray(randn(6), Ones{Int}(6))
         B = BlockArray(randn(6), Ones{Int}(6))


### PR DESCRIPTION
Work towards fixing the error encountered in https://github.com/JuliaApproximation/HarmonicOrthogonalPolynomials.jl/pull/21#issuecomment-776432453 caused by attempting to call axes(::Ref, ::Int).