### PR TITLE
Fix Broadcast.broadcast_shape inference

### DIFF
--- a/src/blockbroadcast.jl
+++ b/src/blockbroadcast.jl
@@ -30,13 +30,14 @@ BroadcastStyle(::PseudoBlockStyle{M}, ::BlockStyle{N}) where {M,N} = BlockStyle(
 
 # sortedunion can assume inputs are already sorted so this could be improved
 sortedunion(a,b) = sort!(union(a,b))
+sortedunion(a::Tuple, b::Tuple) = (a..., b...)
 sortedunion(a::Base.OneTo, b::Base.OneTo) = Base.OneTo(max(last(a),last(b)))
 sortedunion(a::AbstractUnitRange, b::AbstractUnitRange) = min(first(a),first(b)):max(last(a),last(b))
 combine_blockaxes(a, b) = _BlockedUnitRange(sortedunion(blocklasts(a), blocklasts(b)))
 
-Base.Broadcast.axistype(a::BlockedUnitRange, b::BlockedUnitRange) = length(b) == 1 ? a : combine_blockaxes(a, b)
-Base.Broadcast.axistype(a::BlockedUnitRange, b) = length(b) == 1 ? a : combine_blockaxes(a, b)
-Base.Broadcast.axistype(a, b::BlockedUnitRange) = length(b) == 1 ? a : combine_blockaxes(a, b)
+Base.Broadcast.axistype(a::BlockedUnitRange, b::BlockedUnitRange) = combine_blockaxes(a, b)
+Base.Broadcast.axistype(a::BlockedUnitRange, b) = combine_blockaxes(a, b)
+Base.Broadcast.axistype(a, b::BlockedUnitRange) = combine_blockaxes(a, b)
 
 
 similar(bc::Broadcasted{<:AbstractBlockStyle{N}}, ::Type{T}) where {T,N} =

--- a/src/blockbroadcast.jl
+++ b/src/blockbroadcast.jl
@@ -30,10 +30,12 @@ BroadcastStyle(::PseudoBlockStyle{M}, ::BlockStyle{N}) where {M,N} = BlockStyle(
 
 # sortedunion can assume inputs are already sorted so this could be improved
 sortedunion(a,b) = sort!(union(a,b))
-sortedunion(a::Tuple, b::Tuple) = (a..., b...)
+sortedunion_tuple(a::Tuple, b::Tuple) = (a..., b...)
 sortedunion(a::Base.OneTo, b::Base.OneTo) = Base.OneTo(max(last(a),last(b)))
 sortedunion(a::AbstractUnitRange, b::AbstractUnitRange) = min(first(a),first(b)):max(last(a),last(b))
-combine_blockaxes(a, b) = _BlockedUnitRange(sortedunion(blocklasts(a), blocklasts(b)))
+combine_blockaxes(a, b) = combine_blockaxes(a, b, blocklasts(a), blocklasts(b))
+combine_blockaxes(a, b, abl, bbl) = length(b) == 1 ? a : _BlockedUnitRange(sortedunion(abl, bbl))
+combine_blockaxes(a, b, abl::Tuple, bbl::Tuple) = _BlockedUnitRange(sortedunion_tuple(abl, bbl))
 
 Base.Broadcast.axistype(a::BlockedUnitRange, b::BlockedUnitRange) = combine_blockaxes(a, b)
 Base.Broadcast.axistype(a::BlockedUnitRange, b) = combine_blockaxes(a, b)

--- a/test/test_blockbroadcast.jl
+++ b/test/test_blockbroadcast.jl
@@ -182,6 +182,19 @@ import BlockArrays: SubBlockIterator, BlockIndexRange, Diagonal
         u = BlockArray(randn(5), [2,3]);
         @inferred(copyto!(similar(u), Base.broadcasted(exp, u)))
         @test exp.(u) == exp.(Vector(u))
+
+        function test_allocation!(shape1, shape2)
+            x = Base.Broadcast.broadcast_shape(shape1, shape2)
+            return nothing
+        end
+        shape1 = (BlockArrays._BlockedUnitRange((2,)),);
+        shape2 = (BlockArrays._BlockedUnitRange((2,)),);
+        @inferred Base.Broadcast.axistype(shape1[1], shape2[1])
+        @inferred BlockArrays.combine_blockaxes(shape1[1], shape2[1])
+        @inferred Base.Broadcast.broadcast_shape(shape1, shape2)
+        test_allocation!(shape1, shape2) # compile first
+        p = @allocated test_allocation!(shape1, shape2)
+        @test p == 0
     end
 
     @testset "adjtrans" begin


### PR DESCRIPTION
This is an alternative to #312.

I noticed that, in the case when the union combines both entries, the result should still be correct (that's what the existing code is doing afterall). If we make tuples always combine entries then we have the benefit of `Base.Broadcast.broadcast_shape` both being stack allocated and fully type inferred. This fixes my upstream issue (and I would prefer this solution over #312).

@jishnub, does this look okay?

Closes #310.