### PR TITLE
Don't extend `summary(::AbstractBlockArray)`

### DIFF
--- a/src/abstractblockarray.jl
+++ b/src/abstractblockarray.jl
@@ -83,7 +83,7 @@ specialize this method if they need to provide custom block bounds checking beha
 julia> A = BlockArray(rand(2,3), [1,1], [2,1]);
 
 julia> blockcheckbounds(A, 3, 2)
-ERROR: BlockBoundsError: attempt to access 2×2-blocked 2×3 BlockMatrix{Float64, Matrix{Matrix{Float64}}, Tuple{BlockedUnitRange{Vector{Int64}}, BlockedUnitRange{Vector{Int64}}}} at block index [3,2]
+ERROR: BlockBoundsError: attempt to access 2×2-blocked 2×3 BlockMatrix{Float64} at block index [3,2]
 [...]
 ```
 """

--- a/src/abstractblockarray.jl
+++ b/src/abstractblockarray.jl
@@ -23,7 +23,6 @@ const AbstractBlockVecOrMat{T} = Union{AbstractBlockMatrix{T}, AbstractBlockVect
 
 block2string(b, s) = string(join(map(string,b), '×'), "-blocked ", Base.dims2string(s))
 _block_summary(a) = string(block2string(blocksize(a), size(a)), " ", typeof(a))
-Base.summary(a::AbstractBlockArray) = _block_summary(a)
 _show_typeof(io, a) = show(io, typeof(a))
 function _block_summary(io, a)
     print(io, block2string(blocksize(a), size(a)))

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -429,15 +429,19 @@ end
     end
 
     @testset "string" begin
-        A = BlockArray(rand(4, 5), [1,3], [2,3]);
         buf = IOBuffer()
-        Base.showerror(buf, BlockBoundsError(A, (3,2)))
-        @test String(take!(buf)) == "BlockBoundsError: attempt to access 2×2-blocked 4×5 BlockMatrix{Float64, Matrix{Matrix{Float64}}, Tuple{BlockedUnitRange{Vector{$Int}}, BlockedUnitRange{Vector{$Int}}}} at block index [3,2]"
+        A = BlockArray(rand(2,3), [1,1], [2,1]);
+        summary(buf, A)
+        s = String(take!(buf))
+        @test s == summary(A)
 
+        A = BlockArray(rand(4, 5), [1,3], [2,3]);
+        Base.showerror(buf, BlockBoundsError(A, (3,2)))
+        @test String(take!(buf)) == "BlockBoundsError: attempt to access $(summary(A)) at block index [3,2]"
 
         A = PseudoBlockArray(rand(4, 5), [1,3], [2,3]);
         Base.showerror(buf, BlockBoundsError(A, (3,2)))
-        @test String(take!(buf)) == "BlockBoundsError: attempt to access 2×2-blocked 4×5 PseudoBlockMatrix{Float64, Matrix{Float64}, Tuple{BlockedUnitRange{Vector{$Int}}, BlockedUnitRange{Vector{$Int}}}} at block index [3,2]"
+        @test String(take!(buf)) == "BlockBoundsError: attempt to access $(summary(A)) at block index [3,2]"
     end
 
     @testset "replstring" begin


### PR DESCRIPTION
This method isn't necessary, as it's defined by default when `summary(io::IO, ::AbstractBlockArray)` is defined.