### PR TITLE
Compact show for `BlockRange`

### DIFF
--- a/src/blockaxis.jl
+++ b/src/blockaxis.jl
@@ -109,8 +109,11 @@ julia> A = BlockArray([1,2,3],[2,1])
  ─
  3
 
-julia> blockaxes(A)[1]
-2-element BlockRange{1, Tuple{Base.OneTo{Int64}}}:
+julia> blockaxes(A) # returns a tuple of ranges of blocks
+(BlockRange(Base.OneTo(2)),)
+
+julia> collect(blockaxes(A)[1])
+2-element Vector{Block{1, Int64}}:
  Block(1)
  Block(2)
 ```
@@ -132,8 +135,11 @@ julia> A = BlockArray([1,2,3],[2,1])
  ─
  3
 
-julia> blockaxes(A,1)
-2-element BlockRange{1, Tuple{Base.OneTo{Int64}}}:
+julia> blockaxes(A,1) # returns a range of blocks
+BlockRange(Base.OneTo(2))
+
+julia> collect(blockaxes(A,1))
+2-element Vector{Block{1, Int64}}:
  Block(1)
  Block(2)
 ```

--- a/src/blockaxis.jl
+++ b/src/blockaxis.jl
@@ -29,7 +29,7 @@ function _BlockedUnitRange end
 
 is an `AbstractUnitRange{Int}` that has been divided
 into blocks, and is used to represent axes of block arrays.
-Construction is typically via `blockrange` which converts
+Construction is typically via `blockedrange` which converts
 a vector of block lengths to a `BlockedUnitRange`.
 ```jldoctest; setup = quote using BlockArrays end
 julia> blockedrange([2,2,3])

--- a/src/blockindices.jl
+++ b/src/blockindices.jl
@@ -99,15 +99,6 @@ Int(index::Block{1}) = Int(index.n[1])
 Integer(index::Block{1}) = index.n[1]
 Number(index::Block{1}) = index.n[1]
 
-# print
-Base.show(io::IO, B::Block{0,Int}) = print(io, "Block()")
-function Base.show(io::IO, B::Block{N,Int}) where N
-    print(io, "Block($(B.n[1])")
-    for n in Base.tail(B.n)
-        print(io, ", $n")
-    end
-    print(io, ")")
-end
 
 """
     BlockIndex{N}
@@ -164,15 +155,6 @@ block(b::BlockIndex) = Block(b.I...)
 blockindex(b::BlockIndex{1}) = b.α[1]
 
 BlockIndex(indcs::NTuple{N,BlockIndex{1}}) where N = BlockIndex(block.(indcs), blockindex.(indcs))
-
-function Base.show(io::IO, B::BlockIndex)
-    show(io, Block(B.I...))
-    print(io, "[$(B.α[1])")
-    for α in Base.tail(B.α)
-        print(io, ", $α")
-    end
-    print(io, "]")
-end
 
 ##
 # checkindex
@@ -244,17 +226,6 @@ length(iter::BlockIndexRange) = prod(size(iter))
 
 Block(bs::BlockIndexRange) = bs.block
 
-function Base.show(io::IO, B::BlockIndexRange)
-    show(io, Block(B))
-    print(io, "[")
-    show(io, B.indices[1])
-    for α in Base.tail(B.indices)
-        print(io, ", ")
-        show(io, α)
-    end
-    print(io, "]")
-end
-
 
 # #################
 # # support for pointers
@@ -292,7 +263,6 @@ end
 getindex(S::BlockSlice, i::Integer) = getindex(S.indices, i)
 getindex(S::BlockSlice{<:Block}, k::AbstractUnitRange{Int}) = BlockSlice(S.block[k],S.indices[k])
 getindex(S::BlockSlice{<:BlockIndexRange}, k::AbstractUnitRange{Int}) = BlockSlice(S.block[k],S.indices[k])
-show(io::IO, r::BlockSlice) = print(io, "BlockSlice(", r.block, ",", r.indices, ")")
 
 Block(bs::BlockSlice{<:BlockIndexRange}) = Block(bs.block)
 
@@ -332,7 +302,6 @@ broadcasted(::DefaultArrayStyle{0}, ::Type{Int}, block::Block{1}) = Int(block)
 
 # AbstractArray implementation
 axes(iter::BlockRange{N,R}) where {N,R} = map(axes1, iter.indices)
-Base.IndexStyle(::Type{BlockRange{N,R}}) where {N,R} = IndexCartesian()
 @inline function Base.getindex(iter::BlockRange{N,<:NTuple{N,Base.OneTo}}, I::Vararg{Integer, N}) where {N}
     @boundscheck checkbounds(iter, I...)
     Block(I)
@@ -386,8 +355,6 @@ _in(b, ::Tuple{}, ::Tuple{}, ::Tuple{}) = b
 
 # We sometimes need intersection of BlockRange to return a BlockRange
 intersect(a::BlockRange{1}, b::BlockRange{1}) = BlockRange(intersect(a.indices[1], b.indices[1]))
-
-Base.show(io::IO, br::BlockRange) = print(io, "BlockRange(", br.indices..., ")")
 
 # needed for scalar-like broadcasting
 

--- a/src/blocks.jl
+++ b/src/blocks.jl
@@ -90,14 +90,3 @@ This is broken for now. See: https://github.com/JuliaArrays/BlockArrays.jl/issue
     view(a.array, Block.(i)...)
 @propagate_inbounds Base.setindex!(a::BlocksView{T,N}, b, i::Vararg{Int,N}) where {T,N} =
     copyto!(a[i...], b)
-
-function Base.showarg(io::IO, a::BlocksView, toplevel::Bool)
-    if toplevel
-        print(io, "blocks of ")
-        Base.showarg(io, a.array, true)
-    else
-        print(io, "::BlocksView{…,")
-        Base.showarg(io, a.array, false)
-        print(io, '}')
-    end
-end

--- a/src/pseudo_blockarray.jl
+++ b/src/pseudo_blockarray.jl
@@ -248,16 +248,6 @@ Base.reshape(parent::PseudoBlockArray, shp::Tuple{Union{Integer,Base.OneTo}, Var
 Base.reshape(parent::PseudoBlockArray, dims::Tuple{Int,Vararg{Int}}) =
     Base._reshape(parent, dims)
 
-function Base.showarg(io::IO, A::PseudoBlockArray, toplevel::Bool)
-    if toplevel
-        print(io, "PseudoBlockArray of ")
-        Base.showarg(io, A.blocks, true)
-    else
-        print(io, "::PseudoBlockArray{…,")
-        Base.showarg(io, A.blocks, false)
-        print(io, '}')
-    end
-end
 """
 resize!(a::PseudoBlockVector, N::Block) -> PseudoBlockVector
 

--- a/src/show.jl
+++ b/src/show.jl
@@ -192,6 +192,7 @@ function Base.show(io::IO, B::BlockIndexRange)
     print_tuple_elements(io, B.indices)
     print(io, "]")
 end
+Base.show(io::IO, ::MIME"text/plain", B::BlockIndexRange) = show(io, B)
 
 Base.show(io::IO, mimetype::MIME"text/plain", a::BlockedUnitRange) =
     Base.invoke(show, Tuple{typeof(io),MIME"text/plain",AbstractArray},io, mimetype, a)

--- a/src/show.jl
+++ b/src/show.jl
@@ -156,18 +156,23 @@ end
 
 # Utility function to print elements of tuples as a comma-separated list
 function print_tuple_elements(io::IO, @nospecialize(t))
-    print(io, t[1])
-    for n in t[2:end]
-        print(io, ", ", n)
+    if !isempty(t)
+        print(io, t[1])
+        for n in t[2:end]
+            print(io, ", ", n)
+        end
     end
+    return nothing
 end
 
 # Block
 
-Base.show(io::IO, B::Block{0,Int}) = print(io, "Block()")
+_typename(::Block{N,Int}) where {N} = "Block"
+_typename(x::Block) = typeof(x)
 
-function Base.show(io::IO, B::Block{N,Int}) where N
-    print(io, "Block(")
+function Base.show(io::IO, B::Block)
+    print(_typename(B))
+    print(io, "(")
     print_tuple_elements(io, B.n)
     print(io, ")")
 end
@@ -204,7 +209,6 @@ function Base.showarg(io::IO, @nospecialize(a::BlocksView), toplevel::Bool)
     end
 end
 
-show(io::IO, ::BlockRange{0}) = print(io, "BlockRange()")
 function show(io::IO, r::BlockRange)
     print(io, "BlockRange(")
     print_tuple_elements(io, r.indices)

--- a/src/show.jl
+++ b/src/show.jl
@@ -143,7 +143,73 @@ function _show_typeof(io::IO, a::PseudoBlockArray{T,N,Array{T,N},NTuple{N,Defaul
     print(io, '}')
 end
 
-## Cumsum
+function Base.showarg(io::IO, A::PseudoBlockArray, toplevel::Bool)
+    if toplevel
+        print(io, "PseudoBlockArray of ")
+        Base.showarg(io, A.blocks, true)
+    else
+        print(io, "::PseudoBlockArray{…,")
+        Base.showarg(io, A.blocks, false)
+        print(io, '}')
+    end
+end
+
+# Utility function to print elements of tuples as a comma-separated list
+function print_tuple_elements(io::IO, @nospecialize(t))
+    print(io, t[1])
+    for n in t[2:end]
+        print(io, ", ", n)
+    end
+end
+
+# Block
+
+Base.show(io::IO, B::Block{0,Int}) = print(io, "Block()")
+
+function Base.show(io::IO, B::Block{N,Int}) where N
+    print(io, "Block(")
+    print_tuple_elements(io, B.n)
+    print(io, ")")
+end
+
+# Block indices
+
+function Base.show(io::IO, B::BlockIndex)
+    show(io, Block(B.I...))
+    print(io, "[")
+    print_tuple_elements(io, B.α)
+    print(io, "]")
+end
+
+function Base.show(io::IO, B::BlockIndexRange)
+    show(io, Block(B))
+    print(io, "[")
+    print_tuple_elements(io, B.indices)
+    print(io, "]")
+end
 
 Base.show(io::IO, mimetype::MIME"text/plain", a::BlockedUnitRange) =
     Base.invoke(show, Tuple{typeof(io),MIME"text/plain",AbstractArray},io, mimetype, a)
+
+show(io::IO, r::BlockSlice) = print(io, "BlockSlice(", r.block, ",", r.indices, ")")
+
+function Base.showarg(io::IO, @nospecialize(a::BlocksView), toplevel::Bool)
+    if toplevel
+        print(io, "blocks of ")
+        Base.showarg(io, a.array, true)
+    else
+        print(io, "::BlocksView{…,")
+        Base.showarg(io, a.array, false)
+        print(io, '}')
+    end
+end
+
+show(io::IO, ::BlockRange{0}) = print(io, "BlockRange()")
+function show(io::IO, r::BlockRange)
+    print(io, "BlockRange(")
+    print_tuple_elements(io, r.indices)
+    print(io, ")")
+end
+function show(io::IO, ::MIME"text/plain", @nospecialize(r::BlockRange))
+    show(io, r)
+end

--- a/src/show.jl
+++ b/src/show.jl
@@ -171,7 +171,7 @@ _typename(::Block{N,Int}) where {N} = "Block"
 _typename(x::Block) = typeof(x)
 
 function Base.show(io::IO, B::Block)
-    print(_typename(B))
+    print(io, _typename(B))
     print(io, "(")
     print_tuple_elements(io, B.n)
     print(io, ")")

--- a/test/test_blockindices.jl
+++ b/test/test_blockindices.jl
@@ -108,7 +108,7 @@ import BlockArrays: BlockIndex, BlockIndexRange, BlockSlice
         @test stringmime("text/plain", Block{2}(1,2)) == "Block(1, 2)"
 
         @test stringmime("text/plain", BlockIndex((1,2), (3,4))) == "Block(1, 2)[3, 4]"
-        @test repr(BlockArrays.BlockIndexRange(Block(1), 3:4)) == "Block(1)[3:4]"
+        @test stringmime("text/plain", BlockArrays.BlockIndexRange(Block(1), 3:4)) == "Block(1)[3:4]"
 
         @test stringmime("text/plain", BlockRange()) == "BlockRange()"
         @test stringmime("text/plain", BlockRange(1:2)) == "BlockRange(1:2)"

--- a/test/test_blockindices.jl
+++ b/test/test_blockindices.jl
@@ -106,6 +106,10 @@ import BlockArrays: BlockIndex, BlockIndexRange, BlockSlice
         @test stringmime("text/plain", Block{0,BigInt}()) == "Block{0, BigInt}(())"
         @test stringmime("text/plain", Block{1,BigInt}(1)) == "Block{1, BigInt}((1,))"
         @test stringmime("text/plain", Block{2}(1,2)) == "Block(1, 2)"
+
+        @test stringmime("text/plain", BlockRange()) == "BlockRange()"
+        @test stringmime("text/plain", BlockRange(1:2)) == "BlockRange(1:2)"
+        @test stringmime("text/plain", BlockRange(1:2, 2:3)) == "BlockRange(1:2, 2:3)"
     end
 end
 

--- a/test/test_blockindices.jl
+++ b/test/test_blockindices.jl
@@ -103,8 +103,8 @@ import BlockArrays: BlockIndex, BlockIndexRange, BlockSlice
         @test stringmime("text/plain", Block{1}(1)) == "Block(1)"
         @test stringmime("text/plain", Block{2}(1,2)) == "Block(1, 2)"
 
-        @test stringmime("text/plain", Block{0,BigInt}()) == "Block{0, BigInt}(())"
-        @test stringmime("text/plain", Block{1,BigInt}(1)) == "Block{1, BigInt}((1,))"
+        @test stringmime("text/plain", Block{0,BigInt}()) == "Block{0, BigInt}()"
+        @test stringmime("text/plain", Block{1,BigInt}(1)) == "Block{1, BigInt}(1)"
         @test stringmime("text/plain", Block{2}(1,2)) == "Block(1, 2)"
 
         @test stringmime("text/plain", BlockRange()) == "BlockRange()"

--- a/test/test_blockindices.jl
+++ b/test/test_blockindices.jl
@@ -107,6 +107,9 @@ import BlockArrays: BlockIndex, BlockIndexRange, BlockSlice
         @test stringmime("text/plain", Block{1,BigInt}(1)) == "Block{1, BigInt}(1)"
         @test stringmime("text/plain", Block{2}(1,2)) == "Block(1, 2)"
 
+        @test stringmime("text/plain", BlockIndex((1,2), (3,4))) == "Block(1, 2)[3, 4]"
+        @test repr(BlockArrays.BlockIndexRange(Block(1), 3:4)) == "Block(1)[3:4]"
+
         @test stringmime("text/plain", BlockRange()) == "BlockRange()"
         @test stringmime("text/plain", BlockRange(1:2)) == "BlockRange(1:2)"
         @test stringmime("text/plain", BlockRange(1:2, 2:3)) == "BlockRange(1:2, 2:3)"


### PR DESCRIPTION
After this PR
```julia
julia> Block(1):Block(4)
BlockRange(1:4)
```
This makes it more clear that the result is a range, and it's similar to how `CartesianIndices` is displayed.
This PR also removes the `IndexStyle` specialization for `BlockRange`, as the fallback is `IndexCartesian` by default.
It also moves the various `show` methods scattered around to `show.jl`.
Also, fixes a typo in the docstring of `BlockedUnitRange`.