### PR TITLE
Forward `view` to parent for `PseudoBlockArray`

### DIFF
--- a/src/views.jl
+++ b/src/views.jl
@@ -170,6 +170,13 @@ end
 
 view(A::AdjOrTrans{<:Any,<:BlockArray}, K::Block{1}, J::Block{1}) = view(A, Block(Int(K), Int(J)))
 
+# PseudoBlockArray
+
+function view(A::PseudoBlockArray, inds::Union{Int, AbstractArray{Int}, Colon}...)
+    indsparent = to_indices(A, inds)
+    view(A.blocks, indsparent...)
+end
+
 @propagate_inbounds getindex(v::LinearAlgebra.AdjOrTransAbsVec, ::Colon, is::AbstractArray{<:Block{1}}) = LinearAlgebra.wrapperop(v)(v.parent[is])
 
 


### PR DESCRIPTION
This might help in dispatching to efficient methods for `StridedArrays`:
```julia
julia> B = PseudoBlockArray(collect(reshape(1:36,6,6)), [1,2,3], [1,2,3])
3×3-blocked 6×6 PseudoBlockMatrix{Int64}:
 1  │   7  13  │  19  25  31
 ───┼──────────┼────────────
 2  │   8  14  │  20  26  32
 3  │   9  15  │  21  27  33
 ───┼──────────┼────────────
 4  │  10  16  │  22  28  34
 5  │  11  17  │  23  29  35
 6  │  12  18  │  24  30  36

julia> view(B, Block(2,2))
2×2 view(::Matrix{Int64}, 2:3, 2:3) with eltype Int64:
 8  14
 9  15

julia> view(B, 2:3, 2:3) # new in this PR, matches the above
2×2 view(::Matrix{Int64}, 2:3, 2:3) with eltype Int64:
 8  14
 9  15
```