### PR TITLE
`oneunit` and `one`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BlockArrays"
 uuid = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
-version = "0.16.31"
+version = "0.16.32"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/BlockArrays.jl
+++ b/src/BlockArrays.jl
@@ -28,7 +28,7 @@ import Base: @propagate_inbounds, Array, to_indices, to_index,
             RangeIndex, Int, Integer, Number,
             +, -, *, /, \, min, max, isless, in, copy, copyto!, axes, @deprecate,
             BroadcastStyle, checkbounds, throw_boundserror,
-            ones, zeros, intersect, Slice, resize!
+            oneunit, ones, zeros, intersect, Slice, resize!
 using Base: ReshapedArray, dataids
 import Base: AbstractArray
 

--- a/src/blockindices.jl
+++ b/src/blockindices.jl
@@ -58,8 +58,6 @@ ndims(::Block) = 0
 eltype(::Type{B}) where B<:Block = B
 getindex(B::Block, ::CartesianIndex{0}) = B
 
-Base.oneunit(B::Block{N,T}) where {N,T} = Block(ntuple(_->oneunit(T), Val(N)))
-
 # The following code is taken from CartesianIndex
 @inline (+)(index::Block{N}) where {N} = Block{N}(map(+, index.n))
 @inline (-)(index::Block{N}) where {N} = Block{N}(map(-, index.n))
@@ -79,6 +77,9 @@ Base.oneunit(B::Block{N,T}) where {N,T} = Block(ntuple(_->oneunit(T), Val(N)))
 @inline (-)(i::Integer, index::Block{N}) where {N} = Block{N}(map(x->i-x, index.n))
 @inline (*)(a::Integer, index::Block{N}) where {N} = Block{N}(map(x->a*x, index.n))
 @inline (*)(index::Block, a::Integer) = *(a,index)
+
+Base.oneunit(B::Block{N,T}) where {N,T} = Block(ntuple(_->oneunit(T), Val(N)))
+Base.one(B::Block) = true
 
 # comparison
 # _isless copied from Base in Julia 1.7 since it was removed in 1.8.

--- a/src/blockindices.jl
+++ b/src/blockindices.jl
@@ -58,6 +58,8 @@ ndims(::Block) = 0
 eltype(::Type{B}) where B<:Block = B
 getindex(B::Block, ::CartesianIndex{0}) = B
 
+Base.oneunit(B::Block{N,T}) where {N,T} = Block(ntuple(_->oneunit(T), Val(N)))
+
 # The following code is taken from CartesianIndex
 @inline (+)(index::Block{N}) where {N} = Block{N}(map(+, index.n))
 @inline (-)(index::Block{N}) where {N} = Block{N}(map(-, index.n))

--- a/test/test_blockindices.jl
+++ b/test/test_blockindices.jl
@@ -54,6 +54,8 @@ import BlockArrays: BlockIndex, BlockIndexRange, BlockSlice
         @test 1 - Block(1,2) == Block(0,-1)
         @test 2*Block(1,2) == Block(2,4)
         @test Block(1,2)*2 == Block(2,4)
+        @test one(Block(1,2))*Block(1,2) == Block(1,2)
+        @test one(Block(1,2))*Block(Int8(1)) === Block(Int8(1))
 
         @test isless(Block(1,1), Block(2,2))
         @test isless(Block(1,1), Block(2,1))

--- a/test/test_blockindices.jl
+++ b/test/test_blockindices.jl
@@ -48,6 +48,7 @@ import BlockArrays: BlockIndex, BlockIndexRange, BlockSlice
         @test Block(1,2) + Block(2,3) == Block(3,5)
         @test Block(1,2) + 1 == Block(2,3)
         @test 1 + Block(1,2) == Block(2,3)
+        @test oneunit(Block(1,2)) + Block(1,2) == Block(2,3)
         @test Block(2,3) - Block(1,2) == Block(1,1)
         @test Block(1,2) - 1 == Block(0,1)
         @test 1 - Block(1,2) == Block(0,-1)


### PR DESCRIPTION
Since the following work,
```julia
julia> b = Block(1,2)
Block(1, 2)

julia> b + 1
Block(2, 3)

julia> b * 1
Block(1, 2)
```
it makes sense to define `one` and `oneunit` for `Block`s, such that
```julia
julia> b + oneunit(b)
Block(2, 3)

julia> b * one(b)
Block(1, 2)
```