### PR TITLE
Use Codecov token in the coverage action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           file: lcov.info
   docs:
     name: Documentation

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -65,4 +65,5 @@ jobs:
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v4
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: lcov.info


### PR DESCRIPTION
This is necessary to upload Codecov reports correctly using the v4 of the action. Currently, this uses the org-wide token from `JuliaArrays`