### PR TITLE
Tests for views with no indices

### DIFF
--- a/test/test_blockviews.jl
+++ b/test/test_blockviews.jl
@@ -26,6 +26,8 @@ bview(a, b) = Base.invoke(view, Tuple{AbstractArray,Any}, a, b)
         view(A, Block(2))[2] = -1
         @test A[3] == -1
 
+        @test_throws BoundsError view(A)
+
         # backend tests
         @test_throws ArgumentError Base.to_index(A, Block(1))
 
@@ -45,6 +47,8 @@ bview(a, b) = Base.invoke(view, Tuple{AbstractArray,Any}, a, b)
         @test A[2,8] == -1
         @test A[Block(4)] == A[Block(1),Block(2)]
         @test_throws BoundsError A[Block(10)]
+
+        @test_throws BoundsError view(A)
 
         V = view(A, Block(3, 2))
         @test size(V) == (3, 4)


### PR DESCRIPTION
This adds tests to ensure that operations such as
```julia
julia> B = BlockArray(zeros(6,6), 1:3, 1:3);

julia> view(B)
ERROR: BoundsError: attempt to access 3×3-blocked 6×6 BlockMatrix{Float64, Matrix{Matrix{Float64}}, Tuple{BlockedUnitRange{ArrayLayouts.RangeCumsum{Int64, UnitRange{Int64}}}, BlockedUnitRange{ArrayLayouts.RangeCumsum{Int64, UnitRange{Int64}}}}} at index []
```
throw a `BoundsError`. This should prevent regressions.