### PR TITLE
Index into a CartesianIndices with a Block

### DIFF
--- a/src/blockindices.jl
+++ b/src/blockindices.jl
@@ -302,13 +302,13 @@ _indices(B) = B
 
 @propagate_inbounds getindex(S::BlockSlice, i::Integer) = getindex(S.indices, i)
 @propagate_inbounds getindex(S::BlockSlice{<:Block{1}}, k::AbstractUnitRange{Int}) =
-    BlockSlice(S.block, S.indices[_indices(k)])
+    BlockSlice(S.block[_indices(k)], S.indices[_indices(k)])
 @propagate_inbounds getindex(S::BlockSlice{<:BlockIndexRange{1}}, k::AbstractUnitRange{Int}) =
-    BlockSlice(S.block, S.indices[_indices(k)])
+    BlockSlice(S.block[_indices(k)], S.indices[_indices(k)])
 show(io::IO, r::BlockSlice) = print(io, "BlockSlice(", r.block, ",", r.indices, ")")
 
 # Avoid creating a SubArray wrapper in certain non-allocating cases
-Base.@propagate_inbounds Base.view(C::CartesianIndices{N}, bs::Vararg{BlockSlice,N}) where {N} = C[bs...]
+Base.@propagate_inbounds Base.view(C::CartesianIndices{N}, bs::Vararg{BlockSlice,N}) where {N} = view(C, map(x->x.indices, bs)...)
 
 Block(bs::BlockSlice{<:BlockIndexRange}) = Block(bs.block)
 

--- a/src/blockindices.jl
+++ b/src/blockindices.jl
@@ -115,10 +115,13 @@ end
 
 # Some views may be computed eagerly without the SubArray wrapper
 Base.@propagate_inbounds Base.view(r::AbstractRange, B::Block{1}) = r[to_indices(r, (B,))...]
+Base.@propagate_inbounds function Base.view(C::CartesianIndices{N}, b1::Block{1}, B::Block{1}...) where {N}
+    blk = Block((b1, B...))
+    view(C, to_indices(C, (blk,))...)
+end
 Base.@propagate_inbounds function Base.view(C::CartesianIndices{N}, B::Block{N}) where {N}
     inds = to_indices(C, (B,))
-    @boundscheck checkbounds(C, inds...)
-    @inbounds view(C, inds...)
+    view(C, inds...)
 end
 
 """

--- a/src/blockindices.jl
+++ b/src/blockindices.jl
@@ -120,8 +120,7 @@ Base.@propagate_inbounds function Base.view(C::CartesianIndices{N}, b1::Block{1}
     view(C, to_indices(C, (blk,))...)
 end
 Base.@propagate_inbounds function Base.view(C::CartesianIndices{N}, B::Block{N}) where {N}
-    inds = to_indices(C, (B,))
-    view(C, inds...)
+    view(C, to_indices(C, (B,))...)
 end
 
 """

--- a/test/test_blockindices.jl
+++ b/test/test_blockindices.jl
@@ -108,22 +108,24 @@ import BlockArrays: BlockIndex, BlockIndexRange, BlockSlice
         @test view(r, Block(1)) === r
         @test_throws BlockBoundsError view(r, Block(2))
         C = CartesianIndices((2:10, 2:10))
-        @test view(C, Block(1,1)) === C
+        ==ᵥ = VERSION >= v"1.10" ? (===) : (==)
+
+        @test view(C, Block(1,1)) ==ᵥ C
         @test view(C, Block(1), Block(1)) == C
         @test_throws BlockBoundsError view(C, Block(1), Block(2))
         @test_throws BlockBoundsError view(C, Block(1,2))
 
         B = BlockArray([1:3;], [2,1])
         Cb = CartesianIndices(B)
-        @test view(Cb, Block(1)) === Cb[Block(1)] === CartesianIndices((1:2,))
-        @test view(Cb, Block(2)) === Cb[Block(2)] === CartesianIndices((3:3,))
+        @test view(Cb, Block(1)) ==ᵥ Cb[Block(1)] ==ᵥ CartesianIndices((1:2,))
+        @test view(Cb, Block(2)) ==ᵥ Cb[Block(2)] ==ᵥ CartesianIndices((3:3,))
 
         B = BlockArray(reshape([1:9;],3,3), [2,1], [2,1])
         Cb = CartesianIndices(B)
-        @test view(Cb, Block(1,1)) === Cb[Block(1,1)] === CartesianIndices((1:2,1:2))
-        @test view(Cb, Block(1,2)) === Cb[Block(1,2)] === CartesianIndices((1:2, 3:3))
-        @test view(Cb, Block(2,1)) === Cb[Block(2,1)] === CartesianIndices((3:3,1:2))
-        @test view(Cb, Block(2,2)) === Cb[Block(2,2)] === CartesianIndices((3:3, 3:3))
+        @test view(Cb, Block(1,1)) ==ᵥ Cb[Block(1,1)] ==ᵥ CartesianIndices((1:2,1:2))
+        @test view(Cb, Block(1,2)) ==ᵥ Cb[Block(1,2)] ==ᵥ CartesianIndices((1:2, 3:3))
+        @test view(Cb, Block(2,1)) ==ᵥ Cb[Block(2,1)] ==ᵥ CartesianIndices((3:3,1:2))
+        @test view(Cb, Block(2,2)) ==ᵥ Cb[Block(2,2)] ==ᵥ CartesianIndices((3:3, 3:3))
         for i in 1:2, j in 1:2
             @test view(Cb, Block(j), Block(i)) == view(Cb, Block(j, i)) == Cb[Block(j, i)]
         end
@@ -431,9 +433,9 @@ end
 
 @testset "BlockSlice" begin
     b = BlockSlice(Block(5),1:3)
-    @test b[b] === b
+    @test b[b] == b
     @test b[Base.Slice(1:3)] ≡ b
-    @test b[1:2] ≡ b[1:2][1:2] ≡ BlockSlice(Block(5),1:2)
+    @test b[1:2] ≡ b[1:2][1:2] ≡ BlockSlice(Block(5)[1:2],1:2)
     @test Block(b) ≡ Block(5)
 
     @testset "OneTo converts" begin
@@ -448,6 +450,8 @@ end
         b = BlockSlice(Block(1), r)
         @test view(C, b) === view(C, r)
         @test view(1:10, b) === view(1:10, r)
+        C = CartesianIndices((1:3, 1:3))
+        @test view(C, b, b) === view(C, r, r)
     end
 end
 

--- a/test/test_blockindices.jl
+++ b/test/test_blockindices.jl
@@ -127,8 +127,11 @@ import BlockArrays: BlockIndex, BlockIndexRange, BlockSlice
         @test view(Cb, Block(2,1)) ==ᵥ Cb[Block(2,1)] ==ᵥ CartesianIndices((3:3,1:2))
         @test view(Cb, Block(2,2)) ==ᵥ Cb[Block(2,2)] ==ᵥ CartesianIndices((3:3, 3:3))
         for i in 1:2, j in 1:2
-            @test view(Cb, Block(j), Block(i)) == view(Cb, Block(j, i)) == Cb[Block(j, i)]
+            @test view(Cb, Block(j), Block(i)) ==ᵥ view(Cb, Block(j, i))
         end
+        # ensure that calls with mismatched ndims don't error
+        @test view(Cb, Block(1)) == view(Cb, to_indices(Cb, (Block(1),))...)
+        @test reshape(view(Cb, Block(1), Block(1), Block(1)), 2, 2) == view(Cb, Block(1), Block(1))
     end
 
     @testset "print" begin

--- a/test/test_blockindices.jl
+++ b/test/test_blockindices.jl
@@ -437,6 +437,7 @@ end
 @testset "BlockSlice" begin
     b = BlockSlice(Block(5),1:3)
     @test b[b] == b
+    @test b[b] isa BlockSlice{<:BlockIndexRange}
     @test b[Base.Slice(1:3)] ≡ b
     @test b[1:2] ≡ b[1:2][1:2] ≡ BlockSlice(Block(5)[1:2],1:2)
     @test Block(b) ≡ Block(5)

--- a/test/test_blockindices.jl
+++ b/test/test_blockindices.jl
@@ -405,14 +405,23 @@ end
 
 @testset "BlockSlice" begin
     b = BlockSlice(Block(5),1:3)
+    @test b[b] === b
     @test b[Base.Slice(1:3)] ≡ b
-    @test b[1:2] ≡ b[1:2][1:2] ≡ BlockSlice(Block(5)[1:2],1:2)
+    @test b[1:2] ≡ b[1:2][1:2] ≡ BlockSlice(Block(5),1:2)
     @test Block(b) ≡ Block(5)
 
     @testset "OneTo converts" begin
         for b in (BlockSlice(Block(1), 1:1), BlockSlice(Block.(1:1), 1:1), BlockSlice(Block(1)[1:1], 1:1))
             @test convert(typeof(b), Base.OneTo(1)) ≡ b
         end
+    end
+
+    @testset "view into CartesianIndices/ranges" begin
+        C = CartesianIndices((1:3,))
+        r = 1:2
+        b = BlockSlice(Block(1), r)
+        @test view(C, b) === view(C, r)
+        @test view(1:10, b) === view(1:10, r)
     end
 end
 

--- a/test/test_blockindices.jl
+++ b/test/test_blockindices.jl
@@ -103,6 +103,32 @@ import BlockArrays: BlockIndex, BlockIndexRange, BlockSlice
         @test intersect(Block.(2:5), Block.(3:6)) ≡ Block.(3:5)
     end
 
+    @testset "view into CartesianIndices/ranges" begin
+        r = 2:10
+        @test view(r, Block(1)) === r
+        @test_throws BlockBoundsError view(r, Block(2))
+        C = CartesianIndices((2:10, 2:10))
+        @test view(C, Block(1,1)) === C
+        @test view(C, Block(1), Block(1)) == C
+        @test_throws BlockBoundsError view(C, Block(1), Block(2))
+        @test_throws BlockBoundsError view(C, Block(1,2))
+
+        B = BlockArray([1:3;], [2,1])
+        Cb = CartesianIndices(B)
+        @test view(Cb, Block(1)) === Cb[Block(1)] === CartesianIndices((1:2,))
+        @test view(Cb, Block(2)) === Cb[Block(2)] === CartesianIndices((3:3,))
+
+        B = BlockArray(reshape([1:9;],3,3), [2,1], [2,1])
+        Cb = CartesianIndices(B)
+        @test view(Cb, Block(1,1)) === Cb[Block(1,1)] === CartesianIndices((1:2,1:2))
+        @test view(Cb, Block(1,2)) === Cb[Block(1,2)] === CartesianIndices((1:2, 3:3))
+        @test view(Cb, Block(2,1)) === Cb[Block(2,1)] === CartesianIndices((3:3,1:2))
+        @test view(Cb, Block(2,2)) === Cb[Block(2,2)] === CartesianIndices((3:3, 3:3))
+        for i in 1:2, j in 1:2
+            @test view(Cb, Block(j), Block(i)) == view(Cb, Block(j, i)) == Cb[Block(j, i)]
+        end
+    end
+
     @testset "print" begin
         @test sprint(show, "text/plain", Block()) == "Block()"
         @test sprint(show, "text/plain", Block(1)) == "Block(1)"


### PR DESCRIPTION
After this, indexing into a `CartesianIndices` with a `Block` produces a `CartesianIndices` if the `ndims` match.
```julia
julia> B = BlockArray(reshape([1:9;],3,3), [2,1], [2,1])
2×2-blocked 3×3 BlockMatrix{Int64}:
 1  4  │  7
 2  5  │  8
 ──────┼───
 3  6  │  9

julia> C = CartesianIndices(B)
CartesianIndices((1:1:3, 1:1:3))

julia> C[Block(1,1)]
CartesianIndices((1:2, 1:2))
```
This addresses the comment in https://github.com/JuliaArrays/BlockArrays.jl/issues/346#issue-2200055475

The indexing operation `C[Block(1), Block(1)]`  ~~should also work identically, but this is WIP.~~ works identically:
```julia
julia> C[Block(1), Block(1)]
CartesianIndices((1:2, 1:2))
```