### PR TITLE
Fix bug in similar with adjoints/transpose

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BlockArrays"
 uuid = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
-version = "0.16.3"
+version = "0.16.4"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/blockarray.jl
+++ b/src/blockarray.jl
@@ -357,6 +357,8 @@ end
     BlockArray{T}(undef, axes)
 @inline Base.similar(block_array::AbstractArray, ::Type{T}, axes::Tuple{AbstractUnitRange{Int},BlockedUnitRange,Vararg{AbstractUnitRange{Int}}}) where T =
     BlockArray{T}(undef, axes)
+@inline Base.similar(block_array::AbstractArray, ::Type{T}, axes::Tuple{Int,BlockedUnitRange,Vararg{AbstractUnitRange{Int}}}) where T =
+    similar(block_array, T, (Base.OneTo(axes[1]), tail(axes)...))
 
 @inline Base.similar(block_array::Type{<:AbstractArray{T}}, axes::Tuple{BlockedUnitRange,Vararg{AbstractUnitRange{Int}}}) where T =
     BlockArray{T}(undef, axes)

--- a/src/views.jl
+++ b/src/views.jl
@@ -146,6 +146,8 @@ end
 
 Base.view(A::AdjOrTrans{<:Any,<:BlockArray}, K::Block{1}, J::Block{1}) = view(A, Block(Int(K), Int(J)))
 
+@propagate_inbounds getindex(v::LinearAlgebra.AdjOrTransAbsVec, ::Colon, is::AbstractArray{<:Block{1}}) = LinearAlgebra.wrapperop(v)(v.parent[is])
+
 
 unsafe_convert(::Type{Ptr{T}}, V::SubArray{T,N,PseudoBlockArray{T,N,AT},<:Tuple{Vararg{BlockOrRangeIndex}}}) where {T,N,AT} =
     unsafe_convert(Ptr{T}, V.parent) + (Base.first_index(V)-1)*sizeof(T)

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -550,6 +550,9 @@ end
 
     @testset "adjoint getindex" begin
         a = BlockVector(1:5, [2,1,1,1])
+        @test similar(a', Int, 1, axes(a,1)) isa BlockMatrix
         @test (a')[:,Block.(1:2)] == transpose(a)[:,Block.(1:2)] == [1 2 3]
+        @test (a')[:,Block.(1:2)] isa Adjoint
+        @test transpose(a)[:,Block.(1:2)] isa Transpose
     end
 end

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -547,4 +547,9 @@ end
             blockisequal(axes(permutedims(A)), axes(A))
         end
     end
+
+    @testset "adjoint getindex" begin
+        a = BlockVector(1:5, [2,1,1,1])
+        @test (a')[:,Block.(1:2)] == transpose(a)[:,Block.(1:2)] == [1 2 3]
+    end
 end


### PR DESCRIPTION
Before:
```julia
julia> a = BlockVector(1:5,[3,1,1])
3-blocked 5-element BlockVector{Int64, Vector{UnitRange{Int64}}, Tuple{BlockedUnitRange{Vector{Int64}}}}:
 1
 2
 3
 ─
 4
 ─
 5

**julia> similar(a', 1, axes(a,1))
ERROR: MethodError: no method matching similar(::Adjoint{Int64, BlockVector{Int64, Vector{UnitRange{Int64}}, Tuple{BlockedUnitRange{Vector{Int64}}}}}, ::Type{Int64}, ::Tuple{Int64, BlockedUnitRange{Vector{Int64}}})
Closest candidates are:
  similar(::Union{Adjoint{T, var"#s832"}, Transpose{T, var"#s832"}} where {T, var"#s832"<:(AbstractVector{T} where T)}, ::Type{T}) where T at /Users/solver/Projects/julia-1.6/usr/share/julia/stdlib/v1.6/LinearAlgebra/src/adjtrans.jl:230
  similar(::Union{Adjoint{T, S}, Transpose{T, S}} where {T, S}, ::Type{T}) where T at /Users/solver/Projects/julia-1.6/usr/share/julia/stdlib/v1.6/LinearAlgebra/src/adjtrans.jl:234
  similar(::Union{Adjoint{T, S}, Transpose{T, S}} where {T, S}, ::Type{T}, ::Tuple{Vararg{Int64, N}}) where {T, N} at /Users/solver/Projects/julia-1.6/usr/share/julia/stdlib/v1.6/LinearAlgebra/src/adjtrans.jl:235
  ...
Stacktrace:
 [1] similar(::Adjoint{Int64, BlockVector{Int64, Vector{UnitRange{Int64}}, Tuple{BlockedUnitRange{Vector{Int64}}}}}, ::Int64, ::BlockedUnitRange{Vector{Int64}})
   @ Base ./abstractarray.jl:741
 [2] top-level scope
   @ REPL[14]:1

julia> a'[:,Block.(1:2)]
ERROR: MethodError: no method matching similar(::Adjoint{Int64, BlockVector{Int64, Vector{UnitRange{Int64}}, Tuple{BlockedUnitRange{Vector{Int64}}}}}, ::Type{Int64}, ::Tuple{Int64, BlockedUnitRange{Vector{Int64}}})
Closest candidates are:
  similar(::Union{Adjoint{T, var"#s832"}, Transpose{T, var"#s832"}} where {T, var"#s832"<:(AbstractVector{T} where T)}, ::Type{T}) where T at /Users/solver/Projects/julia-1.6/usr/share/julia/stdlib/v1.6/LinearAlgebra/src/adjtrans.jl:230
  similar(::Union{Adjoint{T, S}, Transpose{T, S}} where {T, S}, ::Type{T}) where T at /Users/solver/Projects/julia-1.6/usr/share/julia/stdlib/v1.6/LinearAlgebra/src/adjtrans.jl:234
  similar(::Union{Adjoint{T, S}, Transpose{T, S}} where {T, S}, ::Type{T}, ::Tuple{Vararg{Int64, N}}) where {T, N} at /Users/solver/Projects/julia-1.6/usr/share/julia/stdlib/v1.6/LinearAlgebra/src/adjtrans.jl:235
  ...
Stacktrace:
 [1] similar(a::Adjoint{Int64, BlockVector{Int64, Vector{UnitRange{Int64}}, Tuple{BlockedUnitRange{Vector{Int64}}}}}, dims::Tuple{Base.OneTo{Int64}, BlockedUnitRange{Vector{Int64}}})
   @ Base ./abstractarray.jl:740
 [2] _unsafe_getindex(::IndexLinear, ::Adjoint{Int64, BlockVector{Int64, Vector{UnitRange{Int64}}, Tuple{BlockedUnitRange{Vector{Int64}}}}}, ::Base.Slice{Base.OneTo{Int64}}, ::BlockArrays.BlockSlice{BlockRange{1, Tuple{UnitRange{Int64}}}, BlockedUnitRange{Vector{Int64}}})
   @ Base ./multidimensional.jl:844
 [3] _getindex
   @ ./multidimensional.jl:832 [inlined]
 [4] getindex(::Adjoint{Int64, BlockVector{Int64, Vector{UnitRange{Int64}}, Tuple{BlockedUnitRange{Vector{Int64}}}}}, ::Function, ::BlockRange{1, Tuple{UnitRange{Int64}}})
   @ Base ./abstractarray.jl:1170
 [5] top-level scope
   @ REPL[15]:1
```
After:
```julia
julia> similar(a', 1, axes(a,1))
1×4-blocked 1×5 BlockMatrix{Int64
, Matrix{Matrix{Int64}}, Tuple{OneTo{Int64}, BlockedUnitRange{Vector{Int64}}}}:
 4419193648  4408728624  │  5356839328  │  5356839616  │  5356830784

julia> (a')[:,Block.(1:2)]
1×3 adjoint(::BlockVector{Int64, Vector{Vector{Int64}}, Tuple{BlockedUnitRange{Vector{Int64}}}}) with eltype Int64 with indices Base.OneTo(1)×1:1:3:
 1  2  │  3
```
