### PR TITLE
Don't specialize IndexStyle for AbstractBlockArray

### DIFF
--- a/src/abstractblockarray.jl
+++ b/src/abstractblockarray.jl
@@ -40,11 +40,9 @@ Base.similar(a::AbstractBlockArray{T}, dims::Tuple) where {T}                = s
 # If all we know is size, just return an Array which conforms to BlockArray interface
 Base.similar(::Type{<:AbstractBlockArray{T,N}}, dims::Dims) where {T,N} = similar(Array{T,N}, dims)
 
-Base.IndexStyle(::Type{<:AbstractBlockArray}) = IndexCartesian()
-
 # need to overload axes to return BlockAxis
 @inline size(block_array::AbstractBlockArray) = map(length, axes(block_array))
-@inline axes(block_array::AbstractBlockArray) = throw(error("axes for ", typeof(block_array), " is not implemented"))
+@noinline axes(block_array::AbstractBlockArray) = throw(error("axes for ", typeof(block_array), " is not implemented"))
 
 
 """

--- a/src/abstractblockarray.jl
+++ b/src/abstractblockarray.jl
@@ -42,7 +42,7 @@ Base.similar(::Type{<:AbstractBlockArray{T,N}}, dims::Dims) where {T,N} = simila
 
 # need to overload axes to return BlockAxis
 @inline size(block_array::AbstractBlockArray) = map(length, axes(block_array))
-@noinline axes(block_array::AbstractBlockArray) = throw(error("axes for ", typeof(block_array), " is not implemented"))
+@noinline axes(block_array::AbstractBlockArray) = throw(ArgumentError("axes for $(typeof(block_array)) is not implemented"))
 
 
 """

--- a/test/test_blockarrayinterface.jl
+++ b/test/test_blockarrayinterface.jl
@@ -3,6 +3,10 @@ using BlockArrays, LinearAlgebra, FillArrays, Base64, Test
 # avoid fast-paths for view
 bview(a, b) = Base.invoke(view, Tuple{AbstractArray,Any}, a, b)
 
+@testset "missing fallback block axes" begin
+    @test_throws ArgumentError invoke(axes, Tuple{AbstractBlockArray}, PseudoBlockArray{ComplexF64}(undef, (1:4), (2:5)))
+end
+
 @testset "Array block interface" begin
     @test 1[Block()] == 1
 


### PR DESCRIPTION
This is unnecessary, as the fallback is `IndexCartesian()` anyway.
Also, don't inline an error path.