### PR TITLE
error for incorrect BlockIndex dimension

### DIFF
--- a/src/blockaxis.jl
+++ b/src/blockaxis.jl
@@ -6,6 +6,8 @@
     b[block(K)][K.α...]
 @inline getindex(b::AbstractArray, K::BlockIndex{1}, J::BlockIndex{1}...) =
     b[BlockIndex(tuple(K, J...))]
+getindex(b::AbstractArray{T,N}, K::BlockIndex{1}) where {T,N} =
+    throw(DimensionMismatch("Incorrect blockindex of dimension 1 into into array of dimension $(N)"))
 
 @inline getindex(b::AbstractArray{T,N}, K::BlockIndexRange{N}) where {T,N} = b[block(K)][K.indices...]
 @inline getindex(b::LayoutArray{T,N}, K::BlockIndexRange{N}) where {T,N} = b[block(K)][K.indices...]

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -71,7 +71,7 @@ end
             @test Matrix(ret) == zeros(6,6)
 
             A = [1,2,3,4,5,6]
-            @test A == BlockArray(A, 1:3) == BlockArray{Int}(A, 1:3) == 
+            @test A == BlockArray(A, 1:3) == BlockArray{Int}(A, 1:3) ==
                 BlockArray(A, (blockedrange(1:3),)) == BlockArray{Int}(A, (blockedrange(1:3),)) ==
                 BlockArray{Float64}(A, 1:3)
         end
@@ -94,7 +94,7 @@ end
             @test Matrix(ret) == zeros(6,6)
 
             A = [1,2,3,4,5,6]
-            @test A == PseudoBlockArray(A, 1:3) == PseudoBlockArray{Int}(A, 1:3) == 
+            @test A == PseudoBlockArray(A, 1:3) == PseudoBlockArray{Int}(A, 1:3) ==
                 PseudoBlockArray(A, (blockedrange(1:3),)) == PseudoBlockArray{Int}(A, (blockedrange(1:3),)) ==
                 PseudoBlockArray{Float64}(A, 1:3)
         end
@@ -154,7 +154,7 @@ end
                 )
             end
         end
-        
+
         @testset "BlockVector" begin
             a_data = [1,2,3]
             a = BlockVector(a_data,[1,2])
@@ -199,29 +199,29 @@ end
             B = BlockArray(I, fill(2,4), fill(2,5))
             @test B isa BlockMatrix{Bool}
             @test B == BlockMatrix(I, fill(2,4), fill(2,5)) ==
-                        BlockArray(I, blockedrange.((fill(2,4), fill(2,5)))) == 
-                        BlockMatrix(I, blockedrange.((fill(2,4), fill(2,5)))) == 
+                        BlockArray(I, blockedrange.((fill(2,4), fill(2,5)))) ==
+                        BlockMatrix(I, blockedrange.((fill(2,4), fill(2,5)))) ==
                         Matrix(I, 8, 10)
-            
+
             B = BlockArray{Float64}(I, fill(2,4), fill(2,5))
             @test B isa BlockMatrix{Float64}
             @test B == BlockMatrix{Float64}(I, fill(2,4), fill(2,5)) ==
-                        BlockArray{Float64}(I, blockedrange.((fill(2,4), fill(2,5)))) == 
-                        BlockMatrix{Float64}(I, blockedrange.((fill(2,4), fill(2,5)))) == 
+                        BlockArray{Float64}(I, blockedrange.((fill(2,4), fill(2,5)))) ==
+                        BlockMatrix{Float64}(I, blockedrange.((fill(2,4), fill(2,5)))) ==
                         Matrix(I, 8, 10)
 
             B = PseudoBlockArray(I, fill(2,4), fill(2,5))
             @test B isa PseudoBlockMatrix{Bool}
             @test B == PseudoBlockMatrix(I, fill(2,4), fill(2,5)) ==
-                        PseudoBlockArray(I, blockedrange.((fill(2,4), fill(2,5)))) == 
-                        PseudoBlockMatrix(I, blockedrange.((fill(2,4), fill(2,5)))) == 
+                        PseudoBlockArray(I, blockedrange.((fill(2,4), fill(2,5)))) ==
+                        PseudoBlockMatrix(I, blockedrange.((fill(2,4), fill(2,5)))) ==
                         Matrix(I, 8, 10)
-            
+
             B = PseudoBlockArray{Float64}(I, fill(2,4), fill(2,5))
             @test B isa PseudoBlockMatrix{Float64}
             @test B == PseudoBlockMatrix{Float64}(I, fill(2,4), fill(2,5)) ==
-                        PseudoBlockArray{Float64}(I, blockedrange.((fill(2,4), fill(2,5)))) == 
-                        PseudoBlockMatrix{Float64}(I, blockedrange.((fill(2,4), fill(2,5)))) == 
+                        PseudoBlockArray{Float64}(I, blockedrange.((fill(2,4), fill(2,5)))) ==
+                        PseudoBlockMatrix{Float64}(I, blockedrange.((fill(2,4), fill(2,5)))) ==
                         Matrix(I, 8, 10)
         end
     end
@@ -249,6 +249,9 @@ end
 
         @test BA_2[1,5] == a_2[2]
         @test_throws DimensionMismatch BA_2[Block(1,2)] = rand(1,5)
+
+        # throw error when a BlockIndex{1} is used for an AbstractArray{2}
+        @test_throws DimensionMismatch BA_2[BlockIndex(1,2)]
     end
 
     @testset "misc block tests" begin
@@ -355,9 +358,9 @@ end
 
         Ã = PseudoBlockArray(rand(2,3), Fill(1,2), [2,1])
         @test convert(typeof(A), Ã) == Ã
-        
+
         @test PseudoBlockArray(A, axes(Ã)) isa typeof(Ã)
-        @test PseudoBlockArray(A, axes(Ã)) == A    
+        @test PseudoBlockArray(A, axes(Ã)) == A
 
 
         A = BlockArray(rand(2,3), [1,1], [2,1])
@@ -532,7 +535,7 @@ end
         b = randn(6)
         @test A*b isa PseudoBlockVector{Float64}
         @test Ã*b isa PseudoBlockVector{Float64}
-        @test A*b ≈ Ã*b ≈ Matrix(A)*b 
+        @test A*b ≈ Ã*b ≈ Matrix(A)*b
     end
 
     @testset "Blockindex" begin
@@ -542,8 +545,8 @@ end
         A = PseudoBlockArray(randn(3,3), [1,2], [1,2])
         @test A[Block(1)[1], Block(1)[1]] == A[Block(1,1)[1,1]] == A[1,1]
         @test A[Block(1)[1:1], Block(1)[1:1]] == A[Block(1,1)[1:1,1:1]] == A[1:1,1:1]
-        @test A[Block(1)[1:1], Block(1)[1]] == BlockArray(A)[Block(1)[1:1], Block(1)[1]] == A[1:1,1] 
-        @test A[Block(1)[1], Block(1)[1:1]] == BlockArray(A)[Block(1)[1], Block(1)[1:1]] == A[1,1:1] 
+        @test A[Block(1)[1:1], Block(1)[1]] == BlockArray(A)[Block(1)[1:1], Block(1)[1]] == A[1:1,1]
+        @test A[Block(1)[1], Block(1)[1:1]] == BlockArray(A)[Block(1)[1], Block(1)[1:1]] == A[1,1:1]
     end
 
     @testset "permutedims" begin


### PR DESCRIPTION
Working with `BlockArrays` I received an uninformative `StackOverflowError` when using block indices incorrectly:
```julia
julia> using BlockArrays

julia> A = rand(10,10); A[BlockIndex(1,1)]
ERROR: StackOverflowError:
Stacktrace:
 [1] BlockIndex at /Users/daan/.julia/packages/BlockArrays/aLe8n/src/blockindices.jl:118 [inlined] (repeats 2 times)
 [2] BlockIndex at /Users/daan/.julia/packages/BlockArrays/aLe8n/src/blockindices.jl:122 [inlined]
 [3] BlockIndex at /Users/daan/.julia/packages/BlockArrays/aLe8n/src/blockindices.jl:144 [inlined]
 [4] getindex(::Array{Float64,2}, ::BlockIndex{1}) at /Users/daan/.julia/packages/BlockArrays/aLe8n/src/blockaxis.jl:7 (repeats 79984 times)
```

The problem is that the array `A` has dimension `N=2` but `BlockIndex(1,1)` has `N=1`. I should have used `BlockIndex((1,1),(1,1))` instead. The stack overflow happens [here](https://github.com/JuliaArrays/BlockArrays.jl/blob/eaed58f4f7513e9fca752bf53bb7511840436118/src/blockaxis.jl#L7).

The pull request throws a `DimensionMismatch` when this happens. I've also added a test for this.

The pull request seems to also have removed a lot of trailing whitespaces, making it harder to interpret. There are only two additions: throwing the error [here](https://github.com/daanhb/BlockArrays.jl/blob/5e0aca6277526075b555bf109ede42e03c83828f/src/blockaxis.jl#L9) and the test [here](https://github.com/daanhb/BlockArrays.jl/blob/5e0aca6277526075b555bf109ede42e03c83828f/test/test_blockarrays.jl#L254).

The result is:
```julia
julia> using BlockArrays
A = rand(10,10);
julia> A = rand(10,10); A[BlockIndex(1,1)]
ERROR: DimensionMismatch("Incorrect blockindex of dimension 1 into into array of dimension 2")
```
I thought a `DimensionMismatch` was suitable here. Or should it be a standard `BoundsError`?

I don't know if there was ever a plan to support linear indexing for blocks, that might change things.