### PR TITLE
`BlockRange` for `AbstractArrays`

### DIFF
--- a/src/abstractblockarray.jl
+++ b/src/abstractblockarray.jl
@@ -43,8 +43,6 @@ Base.similar(::Type{<:AbstractBlockArray{T,N}}, dims::Dims) where {T,N} = simila
 @inline size(block_array::AbstractBlockArray) = map(length, axes(block_array))
 @noinline axes(block_array::AbstractBlockArray) = throw(ArgumentError("axes for $(typeof(block_array)) is not implemented"))
 
-BlockRange(B::AbstractBlockArray) = BlockRange(blockaxes(B))
-
 """
     BlockBoundsError([A], [inds...])
 

--- a/src/blockindices.jl
+++ b/src/blockindices.jl
@@ -353,6 +353,8 @@ BlockRange() = BlockRange(())
 BlockRange(sizes::Tuple{Integer, Vararg{Integer}}) = BlockRange(map(oneto, sizes))
 BlockRange(sizes::Vararg{Integer}) = BlockRange(sizes)
 
+BlockRange(B::AbstractArray) = BlockRange(blockaxes(B))
+
 (:)(start::Block{1}, stop::Block{1}) = BlockRange((first(start.n):first(stop.n),))
 (:)(start::Block, stop::Block) = throw(ArgumentError("Use `BlockRange` to construct a cartesian range of blocks"))
 Base.BroadcastStyle(::Type{<:BlockRange{1}}) = DefaultArrayStyle{1}()

--- a/src/pseudo_blockarray.jl
+++ b/src/pseudo_blockarray.jl
@@ -209,6 +209,8 @@ end
 # Misc #
 ########
 
+Base.parent(block_array::PseudoBlockArray) = block_array.blocks
+
 Base.Array(block_array::PseudoBlockArray) = Array(block_array.blocks)
 
 function copyto!(block_array::PseudoBlockArray{T, N, R}, arr::R) where {T,N,R <: AbstractArray}

--- a/test/test_blockviews.jl
+++ b/test/test_blockviews.jl
@@ -61,6 +61,11 @@ bview(a, b) = Base.invoke(view, Tuple{AbstractArray,Any}, a, b)
 
         @test view(V, Block(1, 1)) ≡ V
 
+        B = view(parent(A), axes(A)...)
+        for I in BlockRange(A)
+            @test view(B, I) == view(A, I)
+        end
+
         @test_throws BlockBoundsError view(V, Block(1,2))
         @test_throws BlockBoundsError view(V, Block(2,1))
 


### PR DESCRIPTION
After this,
```julia
julia> r = rand(2,2)
2×2 Matrix{Float64}:
 0.681849  0.273193
 0.848369  0.335195

julia> r[BlockRange(r)]
2×2 Matrix{Float64}:
 0.681849  0.273193
 0.848369  0.335195
```
This also defines `parent` for a `PseudoBlockArray` to extract the wrapped array.
```julia
julia> P = PseudoBlockArray([1:6;], 1:3)
3-blocked 6-element PseudoBlockVector{Int64, Vector{Int64}, Tuple{BlockedUnitRange{ArrayLayouts.RangeCumsum{Int64, UnitRange{Int64}}}}}:
 1
 ─
 2
 3
 ─
 4
 5
 6

julia> parent(P)
6-element Vector{Int64}:
 1
 2
 3
 4
 5
 6
```
`parent` differs from `Array`, as this doesn't create a copy. This PR shouldn't be a breaking change, as `P == parent(P)` still holds, and the new definition matches the docstring of `parent`.