### PR TITLE
Preserve block types in similar for BlockArray

### DIFF
--- a/src/blockarray.jl
+++ b/src/blockarray.jl
@@ -369,6 +369,8 @@ end
 @inline Base.similar(block_array::Type{<:AbstractArray{T}}, axes::Tuple{Union{AbstractUnitRange{Int},Integer},BlockedUnitRange,Vararg{Union{AbstractUnitRange{Int},Integer}}}) where T =
     BlockArray{T}(undef, map(to_axes,axes))
 
+@inline Base.similar(B::BlockArray, ::Type{T}) where {T} = mortar(similar.(blocks(B), T))
+
 const OffsetAxis = Union{Integer, UnitRange, Base.OneTo, Base.IdentityUnitRange}
 
 # avoid ambiguities


### PR DESCRIPTION
If `similar` is called without `axes`, it may be forwarded to the blocks of a `BlockArray`.
```julia
julia> S = sprand(Float64,3,3,0.5)
3×3 SparseMatrixCSC{Float64, Int64} with 3 stored entries:
 0.760755   ⋅   0.112262
  ⋅         ⋅    ⋅ 
 0.432605   ⋅    ⋅ 

julia> B = mortar(fill(S,1,2))
1×2-blocked 3×6 BlockMatrix{Float64, Matrix{SparseMatrixCSC{Float64, Int64}}, Tuple{BlockedUnitRange{Vector{Int64}}, BlockedUnitRange{Vector{Int64}}}}:
 0.760755   ⋅   0.112262  │  0.760755   ⋅   0.112262
  ⋅         ⋅    ⋅        │   ⋅         ⋅    ⋅      
 0.432605   ⋅    ⋅        │  0.432605   ⋅    ⋅      

julia> similar(B, Int8)
1×2-blocked 3×6 BlockMatrix{Int8, Matrix{SparseMatrixCSC{Int8, Int64}}, Tuple{BlockedUnitRange{Vector{Int64}}, BlockedUnitRange{Vector{Int64}}}}:
 0  ⋅  0  │  0  ⋅  0
 ⋅  ⋅  ⋅  │  ⋅  ⋅  ⋅
 0  ⋅  ⋅  │  0  ⋅  ⋅

```