### PR TITLE
Fix blocks in popfirst

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BlockArrays"
 uuid = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
-version = "0.16.39"
+version = "0.16.40"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/blockdeque.jl
+++ b/src/blockdeque.jl
@@ -307,13 +307,12 @@ function Base.popfirst!(A::BlockVector)
     isempty(A) && throw(Argument("array must be nonempty"))
     _squash_firsts!(A)
     x = popfirst!(A.blocks[1])
-    ax, = A.axes
+    lasts = blocklasts(A.axes[1])
     if isempty(A.blocks[1])
         popfirst!(A.blocks)
-        popfirst!(blocklasts(ax))
-    else
-        blocklasts(ax)[1] -= 1
+        popfirst!(lasts)
     end
+    lasts .-= 1
     return x
 end
 

--- a/test/test_blockdeque.jl
+++ b/test/test_blockdeque.jl
@@ -165,6 +165,7 @@ using BlockArrays, Test
             @test pop!(B) == 6
             @test B == 1:5
             @test !any(isempty, blocks(B))
+            @test blocksizes(B,1) == [1,2,2]
         end
     end
 
@@ -176,5 +177,18 @@ using BlockArrays, Test
         end
         @test A == []
         @test B == 1:5
+
+        A = BlockArray([1:6;], [2,2,2])
+        @test popfirst!(A) == 1
+        @test A == 2:6
+        @test blocksizes(A,1) == [1,2,2]
+
+        @testset "empty blocks" begin
+            B = BlockArray([1:6;], [0,0,1,2,3])
+            @test popfirst!(B) == 1
+            @test B == 2:6
+            @test blocksizes(B,1) == [2,3]
+            @test !any(isempty, blocks(B))
+        end
     end
 end


### PR DESCRIPTION
Fixes the following behaviour on master:
```julia
julia> B = BlockArray([1:6;], [2,2,2])
3-blocked 6-element BlockVector{Int64}:
 1
 2
 ─
 3
 4
 ─
 5
 6

julia> popfirst!(B)
1

julia> B
3-blocked 6-element BlockVector{Int64}:
               2
 ───────────────
               3
               4
 139721335802992
 ───────────────
               5
               6
```