### PR TITLE
Construct PseudoBlockVector/Matrix from arrays

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BlockArrays"
 uuid = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
-version = "0.16.29"
+version = "0.16.30"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/pseudo_blockarray.jl
+++ b/src/pseudo_blockarray.jl
@@ -129,10 +129,8 @@ convert(::Type{AbstractArray}, A::PseudoBlockArray) = A
 PseudoBlockArray{T, N}(A::AbstractArray{T2, N}) where {T,T2,N} =
     PseudoBlockArray(Array{T, N}(A), axes(A))
 PseudoBlockArray{T1}(A::AbstractArray{T2, N}) where {T1,T2,N} = PseudoBlockArray{T1, N}(A)
+PseudoBlockArray{<:Any,N}(A::AbstractArray{T, N}) where {T,N} = PseudoBlockArray{T, N}(A)
 PseudoBlockArray(A::AbstractArray{T, N}) where {T,N} = PseudoBlockArray{T, N}(A)
-
-PseudoBlockMatrix(A::AbstractMatrix{T}) where {T} = PseudoBlockMatrix{T}(A)
-PseudoBlockVector(A::AbstractVector{T}) where {T} = PseudoBlockVector{T}(A)
 
 convert(::Type{PseudoBlockArray{T, N}}, A::AbstractArray{T2, N}) where {T,T2,N} =
     PseudoBlockArray(convert(Array{T, N}, A), axes(A))

--- a/src/pseudo_blockarray.jl
+++ b/src/pseudo_blockarray.jl
@@ -131,6 +131,9 @@ PseudoBlockArray{T, N}(A::AbstractArray{T2, N}) where {T,T2,N} =
 PseudoBlockArray{T1}(A::AbstractArray{T2, N}) where {T1,T2,N} = PseudoBlockArray{T1, N}(A)
 PseudoBlockArray(A::AbstractArray{T, N}) where {T,N} = PseudoBlockArray{T, N}(A)
 
+PseudoBlockMatrix(A::AbstractMatrix{T}) where {T} = PseudoBlockMatrix{T}(A)
+PseudoBlockVector(A::AbstractVector{T}) where {T} = PseudoBlockVector{T}(A)
+
 convert(::Type{PseudoBlockArray{T, N}}, A::AbstractArray{T2, N}) where {T,T2,N} =
     PseudoBlockArray(convert(Array{T, N}, A), axes(A))
 convert(::Type{PseudoBlockArray{T1}}, A::AbstractArray{T2, N}) where {T1,T2,N} =

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -94,6 +94,15 @@ end
             @test A == PseudoBlockArray(A, 1:3) == PseudoBlockArray{Int}(A, 1:3) ==
                 PseudoBlockArray(A, (blockedrange(1:3),)) == PseudoBlockArray{Int}(A, (blockedrange(1:3),)) ==
                 PseudoBlockArray{Float64}(A, 1:3)
+
+            @testset "from arrays" begin
+                v = [1,2,3]
+                @test PseudoBlockVector(v) == v
+                @test PseudoBlockArray(v) == v
+                M = [1 2; 3 4]
+                @test PseudoBlockMatrix(M) == M
+                @test PseudoBlockArray(M) == M
+            end
         end
 
         @testset "similar" begin


### PR DESCRIPTION
On master
```julia
julia> M = [1 2; 3 4]
2×2 Matrix{Int64}:
 1  2
 3  4

julia> PseudoBlockArray(M)
1×1-blocked 2×2 PseudoBlockMatrix{Int64, Matrix{Int64}, Tuple{Base.OneTo{Int64}, Base.OneTo{Int64}}}:
 1  2
 3  4

julia> PseudoBlockMatrix(M)
ERROR: MethodError: no method matching (PseudoBlockMatrix{T} where T)(::Matrix{Int64})
```
After this PR,
```julia
julia> PseudoBlockMatrix(M)
1×1-blocked 2×2 PseudoBlockMatrix{Int64, Matrix{Int64}, Tuple{Base.OneTo{Int64}, Base.OneTo{Int64}}}:
 1  2
 3  4
```