### PR TITLE
Improve type inference in mortar

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BlockArrays"
 uuid = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
-version = "0.16.16"
+version = "0.16.17"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/blockarray.jl
+++ b/src/blockarray.jl
@@ -266,8 +266,10 @@ function sizes_from_blocks(blocks::AbstractArray{<:Any, N}, _) where N
         error("All blocks must have ndims consistent with ndims = $N of `blocks` array.")
     end
     fullsizes = map!(size, Array{NTuple{N,Int}, N}(undef, size(blocks)), blocks)
-    block_sizes = ntuple(ndims(blocks)) do i
-        [s[i] for s in view(fullsizes, ntuple(j -> j == i ? (:) : 1, ndims(blocks))...)]
+    fR = reinterpret(reshape, Int, fullsizes)
+    stfR = strides(fR)
+    block_sizes = ntuple(N) do i
+        fR[range(i, step = stfR[i+1], length=size(fullsizes, i))]
     end
     checksizes(fullsizes, block_sizes)
     return block_sizes

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -125,10 +125,15 @@ end
         @test_throws DimensionMismatch BlockArray([1,2,3],[1,1])
 
         @testset "mortar" begin
-            @testset for sizes in [(1:3,), (1:3, 1:3), (1:3, 1:3, 1:3)]
+            @testset for sizes in [(1:3,), (1:3, 1:4), (1:3, 1:4, 1:2)]
                 dims = sum.(sizes)
                 A = @inferred BlockArray(copy(reshape(1:prod(dims), dims)), sizes...)
                 @test @inferred mortar(A.blocks) == A
+                if length(dims) == 2
+                    # compare with hvcat
+                    rows = ntuple(_->length(sizes[2]), length(sizes[1]))
+                    @test mortar(A.blocks) == hvcat(rows, permutedims(A.blocks)...)
+                end
             end
 
             ret = @inferred mortar([spzeros(2), spzeros(3)])
@@ -159,12 +164,12 @@ end
             end
 
             @testset "sizes_from_blocks" begin
-                blocks = reshape([randn(2,2), zeros(1,2),
-                                  zeros(2,3), randn(1,3)], 2, 2);
+                blocks = reshape([rand(2,2), zeros(1,2),
+                                  zeros(2,3), rand(1,3)], 2, 2);
                 @test @inferred BlockArrays.sizes_from_blocks(blocks) == ([2,1], [2,3])
                 blocks = reshape(
-                    [randn(2,2), zeros(1,2), zeros(4,2),
-                     zeros(2,3), randn(1,3), zeros(4,3),
+                    [rand(2,2), zeros(1,2), zeros(4,2),
+                     zeros(2,3), rand(1,3), zeros(4,3),
                      zeros(2,1), zeros(1,1), rand(4,1)], 3, 3);
                 @test @inferred BlockArrays.sizes_from_blocks(blocks) == ([2, 1, 4], [2, 3, 1])
             end

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -127,15 +127,15 @@ end
         @testset "mortar" begin
             @testset for sizes in [(1:3,), (1:3, 1:3), (1:3, 1:3, 1:3)]
                 dims = sum.(sizes)
-                A = BlockArray(copy(reshape(1:prod(dims), dims)), sizes...)
-                @test mortar(A.blocks) == A
+                A = @inferred BlockArray(copy(reshape(1:prod(dims), dims)), sizes...)
+                @test @inferred mortar(A.blocks) == A
             end
 
-            ret = mortar([spzeros(2), spzeros(3)])
+            ret = @inferred mortar([spzeros(2), spzeros(3)])
             @test eltype(ret.blocks) <: SparseVector
             @test axes(ret) == (blockedrange([2, 3]),)
 
-            ret = mortar(
+            ret = @inferred mortar(
                 (spzeros(1, 3), spzeros(1, 4)),
                 (spzeros(2, 3), spzeros(2, 4)),
                 (spzeros(5, 3), spzeros(5, 4)),
@@ -156,6 +156,17 @@ end
                     (zeros(1, 3), zeros(1, 4)),
                     (zeros(2, 3), zeros(111, 222)),
                 )
+            end
+
+            @testset "sizes_from_blocks" begin
+                blocks = reshape([randn(2,2), zeros(1,2),
+                                  zeros(2,3), randn(1,3)], 2, 2);
+                @test @inferred BlockArrays.sizes_from_blocks(blocks) == ([2,1], [2,3])
+                blocks = reshape(
+                    [randn(2,2), zeros(1,2), zeros(4,2),
+                     zeros(2,3), randn(1,3), zeros(4,3),
+                     zeros(2,1), zeros(1,1), rand(4,1)], 3, 3);
+                @test @inferred BlockArrays.sizes_from_blocks(blocks) == ([2, 1, 4], [2, 3, 1])
             end
         end
 


### PR DESCRIPTION
This helps the computation of block sizes be type-inferrable.

On master
```julia
julia> @inferred mortar(
                       (zeros(1, 3), zeros(1, 4)),
                       (zeros(2, 3), zeros(2, 4)),
                       (zeros(5, 3), zeros(5, 4)),
                   )
ERROR: return type BlockMatrix{Float64, Matrix{Matrix{Float64}}, Tuple{BlockedUnitRange{Vector{Int64}}, BlockedUnitRange{Vector{Int64}}}} does not match inferred return type BlockMatrix{Float64, Matrix{Matrix{Float64}}}
```
After this
```julia
julia> @inferred mortar(
                       (zeros(1, 3), zeros(1, 4)),
                       (zeros(2, 3), zeros(2, 4)),
                       (zeros(5, 3), zeros(5, 4)),
                   )
3×2-blocked 8×7 BlockMatrix{Float64}:
 0.0  0.0  0.0  │  0.0  0.0  0.0  0.0
 ───────────────┼────────────────────
 0.0  0.0  0.0  │  0.0  0.0  0.0  0.0
 0.0  0.0  0.0  │  0.0  0.0  0.0  0.0
 ───────────────┼────────────────────
 0.0  0.0  0.0  │  0.0  0.0  0.0  0.0
 0.0  0.0  0.0  │  0.0  0.0  0.0  0.0
 0.0  0.0  0.0  │  0.0  0.0  0.0  0.0
 0.0  0.0  0.0  │  0.0  0.0  0.0  0.0
 0.0  0.0  0.0  │  0.0  0.0  0.0  0.0
```