### PR TITLE
Avoid ind2sub in view with Block{1}

### DIFF
--- a/src/abstractblockarray.jl
+++ b/src/abstractblockarray.jl
@@ -133,7 +133,10 @@ end
 
 viewblock(block_arr, block) = Base.invoke(view, Tuple{AbstractArray, Any}, block_arr, block)
 @inline Base.view(block_arr::AbstractBlockArray{<:Any,N}, block::Block{N}) where N = viewblock(block_arr, block)
-@inline Base.view(block_arr::AbstractBlockArray{<:Any,N}, block::Block{1}) where N = view(block_arr, Block(Base._ind2sub(map(Base.OneTo, blocksize(block_arr)), Int(block))...))
+@inline function Base.view(block_arr::AbstractBlockArray, block::Block{1})
+    blkind = BlockRange(blocksize(block_arr))[Int(block)]
+    view(block_arr, blkind)
+end
 @inline Base.view(block_arr::AbstractBlockVector, block::Block{1}) = viewblock(block_arr, block)
 @inline @propagate_inbounds Base.view(block_arr::AbstractBlockArray, block::Block{1}...) = view(block_arr, Block(block))
 

--- a/src/blockindices.jl
+++ b/src/blockindices.jl
@@ -325,6 +325,10 @@ BlockRange(inds::NTuple{N,AbstractUnitRange{Int}}) where {N} =
 BlockRange(inds::Vararg{AbstractUnitRange{Int},N}) where {N} =
     BlockRange(inds)
 
+BlockRange() = BlockRange(())
+BlockRange(sizes::Tuple{Int, Vararg{Int}}) = BlockRange(map(Base.OneTo, sizes))
+BlockRange(sizes::Vararg{Int}) = BlockRange(sizes)
+
 (:)(start::Block{1}, stop::Block{1}) = BlockRange((first(start.n):first(stop.n),))
 (:)(start::Block, stop::Block) = throw(ArgumentError("Use `BlockRange` to construct a cartesian range of blocks"))
 Base.BroadcastStyle(::Type{<:BlockRange{1}}) = DefaultArrayStyle{1}()

--- a/test/test_blockviews.jl
+++ b/test/test_blockviews.jl
@@ -44,7 +44,7 @@ bview(a, b) = Base.invoke(view, Tuple{AbstractArray,Any}, a, b)
         V[1,1] = -1
         @test A[2,8] == -1
         @test A[Block(4)] == A[Block(1),Block(2)]
-        @test_throws BlockBoundsError A[Block(10)]
+        @test_throws BoundsError A[Block(10)]
 
         V = view(A, Block(3, 2))
         @test size(V) == (3, 4)


### PR DESCRIPTION
This avoids the internal function `_ind2sub` in constructing views of `AbstractBlockArray`s with one `Block{1}` index, and instead, indexes into a `BlockRange` to get the block index. As a consequence, a `BlockBoundsError` is changed to a `BoundsError`, but the error message is actually improved.
On master
```julia
(BlockArrays) julia> B = BlockArray(zeros(6,6), 1:3, 1:3);

(BlockArrays) julia> B[Block(10)]
ERROR: BlockBoundsError: attempt to access 3×3-blocked 6×6 BlockMatrix{Float64, Matrix{Matrix{Float64}}, Tuple{BlockedUnitRange{RangeCumsum{Int64, UnitRange{Int64}}}, BlockedUnitRange{RangeCumsum{Int64, UnitRange{Int64}}}}} at block index [1,4]
```
This PR
```julia
(BlockArrays) julia> B[Block(10)]
ERROR: BoundsError: attempt to access 3×3 BlockRange{2, Tuple{Base.OneTo{Int64}, Base.OneTo{Int64}}} at index [10]
```
The main part of the message is that the index `[1,4]` is changed to `[10]`. The `[1,4]` arises from a lack of bounds-checking in `_ind2sub`, and might be tricky to trace back.

Secondly, this PR introduces a constructor for `BlockRange` that accepts integer block sizes. This parallels `CartesianIndices`:
```julia
(BlockArrays) julia> collect(CartesianIndices((2,3)))
2×3 Matrix{CartesianIndex{2}}:
 CartesianIndex(1, 1)  CartesianIndex(1, 2)  CartesianIndex(1, 3)
 CartesianIndex(2, 1)  CartesianIndex(2, 2)  CartesianIndex(2, 3)

(BlockArrays) julia> collect(BlockRange((2,3)))
2×3 Matrix{Block{2, Int64}}:
 Block(1, 1)  Block(1, 2)  Block(1, 3)
 Block(2, 1)  Block(2, 2)  Block(2, 3)
```