### PR TITLE
Matrix-vector multiplication for compatible block sizes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BlockArrays"
 uuid = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
-version = "0.16.28"
+version = "0.16.29"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/BlockArrays.jl
+++ b/src/BlockArrays.jl
@@ -39,7 +39,7 @@ import Base: (:), IteratorSize, iterate, axes1, strides, isempty
 import Base.Broadcast: broadcasted, DefaultArrayStyle, AbstractArrayStyle, Broadcasted, broadcastable
 import LinearAlgebra: lmul!, rmul!, AbstractTriangular, HermOrSym, AdjOrTrans,
                         StructuredMatrixStyle, cholesky, cholesky!, cholcopy, RealHermSymComplexHerm
-import ArrayLayouts: _fill_lmul!, MatMulVecAdd, MatMulMatAdd, MatLmulVec, MatLdivVec,
+import ArrayLayouts: _fill_lmul!, MatMulVecAdd, MatMulMatAdd, MatLmulVec, MatLdivVec, MulAdd,
                         materialize!, MemoryLayout, sublayout, transposelayout, conjlayout,
                         triangularlayout, triangulardata, _inv, _copyto!, axes_print_matrix_row,
                         colsupport, rowsupport, sub_materialize, zero!

--- a/src/BlockArrays.jl
+++ b/src/BlockArrays.jl
@@ -39,7 +39,7 @@ import Base: (:), IteratorSize, iterate, axes1, strides, isempty
 import Base.Broadcast: broadcasted, DefaultArrayStyle, AbstractArrayStyle, Broadcasted, broadcastable
 import LinearAlgebra: lmul!, rmul!, AbstractTriangular, HermOrSym, AdjOrTrans,
                         StructuredMatrixStyle, cholesky, cholesky!, cholcopy, RealHermSymComplexHerm
-import ArrayLayouts: _fill_lmul!, MatMulVecAdd, MatMulMatAdd, MatLmulVec, MatLdivVec, MulAdd,
+import ArrayLayouts: _fill_lmul!, MatMulVecAdd, MatMulMatAdd, MatLmulVec, MatLdivVec,
                         materialize!, MemoryLayout, sublayout, transposelayout, conjlayout,
                         triangularlayout, triangulardata, _inv, _copyto!, axes_print_matrix_row,
                         colsupport, rowsupport, sub_materialize, zero!

--- a/src/blocklinalg.jl
+++ b/src/blocklinalg.jl
@@ -199,6 +199,14 @@ function materialize!(M::MatMulVecAdd{<:AbstractBlockLayout,<:AbstractStridedLay
     y_in
 end
 
+function _block_muladd!(α, A, X::AbstractVector, β, Y::AbstractVector)
+    _fill_lmul!(β, Y)
+    for N = blockcolsupport(X), K = blockcolsupport(A,N)
+        muladd!(α, view(A,K,N), view(X,N), one(α), view(Y,K))
+    end
+    Y
+end
+
 function _block_muladd!(α, A, X, β, Y)
     _fill_lmul!(β, Y)
     for J = blockaxes(X,2), N = blockcolsupport(X,J), K = blockcolsupport(A,N)

--- a/src/blocklinalg.jl
+++ b/src/blocklinalg.jl
@@ -202,7 +202,7 @@ end
 @inline function _block_muladd!(α, A, X::AbstractVector, β, Y::AbstractVector)
     _fill_lmul!(β, Y)
     for N = blockcolsupport(X), K = blockcolsupport(A,N)
-        muladd!(α, view(A,K,N), view(X,N), one(α), view(Y,K))
+        mul!(view(Y,K), view(A,K,N), view(X,N), α, one(β))
     end
     Y
 end
@@ -210,7 +210,7 @@ end
 @inline function _block_muladd!(α, A, X, β, Y)
     _fill_lmul!(β, Y)
     for J = blockaxes(X,2), N = blockcolsupport(X,J), K = blockcolsupport(A,N)
-        muladd!(α, view(A,K,N), view(X,N,J), one(α), view(Y,K,J))
+        mul!(view(Y,K,J), view(A,K,N), view(X,N,J), α, one(α))
     end
     Y
 end

--- a/src/blocklinalg.jl
+++ b/src/blocklinalg.jl
@@ -199,7 +199,7 @@ function materialize!(M::MatMulVecAdd{<:AbstractBlockLayout,<:AbstractStridedLay
     y_in
 end
 
-function _block_muladd!(α, A, X::AbstractVector, β, Y::AbstractVector)
+@inline function _block_muladd!(α, A, X::AbstractVector, β, Y::AbstractVector)
     _fill_lmul!(β, Y)
     for N = blockcolsupport(X), K = blockcolsupport(A,N)
         muladd!(α, view(A,K,N), view(X,N), one(α), view(Y,K))
@@ -207,7 +207,7 @@ function _block_muladd!(α, A, X::AbstractVector, β, Y::AbstractVector)
     Y
 end
 
-function _block_muladd!(α, A, X, β, Y)
+@inline function _block_muladd!(α, A, X, β, Y)
     _fill_lmul!(β, Y)
     for J = blockaxes(X,2), N = blockcolsupport(X,J), K = blockcolsupport(A,N)
         muladd!(α, view(A,K,N), view(X,N,J), one(α), view(Y,K,J))
@@ -232,8 +232,7 @@ function materialize!(M::MatMulMatAdd{<:AbstractBlockLayout,<:AbstractBlockLayou
     _matmul(M)
 end
 
-function materialize!(M::MulAdd{<:AbstractBlockLayout, <:AbstractBlockLayout, <:AbstractBlockLayout,
-        <:Any, <:AbstractMatrix, <:AbstractVector, <:AbstractVector})
+function materialize!(M::MatMulVecAdd{<:AbstractBlockLayout, <:AbstractBlockLayout, <:AbstractBlockLayout})
     _matmul(M)
 end
 

--- a/src/blocklinalg.jl
+++ b/src/blocklinalg.jl
@@ -211,13 +211,22 @@ mul_blockscompatible(A, B, C) = blockisequal(axes(A,2), axes(B,1)) &&
     blockisequal(axes(A,1), axes(C,1)) &&
     blockisequal(axes(B,2), axes(C,2))
 
-function materialize!(M::MatMulMatAdd{<:AbstractBlockLayout,<:AbstractBlockLayout,<:AbstractBlockLayout})
+@inline function _matmul(M)
     α, A, B, β, C = M.α, M.A, M.B, M.β, M.C
     if mul_blockscompatible(A,B,C)
         _block_muladd!(α, A, B, β, C)
     else # use default
         materialize!(MulAdd{UnknownLayout,UnknownLayout,UnknownLayout}(α, A, B, β, C))
     end
+end
+
+function materialize!(M::MatMulMatAdd{<:AbstractBlockLayout,<:AbstractBlockLayout,<:AbstractBlockLayout})
+    _matmul(M)
+end
+
+function materialize!(M::MulAdd{<:AbstractBlockLayout, <:AbstractBlockLayout, <:AbstractBlockLayout,
+        <:Any, <:AbstractMatrix, <:AbstractVector, <:AbstractVector})
+    _matmul(M)
 end
 
 function materialize!(M::MatMulMatAdd{<:AbstractBlockLayout,<:AbstractBlockLayout,<:AbstractColumnMajor})

--- a/test/test_blocklinalg.jl
+++ b/test/test_blocklinalg.jl
@@ -92,6 +92,20 @@ import ArrayLayouts: DenseRowMajor, ColumnMajor, StridedLayout
                     Matrix(A)*PseudoBlockArray(B) .=== Matrix(A)*Matrix(B))
     end
 
+    @testset "BlockMatrix * BlockVector" begin
+        A = BlockArray(randn(6,6), fill(2,3), 1:3)
+        v = BlockArray(rand(6), 1:3)
+        w = A * v
+        @test w isa BlockArray
+        @test blocksizes(w,1) == fill(2, 3)
+        @test w ≈ Array(A) * v ≈ A * Array(v) ≈ Array(A) * Array(v)
+
+        z = A * w
+        @test z isa BlockArray
+        @test blocksizes(z,1) == fill(2, 3)
+        @test z ≈ Array(A) * w ≈ A * Array(w) ≈ Array(A) * Array(w)
+    end
+
     @testset "adjoint" begin
         A = BlockArray(randn(6,6), fill(2,3), 1:3)
         B = BlockArray(randn(6,6), 1:3, 1:3)


### PR DESCRIPTION
On master
```julia
julia> A = BlockArray(randn(1000,1000), fill(100,10), fill(100,10));

julia> v = BlockArray(rand(1000), fill(100,10));

julia> @btime $A * $v;
  26.571 ms (1012 allocations: 149.64 KiB)
```
This PR
```julia
julia> @btime $A * $v;
  408.885 μs (12 allocations: 8.94 KiB)
```

Edit: this also fixes #220 after [b479605](https://github.com/JuliaArrays/BlockArrays.jl/pull/262/commits/b47960504855a503d355ad8e597bfcfe979a86fa), and we have
```julia
julia> N = 10000; M = 2;

julia> A = BlockArray(sprand(Float64,N + M, N + M, 0.1), [N, M], [N, M]);

julia> SA = sparse(A);

julia> b = BlockVector(rand(Float64,N + M), [N, M]);

julia> v = Vector(b);

julia> A * b ≈ SA * v
true

julia> @time A * b;
  0.016005 seconds (6 allocations: 78.406 KiB)

julia> @time SA * v;
  0.015974 seconds (2 allocations: 78.234 KiB)
```