### PR TITLE
Make length 1 blocks non-allocating

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ benchmark/*.md
 src/.DS_Store
 /Manifest.toml
 .DS_Store
+build

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BlockArrays"
 uuid = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
-version = "0.16.5"
+version = "0.16.6"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
@@ -14,11 +14,10 @@ julia = "1.6"
 
 [extras]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
-FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Base64", "FillArrays", "OffsetArrays", "SparseArrays", "StaticArrays", "Test"]
+test = ["Base64", "OffsetArrays", "SparseArrays", "StaticArrays", "Test"]

--- a/src/abstractblockarray.jl
+++ b/src/abstractblockarray.jl
@@ -180,6 +180,7 @@ end
 @inline Base.getindex(A::AbstractMatrix, kr::AbstractVector, jr::Block) = ArrayLayouts.layout_getindex(A, kr, jr)
 @inline Base.getindex(A::AbstractMatrix, kr::BlockRange{1}, jr::BlockRange{1}) = ArrayLayouts.layout_getindex(A, kr, jr)
 @inline Base.getindex(A::LayoutMatrix, kr::BlockRange{1}, jr::BlockRange{1}) = ArrayLayouts.layout_getindex(A, kr, jr)
+@inline Base.getindex(A::AbstractTriangular{<:Any,<:LayoutMatrix}, kr::BlockRange{1}, jr::BlockRange{1}) = ArrayLayouts.layout_getindex(A, kr, jr)
 
 ###
 # permutedims

--- a/src/blockarray.jl
+++ b/src/blockarray.jl
@@ -423,12 +423,20 @@ function _replace_in_print_matrix_inds(block_arr, i...)
     bl, inds
 end
 function Base.replace_in_print_matrix(block_arr::BlockArray{<:Any,2}, i::Integer, j::Integer, s::AbstractString)
-    bl, inds = _replace_in_print_matrix_inds(block_arr, i, j)
-    Base.replace_in_print_matrix(bl, inds..., s)
+    try
+        bl, inds = _replace_in_print_matrix_inds(block_arr, i, j)
+        Base.replace_in_print_matrix(bl, inds..., s)
+    catch UndefRefError # thrown with undef_blocks
+        s
+    end
 end
 function Base.replace_in_print_matrix(block_arr::BlockArray{<:Any,1}, i::Integer, j::Integer, s::AbstractString)
-    bl, inds = _replace_in_print_matrix_inds(block_arr, i)
-    Base.replace_in_print_matrix(bl, inds..., j, s)
+    try
+        bl, inds = _replace_in_print_matrix_inds(block_arr, i)
+        Base.replace_in_print_matrix(bl, inds..., j, s)
+    catch UndefRefError
+        s
+    end
 end
 
 ########

--- a/src/blockaxis.jl
+++ b/src/blockaxis.jl
@@ -269,13 +269,13 @@ end
 
 returns the first index of each block of `a`.
 """
-blockfirsts(a::AbstractUnitRange{Int}) = [1]
+blockfirsts(a::AbstractUnitRange{Int}) = Ones{Int}(1)
 """
    blocklasts(a::AbstractUnitRange{Int})
 
 returns the last index of each block of `a`.
 """
-blocklasts(a::AbstractUnitRange{Int}) = [length(a)]
+blocklasts(a::AbstractUnitRange{Int}) = Fill(length(a),1)
 """
    blocklengths(a::AbstractUnitRange{Int})
 

--- a/src/pseudo_blockarray.jl
+++ b/src/pseudo_blockarray.jl
@@ -286,3 +286,6 @@ end
 
 Base.replace_in_print_matrix(f::PseudoBlockVecOrMat, i::Integer, j::Integer, s::AbstractString) =
     Base.replace_in_print_matrix(f.blocks, i, j, s)
+
+
+LinearAlgebra.norm(A::PseudoBlockArray, p::Real=2) = norm(A.blocks, p)

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -402,6 +402,11 @@ end
         @test stringmime("text/plain",A) == "1×2-blocked 6×9 PseudoBlockMatrix{Int16}:\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0"
         D = PseudoBlockArray(Diagonal(1:3), [1,2], [2,1])
         @test stringmime("text/plain", D) == "2×2-blocked 3×3 $(PseudoBlockMatrix{Int, Diagonal{Int, UnitRange{Int}}, Tuple{BlockedUnitRange{Vector{Int}}, BlockedUnitRange{Vector{Int}}}}):\n 1  ⋅  │  ⋅\n ──────┼───\n ⋅  2  │  ⋅\n ⋅  ⋅  │  3"
+
+        a = BlockArray{Int}(undef_blocks, [1,2])
+        @test stringmime("text/plain", a) == "2-blocked 3-element BlockVector{Int64}:\n #undef\n ──────\n #undef\n #undef"
+        B = BlockArray{Int}(undef_blocks, [1,2], [1,1])
+        @test stringmime("text/plain", B) == "2×2-blocked 3×2 BlockMatrix{Int64}:\n #undef  │  #undef\n ────────┼────────\n #undef  │  #undef\n #undef  │  #undef"
     end
 
     @testset "AbstractVector{Int} blocks" begin

--- a/test/test_blockrange.jl
+++ b/test/test_blockrange.jl
@@ -51,10 +51,6 @@ using BlockArrays, Test
 
     A = BlockArray(reshape(collect(1:(6*12)),6,12), 1:3, 3:5)
     V = view(view(A, Block.(2:3), Block.(1:3)), Block(2), Block(2))
-    @test parent(V) == A
-    @test parentindices(V)[1] isa BlockArrays.BlockSlice{Block{1,Int}}
-    @test parentindices(V)[1].block == Block(3)
-    @test all(ind -> ind isa BlockArrays.BlockSlice, parentindices(V))
     @test V == view(A, Block.(2:3), Block.(1:3))[Block(2,2)] ==  A[Block(3, 2)]
 
 


### PR DESCRIPTION
An alternative would be to add StaticArrays.jl as a dependency so that the fact that the length is 1 is known at compile time.