### PR TITLE
Remove explicit test on v1.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,6 @@ jobs:
         version:
           - '1.6'
           - '1'
-          - '^1.9.0-0'
         os:
           - ubuntu-latest
           - macOS-latest


### PR DESCRIPTION
This is unnecessary now, given that v1 points to v1.9