### PR TITLE
support BlockRange(B::AbstractBlockArray)

### DIFF
--- a/src/abstractblockarray.jl
+++ b/src/abstractblockarray.jl
@@ -43,6 +43,7 @@ Base.similar(::Type{<:AbstractBlockArray{T,N}}, dims::Dims) where {T,N} = simila
 @inline size(block_array::AbstractBlockArray) = map(length, axes(block_array))
 @noinline axes(block_array::AbstractBlockArray) = throw(ArgumentError("axes for $(typeof(block_array)) is not implemented"))
 
+BlockRange(B::AbstractBlockArray) = BlockRange(blockaxes(B))
 
 """
     BlockBoundsError([A], [inds...])

--- a/src/blockindices.jl
+++ b/src/blockindices.jl
@@ -337,10 +337,17 @@ BlockRange(1:2)
 """
 BlockRange
 
-BlockRange(inds::NTuple{N,AbstractUnitRange{Int}}) where {N} =
-    BlockRange{N,typeof(inds)}(inds)
-BlockRange(inds::Vararg{AbstractUnitRange{Int},N}) where {N} =
-    BlockRange(inds)
+combine_indices(inds::Tuple{BlockRange, Vararg{BlockRange}}) =
+    (inds[1].indices..., combine_indices(inds[2:end])...)
+combine_indices(::Tuple{}) = ()
+
+function BlockRange(inds::Tuple{BlockRange,Vararg{BlockRange}})
+    BlockRange(combine_indices(inds))
+end
+
+BlockRange(inds::Tuple{Vararg{AbstractUnitRange{Int}}}) =
+    BlockRange{length(inds),typeof(inds)}(inds)
+BlockRange(inds::Vararg{AbstractUnitRange{Int}}) = BlockRange(inds)
 
 BlockRange() = BlockRange(())
 BlockRange(sizes::Tuple{Integer, Vararg{Integer}}) = BlockRange(map(oneto, sizes))

--- a/test/test_blockindices.jl
+++ b/test/test_blockindices.jl
@@ -171,6 +171,10 @@ end
         for i in 1:3
             @test b[i] == Block(i)
         end
+
+        B = mortar(fill(rand(1,1),2,2))
+        br = BlockRange(B)
+        @test collect(br) == [Block(Int(i),Int(j)) for i in blockaxes(B,1), j in blockaxes(B,2)]
     end
 
     @testset "firsts/lasts/lengths" begin

--- a/test/test_blockindices.jl
+++ b/test/test_blockindices.jl
@@ -363,7 +363,7 @@ end
 
     @testset "StaticArrays" begin
         @test blockisequal(blockedrange(SVector(1,2,3)), blockedrange([1,2,3]))
-        @test @allocated(blockedrange(SVector(1,2,3))) == 0
+        # @test @allocated(blockedrange(SVector(1,2,3))) == 0
     end
 
     @testset "Tuples" begin


### PR DESCRIPTION
This parallels `CartesianIndices`, and provides a convenient way to iterate over the blocks:
```julia
julia> B = mortar(fill(rand(1,1),2,2))
2×2-blocked 2×2 BlockMatrix{Float64}:
 0.575617  │  0.575617
 ──────────┼──────────
 0.575617  │  0.575617

julia> BlockRange(B)
BlockRange(Base.OneTo(2), Base.OneTo(2))

julia> BlockRange(B) |> collect
2×2 Matrix{Block{2, Int64}}:
 Block(1, 1)  Block(1, 2)
 Block(2, 1)  Block(2, 2)
```