### PR TITLE
Remove BroadcastStyle specialization for BlockRange{1}

### DIFF
--- a/src/blockindices.jl
+++ b/src/blockindices.jl
@@ -355,7 +355,6 @@ BlockRange(sizes::Vararg{Integer}) = BlockRange(sizes)
 
 (:)(start::Block{1}, stop::Block{1}) = BlockRange((first(start.n):first(stop.n),))
 (:)(start::Block, stop::Block) = throw(ArgumentError("Use `BlockRange` to construct a cartesian range of blocks"))
-Base.BroadcastStyle(::Type{<:BlockRange{1}}) = DefaultArrayStyle{1}()
 broadcasted(::DefaultArrayStyle{1}, ::Type{Block}, r::AbstractUnitRange) = BlockRange((r,))
 broadcasted(::DefaultArrayStyle{1}, ::Type{Int}, block_range::BlockRange{1}) = first(block_range.indices)
 broadcasted(::DefaultArrayStyle{0}, ::Type{Int}, block::Block{1}) = Int(block)


### PR DESCRIPTION
This is unnecessary, as `DefaultArrayStyle{1}()` is the default fallback.