### PR TITLE
import setindex and extend without specifying namespace

### DIFF
--- a/src/BlockArrays.jl
+++ b/src/BlockArrays.jl
@@ -21,7 +21,7 @@ export blockappend!, blockpush!, blockpushfirst!, blockpop!, blockpopfirst!
 import Base: @propagate_inbounds, Array, to_indices, to_index,
             unsafe_indices, first, last, size, length, unsafe_length,
             unsafe_convert,
-            getindex, ndims, show, view,
+            getindex, setindex!, ndims, show, view,
             step,
             broadcast, eltype, convert, similar,
             tail, reindex,

--- a/src/abstractblockarray.jl
+++ b/src/abstractblockarray.jl
@@ -159,9 +159,9 @@ false
 """
 @inline blockcheckindex(::Type{Bool}, inds::BlockRange{1}, i::Integer) = Block(i) in inds
 
-@propagate_inbounds Base.setindex!(block_arr::AbstractBlockArray{T,N}, v, block::Block{N}) where {T,N} =
+@propagate_inbounds setindex!(block_arr::AbstractBlockArray{T,N}, v, block::Block{N}) where {T,N} =
     setindex!(block_arr, v, Block.(block.n)...)
-@inline @propagate_inbounds function Base.setindex!(block_arr::AbstractBlockArray{T,N}, v, block::Vararg{Block{1}, N}) where {T,N}
+@inline @propagate_inbounds function setindex!(block_arr::AbstractBlockArray{T,N}, v, block::Vararg{Block{1}, N}) where {T,N}
     blockcheckbounds(block_arr, block...)
     dest = view(block_arr, block...)
     size(dest) == size(v) || throw(DimensionMismatch(string("tried to assign $(size(v)) array to $(size(dest)) block")))
@@ -169,11 +169,11 @@ false
     block_arr
 end
 
-@inline @propagate_inbounds Base.setindex!(block_arr::AbstractBlockArray{T,N}, v, blockindex::BlockIndex{N}) where {T,N} =
+@inline @propagate_inbounds setindex!(block_arr::AbstractBlockArray{T,N}, v, blockindex::BlockIndex{N}) where {T,N} =
     view(block_arr, block(blockindex))[blockindex.α...] = v
-@inline @propagate_inbounds Base.setindex!(block_arr::AbstractBlockVector{T}, v, blockindex::BlockIndex{1}) where {T} =
+@inline @propagate_inbounds setindex!(block_arr::AbstractBlockVector{T}, v, blockindex::BlockIndex{1}) where {T} =
     view(block_arr, block(blockindex))[blockindex.α...] = v
-@inline @propagate_inbounds Base.setindex!(block_arr::AbstractBlockArray{T,N}, v, blockindex::Vararg{BlockIndex{1},N}) where {T,N} =
+@inline @propagate_inbounds setindex!(block_arr::AbstractBlockArray{T,N}, v, blockindex::Vararg{BlockIndex{1},N}) where {T,N} =
     block_arr[BlockIndex(blockindex)] = v
 
 viewblock(block_arr, block) = Base.invoke(view, Tuple{AbstractArray, Any}, block_arr, block)

--- a/src/blockarray.jl
+++ b/src/blockarray.jl
@@ -387,7 +387,7 @@ const OffsetAxis = Union{Integer, UnitRange, Base.OneTo, Base.IdentityUnitRange}
     return v
 end
 
-@inline function Base.setindex!(block_arr::BlockArray{T, N}, v, i::Vararg{Integer, N}) where {T,N}
+@inline function setindex!(block_arr::BlockArray{T, N}, v, i::Vararg{Integer, N}) where {T,N}
     @boundscheck checkbounds(block_arr, i...)
     @inbounds block_arr[findblockindex.(axes(block_arr), i)...] = v
     return block_arr
@@ -406,7 +406,7 @@ function _check_setblock!(block_arr::BlockArray{T, N}, v, block::NTuple{N, Integ
     end
 end
 
-@inline function Base.setindex!(block_arr::BlockArray{T, N}, v, block::Vararg{Block{1}, N}) where {T,N}
+@inline function setindex!(block_arr::BlockArray{T, N}, v, block::Vararg{Block{1}, N}) where {T,N}
     blks = Int.(block)
     @boundscheck blockcheckbounds(block_arr, blks...)
     @boundscheck _check_setblock!(block_arr, v, blks)

--- a/src/blocks.jl
+++ b/src/blocks.jl
@@ -82,13 +82,13 @@ Base.axes(a::BlocksView) = map(br -> only(br.indices), blockaxes(a.array))
 This is broken for now. See: https://github.com/JuliaArrays/BlockArrays.jl/issues/120
 # IndexLinear implementations
 @propagate_inbounds getindex(a::BlocksView, i::Int) = view(a.array, Block(i))
-@propagate_inbounds Base.setindex!(a::BlocksView, b, i::Int) = copyto!(a[i], b)
+@propagate_inbounds setindex!(a::BlocksView, b, i::Int) = copyto!(a[i], b)
 =#
 
 # IndexCartesian implementations
 @propagate_inbounds getindex(a::BlocksView{T,N}, i::Vararg{Int,N}) where {T,N} =
     view(a.array, Block.(i)...)
-@propagate_inbounds Base.setindex!(a::BlocksView{T,N}, b, i::Vararg{Int,N}) where {T,N} =
+@propagate_inbounds setindex!(a::BlocksView{T,N}, b, i::Vararg{Int,N}) where {T,N} =
     copyto!(a[i...], b)
 
 function Base.showarg(io::IO, a::BlocksView, toplevel::Bool)

--- a/src/pseudo_blockarray.jl
+++ b/src/pseudo_blockarray.jl
@@ -177,7 +177,7 @@ to_axes(n::Integer) = Base.oneto(n)
     PseudoBlockArray{T}(undef, map(to_axes,axes))
 
 @propagate_inbounds getindex(block_arr::PseudoBlockArray{T, N}, i::Vararg{Integer, N}) where {T,N} = block_arr.blocks[i...]
-@propagate_inbounds Base.setindex!(block_arr::PseudoBlockArray{T, N}, v, i::Vararg{Integer, N}) where {T,N} = setindex!(block_arr.blocks, v, i...)
+@propagate_inbounds setindex!(block_arr::PseudoBlockArray{T, N}, v, i::Vararg{Integer, N}) where {T,N} = setindex!(block_arr.blocks, v, i...)
 
 ################################
 # AbstractBlockArray Interface #


### PR DESCRIPTION
This makes the style consistent with `getindex`