### PR TITLE
improve type-stability in blocklengths

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BlockArrays"
 uuid = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
-version = "0.16.30"
+version = "0.16.31"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/blockaxis.jl
+++ b/src/blockaxis.jl
@@ -65,7 +65,7 @@ _blocklengths2blocklasts(blocks) = cumsum(blocks) # extra level to allow changin
 
 _diff(a::AbstractVector) = diff(a)
 _diff(a::Tuple) = diff(collect(a))
-@inline blocklengths(a::BlockedUnitRange) = isempty(a.lasts) ? _diff(a.lasts) : [first(a.lasts)-a.first+1; _diff(a.lasts)]
+@inline blocklengths(a::BlockedUnitRange) = isempty(a.lasts) ? [_diff(a.lasts);] : [first(a.lasts)-a.first+1; _diff(a.lasts)]
 
 length(a::BlockedUnitRange) = isempty(a.lasts) ? 0 : Integer(last(a.lasts)-a.first+1)
 

--- a/test/test_blockindices.jl
+++ b/test/test_blockindices.jl
@@ -171,6 +171,7 @@ end
         @test blocklengths(f) ≡ Fill(2,5)
 
         r = blockedrange(Base.OneTo(5))
+        @test (@inferred blocklengths(r)) == 1:5
         @test blocklasts(r) ≡ ArrayLayouts.RangeCumsum(Base.OneTo(5))
     end
 


### PR DESCRIPTION
This adds an allocation in the empty case, but that had a minimal impact (of the order of 30 ns). In the more common case, this doesn't change anything, but importantly, this makes the operation type-stable.