### PR TITLE
Return array in setindex

### DIFF
--- a/src/abstractblockarray.jl
+++ b/src/abstractblockarray.jl
@@ -159,7 +159,7 @@ false
 
 @propagate_inbounds setindex!(block_arr::AbstractBlockArray{T,N}, v, block::Block{N}) where {T,N} =
     setindex!(block_arr, v, Block.(block.n)...)
-@inline @propagate_inbounds function setindex!(block_arr::AbstractBlockArray{T,N}, v, block::Vararg{Block{1}, N}) where {T,N}
+@propagate_inbounds function setindex!(block_arr::AbstractBlockArray{T,N}, v, block::Vararg{Block{1}, N}) where {T,N}
     blockcheckbounds(block_arr, block...)
     dest = view(block_arr, block...)
     size(dest) == size(v) || throw(DimensionMismatch(string("tried to assign $(size(v)) array to $(size(dest)) block")))
@@ -167,12 +167,18 @@ false
     block_arr
 end
 
-@inline @propagate_inbounds setindex!(block_arr::AbstractBlockArray{T,N}, v, blockindex::BlockIndex{N}) where {T,N} =
+@propagate_inbounds function setindex!(block_arr::AbstractBlockArray{T,N}, v, blockindex::BlockIndex{N}) where {T,N}
     view(block_arr, block(blockindex))[blockindex.α...] = v
-@inline @propagate_inbounds setindex!(block_arr::AbstractBlockVector{T}, v, blockindex::BlockIndex{1}) where {T} =
+    block_arr
+end
+@propagate_inbounds function setindex!(block_arr::AbstractBlockVector{T}, v, blockindex::BlockIndex{1}) where {T}
     view(block_arr, block(blockindex))[blockindex.α...] = v
-@inline @propagate_inbounds setindex!(block_arr::AbstractBlockArray{T,N}, v, blockindex::Vararg{BlockIndex{1},N}) where {T,N} =
+    block_arr
+end
+@propagate_inbounds function setindex!(block_arr::AbstractBlockArray{T,N}, v, blockindex::Vararg{BlockIndex{1},N}) where {T,N}
     block_arr[BlockIndex(blockindex)] = v
+    block_arr
+end
 
 viewblock(block_arr, block) = Base.invoke(view, Tuple{AbstractArray, Any}, block_arr, block)
 @inline view(block_arr::AbstractBlockArray{<:Any,N}, block::Block{N}) where N = viewblock(block_arr, block)
@@ -181,7 +187,7 @@ viewblock(block_arr, block) = Base.invoke(view, Tuple{AbstractArray, Any}, block
     view(block_arr, blkind)
 end
 @inline view(block_arr::AbstractBlockVector, block::Block{1}) = viewblock(block_arr, block)
-@inline @propagate_inbounds view(block_arr::AbstractBlockArray, block::Block{1}...) = view(block_arr, Block(block))
+@propagate_inbounds view(block_arr::AbstractBlockArray, block::Block{1}...) = view(block_arr, Block(block))
 
 """
     eachblock(A::AbstractBlockArray)

--- a/src/blocks.jl
+++ b/src/blocks.jl
@@ -88,8 +88,10 @@ This is broken for now. See: https://github.com/JuliaArrays/BlockArrays.jl/issue
 # IndexCartesian implementations
 @propagate_inbounds getindex(a::BlocksView{T,N}, i::Vararg{Int,N}) where {T,N} =
     view(a.array, Block.(i)...)
-@propagate_inbounds setindex!(a::BlocksView{T,N}, b, i::Vararg{Int,N}) where {T,N} =
+@propagate_inbounds function setindex!(a::BlocksView{T,N}, b, i::Vararg{Int,N}) where {T,N}
     copyto!(a[i...], b)
+    a
+end
 
 function Base.showarg(io::IO, a::BlocksView, toplevel::Bool)
     if toplevel

--- a/src/pseudo_blockarray.jl
+++ b/src/pseudo_blockarray.jl
@@ -225,7 +225,10 @@ to_axes(n::Integer) = Base.oneto(n)
     PseudoBlockArray{T}(undef, map(to_axes,axes))
 
 @propagate_inbounds getindex(block_arr::PseudoBlockArray{T, N}, i::Vararg{Integer, N}) where {T,N} = block_arr.blocks[i...]
-@propagate_inbounds setindex!(block_arr::PseudoBlockArray{T, N}, v, i::Vararg{Integer, N}) where {T,N} = setindex!(block_arr.blocks, v, i...)
+@propagate_inbounds function setindex!(block_arr::PseudoBlockArray{T, N}, v, i::Vararg{Integer, N}) where {T,N}
+    setindex!(block_arr.blocks, v, i...)
+    block_arr
+end
 
 ################################
 # AbstractBlockArray Interface #


### PR DESCRIPTION
This follows the Base convention of returning the array in a `setindex!`