### PR TITLE
remove unnecessary promote_rule for BlockedUnitRange

### DIFF
--- a/src/blockaxis.jl
+++ b/src/blockaxis.jl
@@ -127,7 +127,6 @@ Base.convert(::Type{BlockedUnitRange{CS}}, axis::AbstractUnitRange{Int}) where C
 
 Base.unitrange(b::BlockedUnitRange) = first(b):last(b)
 
-Base.promote_rule(::Type{BlockedUnitRange{CS}}, ::Type{UnitRange{Int}}) where CS = UnitRange{Int}
 Base.promote_rule(::Type{BlockedUnitRange{CS}}, ::Type{Base.OneTo{Int}}) where CS = UnitRange{Int}
 
 """

--- a/test/test_blockindices.jl
+++ b/test/test_blockindices.jl
@@ -117,12 +117,15 @@ import BlockArrays: BlockIndex, BlockIndexRange, BlockSlice
 end
 
 @testset "BlockedUnitRange" begin
+    @testset "promote" begin
+        b = blockedrange([1,2,3])
+        @test promote(b, 1:2) == (1:6, 1:2)
+        @test promote(b, Base.OneTo(2)) == (1:6, 1:2)
+    end
     @testset "Block indexing" begin
         b = blockedrange([1,2,3])
         @test axes(b) == (b,)
         @test blockaxes(b,1) isa BlockRange
-        @test promote(b, 1:2) == (1:6, 1:2)
-        @test promote(b, Base.OneTo(2)) == (1:6, 1:2)
 
         @test @inferred(b[Block(1)]) == 1:1
         @test b[Block(2)] == 2:3

--- a/test/test_blockindices.jl
+++ b/test/test_blockindices.jl
@@ -121,6 +121,8 @@ end
         b = blockedrange([1,2,3])
         @test axes(b) == (b,)
         @test blockaxes(b,1) isa BlockRange
+        @test promote(b, 1:2) == (1:6, 1:2)
+        @test promote(b, Base.OneTo(2)) == (1:6, 1:2)
 
         @test @inferred(b[Block(1)]) == 1:1
         @test b[Block(2)] == 2:3


### PR DESCRIPTION
This rule is already defined in `⁣Base`.