### PR TITLE
Change `muladd` to `mul` in BlockArray * StridedVector

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BlockArrays"
 uuid = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
-version = "0.16.32"
+version = "0.16.33"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"


### PR DESCRIPTION
This avoids slow fallback methods.
On master:
```julia
julia> S = reshape([sprand(Float64,200,200,0.01), sprand(Float64,300,200,0.01), sprand(Float64,200,400,0.01), sprand(Float64,300,400,0.01)], 2, 2);

julia> B = mortar(S);

julia> v = rand(size(B,2));

julia> @btime $B * $v;
  1.136 ms (1 allocation: 4.06 KiB)
```
This PR:
```julia
julia> @btime $B * $v;
  5.374 μs (2 allocations: 4.12 KiB)
```