### PR TITLE
Block view of blocked range returns a range

### DIFF
--- a/src/blockaxis.jl
+++ b/src/blockaxis.jl
@@ -252,6 +252,9 @@ first(b::BlockedUnitRange) = b.first
 # ::Integer works around case where blocklasts might return different type
 last(b::BlockedUnitRange)::Integer = isempty(blocklasts(b)) ? first(b)-1 : last(blocklasts(b))
 
+# view and indexing are identical for a unitrange
+Base.view(b::BlockedUnitRange, K::Block{1}) = b[K]
+
 @propagate_inbounds function getindex(b::BlockedUnitRange, K::Block{1})
     k = Integer(K)
     bax = blockaxes(b,1)

--- a/test/test_blockindices.jl
+++ b/test/test_blockindices.jl
@@ -122,11 +122,13 @@ end
         @test axes(b) == (b,)
         @test blockaxes(b,1) isa BlockRange
 
-        @test @inferred(b[Block(1)]) == 1:1
-        @test b[Block(2)] == 2:3
-        @test b[Block(3)] == 4:6
+        @test @inferred(b[Block(1)]) === 1:1
+        @test b[Block(2)] === 2:3
+        @test b[Block(3)] === 4:6
+        @test @inferred(view(b, Block(3))) === 4:6
         @test_throws BlockBoundsError b[Block(0)]
         @test_throws BlockBoundsError b[Block(4)]
+        @test_throws BlockBoundsError view(b, Block(4))
 
         o = OffsetArray([2,2,3],-1:1)
         b = blockedrange(o)


### PR DESCRIPTION
After this,
```julia
julia> b = blockedrange([1,2,3])
3-blocked 6-element BlockedUnitRange{Vector{Int64}}:
 1
 ─
 2
 3
 ─
 4
 5
 6

julia> view(b, Block(1))
1:1

julia> view(b, Block(3))
4:6
```
This matches the behavior of a `UnitRange`.