### PR TITLE
ensure that Array returns an Array

### DIFF
--- a/src/blockarray.jl
+++ b/src/blockarray.jl
@@ -420,7 +420,7 @@ Base.dataids(arr::BlockArray) = (dataids(arr.blocks)..., dataids(arr.axes)...)
 function _replace_in_print_matrix_inds(block_arr, i...)
     J = findblockindex.(axes(block_arr), i)
     blind = map(block, J)
-    bl = block_arr[blind...]
+    bl = @view block_arr[blind...]
     inds = map(blockindex, J)
     bl, inds
 end
@@ -453,11 +453,11 @@ end
 @generated function Base.Array(block_array::BlockArray{T, N, R}) where {T,N,R}
     # TODO: This will fail for empty block array
     return quote
-        arr = similar(block_array.blocks[1], size(block_array)...)
+        arr = Array{eltype(T)}(undef, size(block_array))
         @nloops $N i i->blockaxes(block_array,i) begin
             block_index = @ntuple $N i
             indices = getindex.(axes(block_array), block_index)
-            arr[indices...] = block_array[block_index...]
+            arr[indices...] = @view block_array[block_index...]
         end
 
         return arr

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -74,6 +74,12 @@ end
             @test A == BlockArray(A, 1:3) == BlockArray{Int}(A, 1:3) ==
                 BlockArray(A, (blockedrange(1:3),)) == BlockArray{Int}(A, (blockedrange(1:3),)) ==
                 BlockArray{Float64}(A, 1:3)
+
+            #test that Array(::BlockArray) always returns an Array
+            S = spzeros(2,1)
+            B = mortar(fill(S,2,2))
+            A = Array(B)
+            @test A isa Matrix
         end
 
         @testset "PseudoBlockArray constructors" begin


### PR DESCRIPTION
Using `similar` to generate the destination isn't ideal, as this doesn't ensure that the type of the destination is an `Array`. This changes the destination to an `Array`. After this,
```julia
julia> S = sprand(Float64,3,3,0.5)
3×3 SparseMatrixCSC{Float64, Int64} with 4 stored entries:
  ⋅        0.713293   ⋅ 
  ⋅         ⋅        0.181664
 0.379387  0.183307   ⋅ 

julia> B = mortar(fill(S,1,2))
1×2-blocked 3×6 BlockMatrix{Float64, Matrix{SparseMatrixCSC{Float64, Int64}}, Tuple{BlockedUnitRange{Vector{Int64}}, BlockedUnitRange{Vector{Int64}}}}:
  ⋅        0.713293   ⋅        │   ⋅        0.713293   ⋅      
  ⋅         ⋅        0.181664  │   ⋅         ⋅        0.181664
 0.379387  0.183307   ⋅        │  0.379387  0.183307   ⋅      

julia> Array(B)
3×6 Matrix{Float64}:
 0.0       0.713293  0.0       0.0       0.713293  0.0
 0.0       0.0       0.181664  0.0       0.0       0.181664
 0.379387  0.183307  0.0       0.379387  0.183307  0.0
```
whereas on master
```julia
julia> Array(B)
3×6 SparseMatrixCSC{Float64, Int64} with 8 stored entries:
  ⋅        0.713293   ⋅         ⋅        0.713293   ⋅ 
  ⋅         ⋅        0.181664   ⋅         ⋅        0.181664
 0.379387  0.183307   ⋅        0.379387  0.183307   ⋅ 
```
Also, adds some `@view` annotations at a couple of places.