### PR TITLE
Don't check for Project.toml formatting on v1.6

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,7 +2,10 @@ using BlockArrays, LinearAlgebra, Test
 
 using Aqua
 @testset "Project quality" begin
-    Aqua.test_all(BlockArrays, ambiguities=false)
+    Aqua.test_all(BlockArrays, ambiguities=false,
+        # only test formatting on VERSION >= v1.7
+        # https://github.com/JuliaTesting/Aqua.jl/issues/105#issuecomment-1551405866
+        project_toml_formatting = VERSION >= v"1.9")
 end
 
 using Documenter


### PR DESCRIPTION
This works around a Pkg bug on v1.6 that doesn't play well with extensions