### PR TITLE
Fix show for BlockRange

### DIFF
--- a/src/blockaxis.jl
+++ b/src/blockaxis.jl
@@ -171,7 +171,10 @@ julia> A = BlockArray([1,2,3],[2,1])
  3
 
 julia> blockaxes(A,1)
-2-element BlockRange{1, Tuple{Base.OneTo{Int64}}}:
+BlockRange(Base.OneTo(2))
+
+julia> blockaxes(A,1) |> collect
+2-element Vector{Block{1, Int64}}:
  Block(1)
  Block(2)
 ```

--- a/src/blockindices.jl
+++ b/src/blockindices.jl
@@ -321,20 +321,18 @@ The relationship between `Block` and `BlockRange` mimics the relationship betwee
 
 # Examples
 ```jldoctest
-julia> BlockRange(2,2)
-2×2 BlockRange{2, Tuple{Base.OneTo{Int64}, Base.OneTo{Int64}}}:
- Block(1, 1)  Block(1, 2)
- Block(2, 1)  Block(2, 2)
-
-julia> BlockRange(2:3, 3:4)
-2×2 BlockRange{2, Tuple{UnitRange{Int64}, UnitRange{Int64}}}:
+julia> BlockRange(2:3, 3:4) |> collect
+2×2 Matrix{Block{2, Int64}}:
  Block(2, 3)  Block(2, 4)
  Block(3, 3)  Block(3, 4)
 
+julia> BlockRange(2, 2) |> collect # number of elements, starting at 1
+2×2 Matrix{Block{2, Int64}}:
+ Block(1, 1)  Block(1, 2)
+ Block(2, 1)  Block(2, 2)
+
 julia> Block(1):Block(2)
-2-element BlockRange{1, Tuple{UnitRange{Int64}}}:
- Block(1)
- Block(2)
+BlockRange(1:2)
 ```
 """
 BlockRange
@@ -415,8 +413,6 @@ _in(b, ::Tuple{}, ::Tuple{}, ::Tuple{}) = b
 
 # We sometimes need intersection of BlockRange to return a BlockRange
 intersect(a::BlockRange{1}, b::BlockRange{1}) = BlockRange(intersect(a.indices[1], b.indices[1]))
-
-Base.show(io::IO, br::BlockRange) = print(io, "BlockRange(", br.indices..., ")")
 
 # needed for scalar-like broadcasting
 

--- a/src/blocklinalg.jl
+++ b/src/blocklinalg.jl
@@ -13,8 +13,8 @@ julia> B = BlockArray(collect(reshape(1:9, 3, 3)), [1,2], [1,1,1])
  2  │  5  │  8
  3  │  6  │  9
 
-julia> BlockArrays.blockrowsupport(B, 2)
-3-element BlockRange{1, Tuple{Base.OneTo{Int64}}}:
+julia> BlockArrays.blockrowsupport(B, 2) |> collect
+3-element Vector{Block{1, Int64}}:
  Block(1)
  Block(2)
  Block(3)
@@ -39,8 +39,8 @@ julia> B = BlockArray(collect(reshape(1:9, 3, 3)), [1,2], [1,1,1])
  2  │  5  │  8
  3  │  6  │  9
 
-julia> BlockArrays.blockcolsupport(B, 2)
-2-element BlockRange{1, Tuple{Base.OneTo{Int64}}}:
+julia> BlockArrays.blockcolsupport(B, 2) |> collect
+2-element Vector{Block{1, Int64}}:
  Block(1)
  Block(2)
 ```

--- a/src/show.jl
+++ b/src/show.jl
@@ -147,3 +147,8 @@ end
 
 Base.show(io::IO, mimetype::MIME"text/plain", a::BlockedUnitRange) =
     Base.invoke(show, Tuple{typeof(io),MIME"text/plain",AbstractArray},io, mimetype, a)
+
+# BlockRange
+
+Base.show(io::IO, br::BlockRange) = print(io, "BlockRange(", join(br.indices, ", "), ")")
+Base.show(io::IO, ::MIME"text/plain", br::BlockRange) = show(io, br)

--- a/test/test_blockindices.jl
+++ b/test/test_blockindices.jl
@@ -110,6 +110,9 @@ import BlockArrays: BlockIndex, BlockIndexRange, BlockSlice
         @test stringmime("text/plain", Block{0,BigInt}()) == "Block{0, BigInt}(())"
         @test stringmime("text/plain", Block{1,BigInt}(1)) == "Block{1, BigInt}((1,))"
         @test stringmime("text/plain", Block{2}(1,2)) == "Block(1, 2)"
+
+        @test sprint(show, BlockRange(1:2, 2:3)) == "BlockRange(1:2, 2:3)"
+        @test sprint(show, "text/plain", BlockRange(1:2, 2:3)) == "BlockRange(1:2, 2:3)"
     end
 end
 


### PR DESCRIPTION
On master
```julia
julia> show(BlockRange((1:3, 1:3)))
BlockRange(1:31:3)
```
There is a missing comma between the ranges. After this PR,
```julia
julia> show(BlockRange((1:3, 1:3)))
BlockRange(1:3, 1:3)
```
This also changes the "text/plain" display of a `BlockRange` to make it easier to understand.
On master
```julia
julia> BlockRange((1:3, 1:3))
3×3 BlockRange{2, Tuple{UnitRange{Int64}, UnitRange{Int64}}}:
 Block(1, 1)  Block(1, 2)  Block(1, 3)
 Block(2, 1)  Block(2, 2)  Block(2, 3)
 Block(3, 1)  Block(3, 2)  Block(3, 3)
``` 
This PR uses forwards it to the default `show`:
```julia
julia> BlockRange((1:3, 1:3))
BlockRange(1:3, 1:3)
```
This matches the display for `CartesianIndices`:
```julia
julia> CartesianIndices((1:3, 1:3))
CartesianIndices((1:3, 1:3))
```