### PR TITLE
Reduce allocation in blockfirsts

### DIFF
--- a/src/blockaxis.jl
+++ b/src/blockaxis.jl
@@ -62,7 +62,12 @@ BlockedUnitRange(::BlockedUnitRange) = throw(ArgumentError("Forbidden due to amb
 _blocklengths2blocklasts(blocks) = cumsum(blocks) # extra level to allow changing default cumsum behaviour
 @inline blockedrange(blocks::Union{Tuple,AbstractVector}) = _BlockedUnitRange(_blocklengths2blocklasts(blocks))
 
-@inline blockfirsts(a::BlockedUnitRange) = [a.first; @views(a.lasts[1:end-1]) .+ 1]
+@inline function blockfirsts(a::BlockedUnitRange)
+    v = Vector{eltype(a)}(undef, length(a.lasts))
+    v[1] = a.first
+    v[2:end] .= @views(a.lasts[oneto(end-1)]) .+ 1
+    return v
+end
 @inline blocklasts(a::BlockedUnitRange) = a.lasts
 
 _diff(a::AbstractVector) = diff(a)

--- a/src/blockaxis.jl
+++ b/src/blockaxis.jl
@@ -62,7 +62,9 @@ BlockedUnitRange(::BlockedUnitRange) = throw(ArgumentError("Forbidden due to amb
 _blocklengths2blocklasts(blocks) = cumsum(blocks) # extra level to allow changing default cumsum behaviour
 @inline blockedrange(blocks::Union{Tuple,AbstractVector}) = _BlockedUnitRange(_blocklengths2blocklasts(blocks))
 
-@inline function blockfirsts(a::BlockedUnitRange)
+@inline blockfirsts(a::BlockedUnitRange) = [a.first; @views(a.lasts[1:end-1]) .+ 1]
+# optimize common cases
+@inline function blockfirsts(a::BlockedUnitRange{<:Union{Vector, RangeCumsum{<:Any, <:UnitRange}}})
     v = Vector{eltype(a)}(undef, length(a.lasts))
     v[1] = a.first
     v[2:end] .= @views(a.lasts[oneto(end-1)]) .+ 1


### PR DESCRIPTION
On master
```julia
julia> b = blockedrange([2,3,4,5]);

julia> @btime BlockArrays.blockfirsts($b);
  79.737 ns (2 allocations: 176 bytes)
```
This PR
```julia
julia> @btime BlockArrays.blockfirsts($b);
  40.559 ns (1 allocation: 96 bytes)
```

~This won't work with infinite ranges, but that is broken at present. Perhaps this should be limited to finite blocked ranges. I wonder what's the best way to achieve that?~

The optimization is only applied for `Vector` and `UnitRange` block sizes, and infinite cases should fall back to the default concatenation-based method.