### PR TITLE
ignore all manifests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,6 @@ docs/site/
 *.jld
 benchmark/*.md
 src/.DS_Store
-/Manifest.toml
+Manifest.toml
 .DS_Store
 build


### PR DESCRIPTION
This ignores `docs/Manifest.toml` as well