### PR TITLE
Type-stability in subblocks

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BlockArrays"
 uuid = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
-version = "0.16.21"
+version = "0.16.22"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/blockbroadcast.jl
+++ b/src/blockbroadcast.jl
@@ -135,9 +135,6 @@ subblocks(::Any, bs::NTuple{N,AbstractUnitRange{Int}}, dim::Integer) where N =
     (nothing for _ in blockaxes(bs[dim], 1))
 
 function subblocks(arr::AbstractArray, bs::NTuple{N,AbstractUnitRange{Int}}, dim::Integer) where N
-    if size(arr, dim) == 1
-        return (BlockIndexRange(Block(1), 1:1) for _ in blockaxes(bs[dim], 1))
-    end
     return SubBlockIterator(arr, bs, dim)
 end
 

--- a/test/test_blockbroadcast.jl
+++ b/test/test_blockbroadcast.jl
@@ -251,4 +251,14 @@ import BlockArrays: SubBlockIterator, BlockIndexRange, Diagonal
 
         @test [idx.indices[1] for idx in SubBlockIterator(subblock_lasts, block_lasts)] == [1:1,1:2,1:1,2:3]
     end
+
+    @testset "Adding BlockArrays" begin
+        B = mortar(reshape([[1;;]], 1, 1))
+        C = B + B
+        @test C[Block(1,1)] == 2B[Block(1,1)]
+
+        B = mortar(reshape([[1 2], [3 4]], 1, 2))
+        C = B + B
+        @test C[Block(1,1)] == 2B[Block(1,1)]
+    end
 end

--- a/test/test_blockbroadcast.jl
+++ b/test/test_blockbroadcast.jl
@@ -253,7 +253,7 @@ import BlockArrays: SubBlockIterator, BlockIndexRange, Diagonal
     end
 
     @testset "Adding BlockArrays" begin
-        B = mortar(reshape([[1;;]], 1, 1))
+        B = mortar(reshape([ones(1,1)], 1, 1))
         C = B + B
         @test C[Block(1,1)] == 2B[Block(1,1)]
 

--- a/test/test_blockbroadcast.jl
+++ b/test/test_blockbroadcast.jl
@@ -260,5 +260,9 @@ import BlockArrays: SubBlockIterator, BlockIndexRange, Diagonal
         B = mortar(reshape([[1 2], [3 4]], 1, 2))
         C = B + B
         @test C[Block(1,1)] == 2B[Block(1,1)]
+
+        B = mortar(reshape([[1]], 1))
+        C = B + B
+        @test C[Block(1)] == 2B[Block(1)]
     end
 end


### PR DESCRIPTION
On master
```julia
julia> using BlockArrays, BenchmarkTools

julia> B = mortar(reshape([rand(1, 2), rand(1,2)], 1, 2));

julia> @btime $B + $B;
  4.258 μs (84 allocations: 4.47 KiB)
```
This PR
```julia
julia> @btime $B + $B;
  1.230 μs (19 allocations: 1.41 KiB)
```