### PR TITLE
Test using Aqua v0.8

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,11 +8,17 @@ FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [compat]
-Aqua = "0.5, 0.6, 0.7"
+Aqua = "0.8"
+Base64 = "1.6"
 ArrayLayouts = "1.0.8"
 Documenter = "0.27"
 FillArrays = "1"
 LinearAlgebra = "1.6"
+OffsetArrays = "1"
+Random = "1.6"
+SparseArrays = "1.6"
+StaticArrays = "1.6"
+Test = "1.6"
 julia = "1.6"
 
 [extras]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,10 +2,7 @@ using BlockArrays, LinearAlgebra, Test
 
 using Aqua
 @testset "Project quality" begin
-    Aqua.test_all(BlockArrays, ambiguities=false,
-        # only test formatting on VERSION >= v1.7
-        # https://github.com/JuliaTesting/Aqua.jl/issues/105#issuecomment-1551405866
-        project_toml_formatting = VERSION >= v"1.9")
+    Aqua.test_all(BlockArrays, ambiguities=false)
 end
 
 using Documenter


### PR DESCRIPTION
Also add compat specifications for all dependencies (including test dependencies), which should reduce potential breakages in the future.