### PR TITLE
Optimize findblockindex

### DIFF
--- a/src/blockaxis.jl
+++ b/src/blockaxis.jl
@@ -12,8 +12,13 @@
 @inline getindex(b::LayoutArray{T,1}, K::BlockIndexRange{1}) where {T} = b[block(K)][K.indices...]
 
 function findblockindex(b::AbstractVector, k::Integer)
-    K = findblock(b, k)
-    K[searchsortedfirst(b[K], k)] # guaranteed to be in range
+    @boundscheck k in b || throw(BoundsError())
+    bl = blocklasts(b)
+    blockidx = _searchsortedfirst(bl, k)
+    @assert blockindex != lastindex(bl) + 1 # guaranteed by the @boundscheck above
+    prevblocklast = blockidx == firstindex(bl) ? first(b)-1 : bl[blockidx-1]
+    local_index = k - prevblocklast
+    return BlockIndex(blockidx, local_index)
 end
 
 function _BlockedUnitRange end


### PR DESCRIPTION
~This patch speeds up findblockindex by replacing a binary search of a unit range with some integer arithmetic. This reduces the time for the following benchmark with 15% (from 174.650 μs to 147.109 μs):~

This patch rewrites `findblockindex` to compute the block and the index
in one step instead of first looking up the block and then looking up
the index.

This reduces the time for the following `getindex`-benchmark with around
50%, from 185μs to 84μs.

```julia
using BlockArrays, BenchmarkTools

const D = rand(100, 100);
const B = BlockArray(D, [50, 50], [50, 50])

function getindex_bench(A)
    s = zero(eltype(A))
    for j in axes(A, 2), i in axes(A, 1)
        s += A[i, j]
    end
    return s
end

@btime getindex_bench(B)
```

In particular this makes `BlockArray` indexing comparable to
`SparseMatrixCSC` indexing: the benchmark above, with `S = sparse(D)`,
takes 60μs.