### PR TITLE
Vector indexing for `BlockRange`

### DIFF
--- a/test/test_blockindices.jl
+++ b/test/test_blockindices.jl
@@ -156,6 +156,13 @@ end
         @test b[Block(100_000)] == 299_998:300_000
         @test_throws BlockBoundsError b[Block(0)]
         @test_throws BlockBoundsError b[Block(1_000_001)]
+
+        b = BlockRange((2:4, 3:4))
+        @test b[2,2] === Block(3,4)
+        @test b[axes(b)...] === b
+
+        b = BlockRange(OffsetArrays.IdOffsetRange.((2:4, 3:5), 2))
+        @test b[axes(b)...] === b
     end
 
     @testset "firsts/lasts/lengths" begin


### PR DESCRIPTION
This PR does not materialize the result if a `BlockRange` is indexed by a matching number of `AbstractUnitRange`s.

On master
```julia
julia> b = BlockRange((1:3,));

julia> b[1:3]
3-element Vector{Block{1, Int64}}:
 Block(1)
 Block(2)
 Block(3)
```
This PR
```julia
julia> b[1:3]
3-element BlockRange{1, Tuple{UnitRange{Int64}}}:
 Block(1)
 Block(2)
 Block(3)
```