### PR TITLE
fix whitespace

### DIFF
--- a/src/blocklinalg.jl
+++ b/src/blocklinalg.jl
@@ -144,7 +144,7 @@ function _copyto!(_, ::AbstractBlockLayout, dest::AbstractMatrix, src::AbstractM
         for K = first(CS_d):first(CS_s)-Block(1)
             zero!(view(dest,K,J))
         end
-        for K = CS_s 
+        for K = CS_s
             copyto!(view(dest,K,J), view(src,K,J))
         end
         for K = last(CS_s)+Block(1):last(CS_d)

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -494,7 +494,7 @@ end
         @test A == B
         B[1] = 2
         @test B[1] == 2
-        @test A[1] ≠ 2
+        @test A[1] ≠ 2
 
         A = BlockArray(randn(6), 1:3)
         B = copy(A)
@@ -503,7 +503,7 @@ end
         @test A == B
         B[1] = 2
         @test B[1] == 2
-        @test A[1] ≠ 2
+        @test A[1] ≠ 2
         @testset "copyto!" begin
             A = PseudoBlockArray(randn(6), 1:3)
             B = BlockArray(randn(6), 1:3)

--- a/test/test_blockcholesky.jl
+++ b/test/test_blockcholesky.jl
@@ -33,7 +33,7 @@ Random.seed!(0)
     #Tests on A
     @test cholesky(A).U ≈ cholesky(A_T).U
     @test cholesky(A).U'cholesky(A).U ≈ A
-    
+
     #Tests on B
     @test cholesky(B).U ≈ cholesky(B_T).U
     @test cholesky(B).U'cholesky(B).U ≈ B

--- a/test/test_blockindices.jl
+++ b/test/test_blockindices.jl
@@ -356,7 +356,7 @@ end
 
 #     @test_throws BlockBoundsError A[Block(3)]
 #     @test_throws BlockBoundsError A[Block(3)[1]]
-#     @test_throws BoundsError A[Block(3)[1:1]] # this is likely an error
+#     @test_throws BoundsError A[Block(3)[1:1]] # this is likely an error
 #     @test_throws BoundsError A[Block(2)[3]]
 #     @test_throws BoundsError A[Block(2)[3:3]]
 # end

--- a/test/test_blockviews.jl
+++ b/test/test_blockviews.jl
@@ -190,13 +190,13 @@ bview(a, b) = Base.invoke(view, Tuple{AbstractArray,Any}, a, b)
     @testset "non-allocation blocksize" begin
         A = BlockArray(randn(5050), 1:100)
         @test blocksize(A) == (100,)
-        @test @allocated(blocksize(A)) ≤ 40
+        @test @allocated(blocksize(A)) ≤ 40
         V = view(A, Block(3))
         @test blocksize(V) == (1,)
-        @test @allocated(blocksize(V)) ≤ 40
+        @test @allocated(blocksize(V)) ≤ 40
         V = view(A, Block.(1:30))
         @test blocksize(V) == (30,)
-        @test @allocated(blocksize(V)) ≤ 40
+        @test @allocated(blocksize(V)) ≤ 40
         V = view(A, 3:43)
         @test blocksize(V) == (1,)
         V = view(A, 5)
@@ -204,16 +204,16 @@ bview(a, b) = Base.invoke(view, Tuple{AbstractArray,Any}, a, b)
 
         A = BlockArray(randn(5050,21), 1:100, 1:6)
         @test blocksize(A) == (100,6)
-        @test @allocated(blocksize(A)) ≤ 40
+        @test @allocated(blocksize(A)) ≤ 40
         V = view(A, Block(3,2))
         @test blocksize(V) == (1,1)
-        @test @allocated(blocksize(V)) ≤ 40
+        @test @allocated(blocksize(V)) ≤ 40
         V = view(A, Block.(1:30), Block(3))
         @test blocksize(V) == (30,1)
-        @test @allocated(blocksize(V)) ≤ 40
+        @test @allocated(blocksize(V)) ≤ 40
         V = view(A, Block.(1:30), Block.(1:3))
         @test blocksize(V) == (30,3)
-        @test @allocated(blocksize(V)) ≤ 40
+        @test @allocated(blocksize(V)) ≤ 40
         V = view(A, 3:43,1:3)
         @test blocksize(V) == (1,1)
         V = view(A, 5, 1:3)


### PR DESCRIPTION
Remove trailing spaces, and replace non-breaking spaces with standard ones. No code change.