### PR TITLE
Forward blocks to parent in block-blockrange views

### DIFF
--- a/src/blockarray.jl
+++ b/src/blockarray.jl
@@ -330,7 +330,7 @@ copy(A::BlockArray) = _BlockArray(map(copy,A.blocks), A.axes)
 ################################
 @inline axes(block_array::BlockArray) = block_array.axes
 
-function viewblock(block_arr::BlockArray, block)
+@propagate_inbounds function viewblock(block_arr::BlockArray, block::Block)
     blks = block.n
     @boundscheck blockcheckbounds(block_arr, blks...)
     block_arr.blocks[blks...]

--- a/src/blocklinalg.jl
+++ b/src/blocklinalg.jl
@@ -300,7 +300,7 @@ function _matchingblocks_triangular_mul!(::Val{'U'}, UNIT, A::AbstractMatrix{T},
     for K = blockaxes(A,1)
         b_2 = view(b, K)
         Ũ = _triangular_matrix(Val('U'), UNIT, view(A, K,K))
-        materialize!(Lmul(Ũ, b_2))
+        lmul!(Ũ, b_2)
         JR = (K+1):last(blockrowsupport(A,K))
         if !isempty(JR)
             muladd!(one(T), view(A, K, JR), view(b,JR), one(T), b_2)
@@ -318,7 +318,7 @@ function _matchingblocks_triangular_mul!(::Val{'L'}, UNIT, A::AbstractMatrix{T},
     for K = N:-1:1
         b_2 = view(b, Block(K))
         L̃ = _triangular_matrix(Val('L'), UNIT, view(A, Block(K,K)))
-        materialize!(Lmul(L̃, b_2))
+        lmul!(L̃, b_2)
         JR = blockrowstart(A,Block(K)):Block(K-1)
         if !isempty(JR)
             muladd!(one(T), view(A, Block(K), JR), view(b,JR), one(T), b_2)

--- a/src/views.jl
+++ b/src/views.jl
@@ -131,10 +131,11 @@ block(A::Block) = A
 @inline Base.view(block_arr::AbstractBlockArray{<:Any,N}, blocks::Vararg{BlockSlice1, N}) where N =
     view(block_arr, map(block,blocks)...)
 
-const BlockSlices = Union{Base.Slice,BlockSlice{<:BlockRange{1}}}
+const BlockSlices = Union{Base.Slice,BlockSlice{<:Union{BlockRange{1},Block{1}}}}
 # Base.view(V::SubArray{<:Any,N,NTuple{N,BlockSlices}},
 
-_block_reindex(b::BlockSlice, i::Block{1}) = b.block[Int(i)]
+_block_reindex(b::BlockSlice{<:Block{1}}, i::Block{1}) = Block(b.block.n[Int(i)])
+_block_reindex(b::BlockSlice{<:BlockRange{1}}, i::Block{1}) = b.block[Int(i)]
 _block_reindex(b::Slice, i::Block{1}) = i
 
 @inline Base.view(V::SubArray{<:Any,N,<:AbstractBlockArray,<:NTuple{N,BlockSlices}}, block::Block{N}) where N =

--- a/test/test_blockviews.jl
+++ b/test/test_blockviews.jl
@@ -182,6 +182,11 @@ bview(a, b) = Base.invoke(view, Tuple{AbstractArray,Any}, a, b)
         @test stringmime("text/plain", W) == "3×1 view(::BlockMatrix{$Int, Matrix{Matrix{$Int}}"*
             ", $(typeof(axes(A)))}, $(Wi[1]), $(Wi[2])) "*
             "with eltype $Int with indices $(axes(W,1))×$(axes(W,2)):\n 1\n ─\n 4\n 7"
+
+        Vv = view(V, Block(1), Block(2))
+        @test Vv === blocks(A)[1,2]
+        Wv = view(W, Block(2), Block(1))
+        @test Wv === blocks(A)[2,1]
     end
 
     @testset "getindex with BlockRange" begin


### PR DESCRIPTION
After this,
```julia
julia> S = sprand(Float64,4,4,0.2);

julia> B = mortar(fill(S,3,3));

julia> SB = view(B, Block(1), BlockRange(2:3))
4×8 view(::BlockMatrix{Float64, Matrix{SparseMatrixCSC{Float64, Int64}}, Tuple{BlockedUnitRange{Vector{Int64}}, BlockedUnitRange{Vector{Int64}}}}, BlockSlice(Block(1),1:4), BlockSlice(BlockRange(2:3),5:1:12)) with eltype Float64 with indices Base.OneTo(4)×1:1:8:
 0.0       0.0      0.0  0.0  │  0.0       0.0      0.0  0.0
 0.158791  0.0      0.0  0.0  │  0.158791  0.0      0.0  0.0
 0.0       0.0      0.0  0.0  │  0.0       0.0      0.0  0.0
 0.0       0.96011  0.0  0.0  │  0.0       0.96011  0.0  0.0

julia> view(SB, Block(1), Block(2))
4×4 SparseMatrixCSC{Float64, Int64} with 2 stored entries:
  ⋅         ⋅        ⋅    ⋅ 
 0.158791   ⋅        ⋅    ⋅ 
  ⋅         ⋅        ⋅    ⋅ 
  ⋅        0.96011   ⋅    ⋅ 
```
The view is forwarded to the parent block array, even when the `parentindices` of the view is a mix of `Block` and `BlockRange`s. On master, this works only if the `parentindices` are all `BlockRange`s. This, using `lmul!` instead of `LMul` in the matrix-multiplication method, makes the following faster:
```julia
julia> S = sprand(Float64,400,400,0.01);

julia> B = mortar(fill(S,3,3));

julia> U = UpperTriangular(B);

julia> v = Float64[1:size(B,2);];

julia> @btime $U * $v;
  10.724 ms (42 allocations: 12.42 KiB) # master
  2.999 ms (30 allocations: 11.55 KiB) # PR
```