### PR TITLE
checkindex `BlockedUnitRange` with `BlockIndex`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BlockArrays"
 uuid = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
-version = "0.16.23"
+version = "0.16.24"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/blockaxis.jl
+++ b/src/blockaxis.jl
@@ -253,6 +253,13 @@ Base.dataids(b::BlockedUnitRange) = Base.dataids(blocklasts(b))
 Base.checkindex(::Type{Bool}, b::BlockRange, K::Int) = checkindex(Bool, Int.(b), K)
 Base.checkindex(::Type{Bool}, b::AbstractUnitRange{Int}, K::Block{1}) = checkindex(Bool, blockaxes(b,1), Int(K))
 
+function Base.checkindex(::Type{Bool}, axis::BlockedUnitRange, ind::BlockIndexRange{1})
+    checkindex(Bool, axis, first(ind)) && checkindex(Bool, axis, last(ind))
+end
+function Base.checkindex(::Type{Bool}, axis::BlockedUnitRange, ind::BlockIndex{1})
+    checkindex(Bool, axis, block(ind)) && checkbounds(Bool, axis[block(ind)], blockindex(ind))
+end
+
 function getindex(b::AbstractUnitRange{Int}, K::Block{1})
     @boundscheck K == Block(1) || throw(BlockBoundsError(b, K))
     b

--- a/test/test_blockindices.jl
+++ b/test/test_blockindices.jl
@@ -296,10 +296,32 @@ end
         @test checkindex(Bool, b, Block(1))
         @test checkindex(Bool, b, Block(3))
         @test !checkindex(Bool, b, Block(4))
+        # treat b as the array, and check against the axis of b
         @test checkbounds(Bool, b, Block(1)[1])
+        @test checkbounds(Bool, b, Block(1)[1:1])
         @test !checkbounds(Bool, b, Block(1)[2])
+        @test checkbounds(Bool, b, Block(2)[1])
+        @test checkbounds(Bool, b, Block(2)[1:2])
+        @test !checkbounds(Bool, b, Block(2)[3])
+        @test checkbounds(Bool, b, Block(3)[1])
+        @test checkbounds(Bool, b, Block(3)[3])
+        @test checkbounds(Bool, b, Block(3)[1:3])
+        @test !checkbounds(Bool, b, Block(3)[4])
         @test !checkbounds(Bool, b, Block(0)[1])
         @test !checkbounds(Bool, b, Block(1)[0])
+        # treat b as the axis
+        @test checkindex(Bool, b, Block(1)[1])
+        @test checkindex(Bool, b, Block(1)[1:1])
+        @test !checkindex(Bool, b, Block(1)[2])
+        @test checkindex(Bool, b, Block(2)[1])
+        @test checkindex(Bool, b, Block(2)[1:2])
+        @test !checkindex(Bool, b, Block(2)[3])
+        @test checkindex(Bool, b, Block(3)[1])
+        @test checkindex(Bool, b, Block(3)[3])
+        @test checkindex(Bool, b, Block(3)[1:3])
+        @test !checkindex(Bool, b, Block(3)[4])
+        @test !checkindex(Bool, b, Block(0)[1])
+        @test !checkindex(Bool, b, Block(1)[0])
     end
 
     @testset "Slice" begin


### PR DESCRIPTION
This fixes an error that came up in my real-world code

```julia
julia> using BlockArrays, BlockBandedMatrices, FillArrays, StructArrays

julia> blockbandedzero(rows, cols, (l, u)) = BlockBandedMatrix(Zeros(sum(rows), sum(cols)), rows, cols, (l,u));

julia> blockdiagzero(rows, cols) = blockbandedzero(rows, cols, (0, 0));

julia> function allocate_block_matrix(nvariables, bandwidth, rows, cols = rows)
    l,u = bandwidth, bandwidth # block bandwidths
    mortar(reshape(
            [blockbandedzero(rows, cols, (l,u)) for _ in 1:nvariables^2],
                nvariables, nvariables))
end;

julia> nvariables = 3; bandwidth = 2; rows = Fill(2, 2);

julia> R = allocate_block_matrix(nvariables, bandwidth, rows);

julia> S = StructArray{ComplexF64}((R,R));

julia> real(S)
ERROR: ArgumentError: unable to check bounds for indices of type BlockIndex{1}
Stacktrace:
  [1] checkindex(#unused#::Type{Bool}, inds::BlockedUnitRange{Vector{Int64}}, i::BlockIndex{1})
    @ Base ~/packages/julias/julia-1.9/share/julia/base/abstractarray.jl:766
  [2] checkindex
    @ ./abstractarray.jl:781 [inlined]
  [3] checkbounds_indices
    @ ./abstractarray.jl:735 [inlined]
  [4] checkbounds
    @ ./abstractarray.jl:688 [inlined]
  [5] checkbounds
    @ ./abstractarray.jl:709 [inlined]
  [6] view
    @ ~/Dropbox/JuliaPackages/StructArrays.jl/src/structarray.jl:362 [inlined]
  [7] _bview
    @ ~/.julia/packages/BlockArrays/ZIuFR/src/blockbroadcast.jl:142 [inlined]
  [8] macro expansion
    @ ~/.julia/packages/BlockArrays/ZIuFR/src/blockbroadcast.jl:172 [inlined]
  [9] _generic_blockbroadcast_copyto!(dest::BlockMatrix{Float64, Matrix{Matrix{Float64}}, Tuple{BlockedUnitRange{Vector{Int64}}, BlockedUnitRange{Vector{Int64}}}}, bc::Base.Broadcast.Broadcasted{BlockArrays.BlockStyle{2}, Tuple{BlockedUnitRange{Vector{Int64}}, BlockedUnitRange{Vector{Int64}}}, typeof(real), Tuple{StructArray{ComplexF64, 2, NamedTuple{(:re, :im), Tuple{BlockMatrix{Float64, Matrix{BlockBandedMatrix{Float64}}, Tuple{BlockedUnitRange{Vector{Int64}}, BlockedUnitRange{Vector{Int64}}}}, BlockMatrix{Float64, Matrix{BlockBandedMatrix{Float64}}, Tuple{BlockedUnitRange{Vector{Int64}}, BlockedUnitRange{Vector{Int64}}}}}}, CartesianIndex{2}}}})
    @ BlockArrays ~/.julia/packages/BlockArrays/ZIuFR/src/blockbroadcast.jl:148
 [10] copyto!
    @ ~/.julia/packages/BlockArrays/ZIuFR/src/blockbroadcast.jl:190 [inlined]
 [11] copyto!
    @ ~/.julia/packages/StructArrays/F5fDf/src/structarray.jl:535 [inlined]
 [12] copy
    @ ./broadcast.jl:898 [inlined]
 [13] materialize
    @ ./broadcast.jl:873 [inlined]
 [14] broadcast_preserving_zero_d
    @ ./broadcast.jl:862 [inlined]
 [15] real(A::StructArray{ComplexF64, 2, NamedTuple{(:re, :im), Tuple{BlockMatrix{Float64, Matrix{BlockBandedMatrix{Float64}}, Tuple{BlockedUnitRange{Vector{Int64}}, BlockedUnitRange{Vector{Int64}}}}, BlockMatrix{Float64, Matrix{BlockBandedMatrix{Float64}}, Tuple{BlockedUnitRange{Vector{Int64}}, BlockedUnitRange{Vector{Int64}}}}}}, CartesianIndex{2}})
    @ Base ./abstractarraymath.jl:170
 [16] top-level scope
    @ REPL[207]:1
```