### PR TITLE
Compact show for BlockRange

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,6 @@ docs/site/
 *.jld
 benchmark/*.md
 src/.DS_Store
-/Manifest.toml
+Manifest.toml
 .DS_Store
 build

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BlockArrays"
 uuid = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
-version = "0.16.23"
+version = "0.16.24"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+BlockArrays = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 
 [compat]

--- a/docs/src/man/blockarrays.md
+++ b/docs/src/man/blockarrays.md
@@ -156,7 +156,7 @@ julia> view(A, Block(2)) .= [3,4]; A[Block(2)]
  4.0
 
 julia> view(A, Block.(1:2))
-3-element view(::BlockVector{Float64, Vector{Vector{Float64}}, Tuple{BlockedUnitRange{ArrayLayouts.RangeCumsum{Int64, UnitRange{Int64}}}}}, BlockSlice(Block{1, Int64}[Block(1), Block(2)],1:1:3)) with eltype Float64 with indices 1:1:3:
+3-element view(::BlockVector{Float64, Vector{Vector{Float64}}, Tuple{BlockedUnitRange{ArrayLayouts.RangeCumsum{Int64, UnitRange{Int64}}}}}, BlockSlice(BlockRange(1:2),1:1:3)) with eltype Float64 with indices 1:1:3:
  1.0
  3.0
  4.0

--- a/src/blockindices.jl
+++ b/src/blockindices.jl
@@ -387,6 +387,7 @@ _in(b, ::Tuple{}, ::Tuple{}, ::Tuple{}) = b
 # We sometimes need intersection of BlockRange to return a BlockRange
 intersect(a::BlockRange{1}, b::BlockRange{1}) = BlockRange(intersect(a.indices[1], b.indices[1]))
 
+Base.show(io::IO, br::BlockRange) = print(io, "BlockRange(", br.indices..., ")")
 
 # needed for scalar-like broadcasting
 

--- a/test/test_blockviews.jl
+++ b/test/test_blockviews.jl
@@ -174,8 +174,14 @@ bview(a, b) = Base.invoke(view, Tuple{AbstractArray,Any}, a, b)
         W = view(A,Block.(1:2),Block(1))
         @test blocks(V) == blocks(A)[1:1,1:2]
         @test blocks(W) == blocks(A)[1:2,1:1]
-        @test stringmime("text/plain", V) == "1×3 view(::BlockMatrix{$Int, Matrix{Matrix{$Int}}, $(typeof(axes(A)))}, BlockSlice(Block(1),1:1), BlockSlice(Block{1, $Int}[Block(1), Block(2)],1:1:3)) with eltype $Int with indices Base.OneTo(1)×1:1:3:\n 1  │  2  3"
-        @test stringmime("text/plain", W) == "3×1 view(::BlockMatrix{$Int, Matrix{Matrix{$Int}}, $(typeof(axes(A)))}, BlockSlice(Block{1, $Int}[Block(1), Block(2)],1:1:3), BlockSlice(Block(1),1:1)) with eltype $Int with indices 1:1:3×Base.OneTo(1):\n 1\n ─\n 4\n 7"
+        Vi = parentindices(V)
+        @test stringmime("text/plain", V) == "1×3 view(::BlockMatrix{$Int, Matrix{Matrix{$Int}}, "*
+            "$(typeof(axes(A)))}, $(Vi[1]), $(Vi[2])) "*
+            "with eltype $Int with indices $(axes(V,1))×$(axes(V,2)):\n 1  │  2  3"
+        Wi = parentindices(W)
+        @test stringmime("text/plain", W) == "3×1 view(::BlockMatrix{$Int, Matrix{Matrix{$Int}}"*
+            ", $(typeof(axes(A)))}, $(Wi[1]), $(Wi[2])) "*
+            "with eltype $Int with indices $(axes(W,1))×$(axes(W,2)):\n 1\n ─\n 4\n 7"
     end
 
     @testset "getindex with BlockRange" begin


### PR DESCRIPTION
On master
```julia
julia> show(Block(1):Block(100))
Block{1, Int64}[Block(1), Block(2), Block(3), Block(4), Block(5), Block(6), Block(7), Block(8), Block(9), Block(10), Block(11), Block(12), Block(13), Block(14), Block(15), Block(16), Block(17), Block(18), Block(19), Block(20), Block(21), Block(22), Block(23), Block(24), Block(25), Block(26), Block(27), Block(28), Block(29), Block(30), Block(31), Block(32), Block(33), Block(34), Block(35), Block(36), Block(37), Block(38), Block(39), Block(40), Block(41), Block(42), Block(43), Block(44), Block(45), Block(46), Block(47), Block(48), Block(49), Block(50), Block(51), Block(52), Block(53), Block(54), Block(55), Block(56), Block(57), Block(58), Block(59), Block(60), Block(61), Block(62), Block(63), Block(64), Block(65), Block(66), Block(67), Block(68), Block(69), Block(70), Block(71), Block(72), Block(73), Block(74), Block(75), Block(76), Block(77), Block(78), Block(79), Block(80), Block(81), Block(82), Block(83), Block(84), Block(85), Block(86), Block(87), Block(88), Block(89), Block(90), Block(91), Block(92), Block(93), Block(94), Block(95), Block(96), Block(97), Block(98), Block(99), Block(100)]
```

After this PR
```julia
julia> show(Block(1):Block(100))
BlockRange(1:100)
```

The compact display is easier to understand, and it's a valid constructor as well.

I've also updated some tests in block views to make them less fragile to changes in displayed forms.