### PR TITLE
[WIP] `BlockIndices`

### DIFF
--- a/src/BlockArrays.jl
+++ b/src/BlockArrays.jl
@@ -56,6 +56,7 @@ end
 include("blockindices.jl")
 include("blockaxis.jl")
 include("abstractblockarray.jl")
+include("block_indices.jl")
 include("blockarray.jl")
 include("pseudo_blockarray.jl")
 include("views.jl")

--- a/src/block_indices.jl
+++ b/src/block_indices.jl
@@ -25,8 +25,8 @@ end
 function Base.axes(a::BlockIndices)
   return map(Base.axes1, blockedunitrange_getindex.(a.indices, range.(a.first, last.(a.indices))))
 end
-function BlockIndices(indices::Tuple{Vararg{AbstractUnitRange{Int}}})
-    first = ntuple(Returns(1), length(indices))
+function BlockIndices(indices::Tuple{Vararg{AbstractUnitRange{Int},N}}) where {N}
+    first = ntuple(_ -> 1, Val(N))
     return _BlockIndices(first, indices)
 end
 BlockIndices(a::AbstractArray) = BlockIndices(axes(a))
@@ -68,7 +68,7 @@ function Base.getindex(a::BlockIndices{N}, indices::BlockIndexRange{N}) where {N
 end
 
 function Base.view(a::BlockIndices{N}, indices::Vararg{AbstractUnitRange,N}) where {N}
-    offsets = a.first .- ntuple(Returns(1), Val(N))
+    offsets = a.first .- ntuple(_ -> 1, Val(N))
     firsts = first.(indices) .+ offsets
     inds = blockedunitrange_getindex.(a.indices, Base.OneTo.(last.(indices) .+ offsets))
     return _BlockIndices(firsts, inds)

--- a/src/block_indices.jl
+++ b/src/block_indices.jl
@@ -1,9 +1,3 @@
-struct BlockIndices{N,R<:NTuple{N,OrdinalRange{Int,Int}}} <: AbstractBlockArray{BlockIndex{N},N}
-  indices::R
-end
-Base.axes(a::BlockIndices) = map(Base.axes1, a.indices)
-BlockIndices(a::AbstractArray) = BlockIndices(axes(a))
-
 function to_blockindex(a::AbstractUnitRange, index::Integer)
     axis_blockindex = findblockindex(only(axes(a)), index)
     if !isone(first(a)) && block(axis_blockindex) == Block(1)
@@ -12,19 +6,95 @@ function to_blockindex(a::AbstractUnitRange, index::Integer)
     return axis_blockindex
 end
 
+function blockedunitrange_getindex(a::BlockedUnitRange, indices::AbstractUnitRange)
+  first_block = block(to_blockindex(a, first(indices)))
+  last_block = block(to_blockindex(a, last(indices)))
+  lasts = [blocklasts(a)[Int(first_block):(Int(last_block) - 1)]; last(indices)]
+  return BlockArrays._BlockedUnitRange(first(indices), lasts)
+end
+
+function _BlockIndices end
+
+struct BlockIndices{N,R<:NTuple{N,AbstractUnitRange{Int}}} <: AbstractBlockArray{BlockIndex{N},N}
+  first::NTuple{N,Int}
+  indices::R
+  global function _BlockIndices(first::NTuple{N,Int}, indices::NTuple{N,AbstractUnitRange{Int}}) where {N}
+      return new{N,typeof(indices)}(first, indices)
+  end
+end
+function Base.axes(a::BlockIndices)
+  return map(Base.axes1, blockedunitrange_getindex.(a.indices, range.(a.first, last.(a.indices))))
+end
+function BlockIndices(indices::Tuple{Vararg{AbstractUnitRange{Int}}})
+    first = ntuple(Returns(1), length(indices))
+    return _BlockIndices(first, indices)
+end
+BlockIndices(a::AbstractArray) = BlockIndices(axes(a))
+
 function Base.getindex(a::BlockIndices{N}, index::Vararg{Integer,N}) where {N}
-    return BlockIndex(to_blockindex.(a.indices, index))
+    return BlockIndex(to_blockindex.(a.indices, index .+ a.first .- 1))
 end
 
 function Base.view(a::BlockIndices{N}, block::Block{N}) where {N}
     return viewblock(a, block)
 end
 
-function Base.view(a::BlockIndices, block::Vararg{Block{1}})
-  return view(a, Block(block))
+function Base.view(a::BlockIndices{1}, block::Block{1})
+    return viewblock(a, block)
+end
+
+function Base.view(a::BlockIndices{N}, block::Vararg{Block{1},N}) where {N}
+    return view(a, Block(block))
 end
 
 function viewblock(a::BlockIndices, block)
     range = Base.OneTo.(getindex.(blocklengths.(axes(a)), Int.(Tuple(block))))
     return block[range...]
+end
+
+function Base.view(a::BlockIndices{N}, indices::Vararg{BlockIndexRange{1},N}) where {N}
+    return view(a, BlockIndexRange(Block(block.(indices)), only.(getfield.(indices, :indices))))
+end
+
+function Base.view(a::BlockIndices{N}, indices::BlockIndexRange{N}) where {N}
+    a_block = a[block(indices)]
+    return block(a_block)[getindex.(a_block.indices, indices.indices)...]
+end
+
+# Circumvent that this is getting hijacked to call `a[block(indices)][indices.indices...]`,
+# which hits the bug https://github.com/JuliaArrays/BlockArrays.jl/issues/355.
+function Base.getindex(a::BlockIndices{N}, indices::BlockIndexRange{N}) where {N}
+    return view(a, indices)
+end
+
+function Base.view(a::BlockIndices{N}, indices::Vararg{AbstractUnitRange,N}) where {N}
+    offsets = a.first .- ntuple(Returns(1), Val(N))
+    firsts = first.(indices) .+ offsets
+    inds = blockedunitrange_getindex.(a.indices, Base.OneTo.(last.(indices) .+ offsets))
+    return _BlockIndices(firsts, inds)
+end
+
+# Ranges that result in contiguous slices, and therefore preserve `BlockIndices`.
+const BlockOrUnitRanges = Union{AbstractUnitRange,CartesianIndices{1},Block{1},BlockRange{1},BlockIndexRange{1}}
+
+function Base.view(a::BlockIndices{N}, indices::Vararg{BlockOrUnitRanges,N}) where {N}
+    return view(a, to_indices(a, indices)...)
+end
+
+function Base.view(a::BlockIndices{N}, indices::CartesianIndices{N}) where {N}
+    return view(a, to_indices(a, (indices,))...)
+end
+
+# For some reason this doesn't call `view` automatically.
+function Base.getindex(a::BlockIndices{N}, indices::CartesianIndices{N}) where {N}
+    return view(a, to_indices(a, (indices,))...)
+end
+
+function Base.view(a::BlockIndices{N}, indices::BlockRange{N}) where {N}
+    return view(a, to_indices(a, (indices,))...)
+end
+
+# For some reason this doesn't call `view` automatically.
+function Base.getindex(a::BlockIndices{N}, indices::BlockRange{N}) where {N}
+    return view(a, to_indices(a, (indices,))...)
 end

--- a/src/block_indices.jl
+++ b/src/block_indices.jl
@@ -1,0 +1,18 @@
+struct BlockIndices{N,R<:NTuple{N,OrdinalRange{Int,Int}}} <: AbstractBlockArray{BlockIndex{N},N}
+  indices::R
+end
+Base.axes(a::BlockIndices) = map(Base.axes1, a.indices)
+BlockIndices(a::AbstractArray) = BlockIndices(axes(a))
+
+function Base.getindex(a::BlockIndices{N}, index::Vararg{Integer,N}) where {N}
+    return BlockIndex(findblockindex.(axes(a), index))
+end
+
+function Base.view(a::BlockIndices{N}, block::Block{N}) where {N}
+    return viewblock(a, block)
+end
+
+function viewblock(a::BlockIndices, block)
+    range = Base.OneTo.(getindex.(blocklengths.(axes(a)), Int.(Tuple(block))))
+    return block[range...]
+end

--- a/src/block_indices.jl
+++ b/src/block_indices.jl
@@ -4,12 +4,24 @@ end
 Base.axes(a::BlockIndices) = map(Base.axes1, a.indices)
 BlockIndices(a::AbstractArray) = BlockIndices(axes(a))
 
+function to_blockindex(a::AbstractUnitRange, index::Integer)
+    axis_blockindex = findblockindex(only(axes(a)), index)
+    if !isone(first(a)) && block(axis_blockindex) == Block(1)
+        axis_blockindex = block(axis_blockindex)[blockindex(axis_blockindex) + first(a) - one(eltype(a))]
+    end
+    return axis_blockindex
+end
+
 function Base.getindex(a::BlockIndices{N}, index::Vararg{Integer,N}) where {N}
-    return BlockIndex(findblockindex.(axes(a), index))
+    return BlockIndex(to_blockindex.(a.indices, index))
 end
 
 function Base.view(a::BlockIndices{N}, block::Block{N}) where {N}
     return viewblock(a, block)
+end
+
+function Base.view(a::BlockIndices, block::Vararg{Block{1}})
+  return view(a, Block(block))
 end
 
 function viewblock(a::BlockIndices, block)

--- a/src/block_indices.jl
+++ b/src/block_indices.jl
@@ -23,7 +23,7 @@ struct BlockIndices{N,R<:NTuple{N,AbstractUnitRange{Int}}} <: AbstractBlockArray
   end
 end
 function Base.axes(a::BlockIndices)
-  return map(Base.axes1, blockedunitrange_getindex.(a.indices, range.(a.first, last.(a.indices))))
+  return map(Base.axes1, blockedunitrange_getindex.(a.indices, (:).(a.first, last.(a.indices))))
 end
 function BlockIndices(indices::Tuple{Vararg{AbstractUnitRange{Int},N}}) where {N}
     first = ntuple(_ -> 1, Val(N))

--- a/src/block_indices.jl
+++ b/src/block_indices.jl
@@ -102,3 +102,15 @@ end
 function Base.getindex(a::BlockIndices{N}, indices::BlockRange{N}) where {N}
     return view(a, to_indices(a, (indices,))...)
 end
+
+function Base.getindex(a::CartesianIndices{N}, indices::BlockIndices{N}) where {N}
+  # TODO: Is there a better way to write this?
+  new_axes = (:).(Tuple(a[first(indices)]), Tuple(a[last(indices)]))
+  firsts = first.(new_axes)
+  blocklasts = ntuple(i -> accumulate(+, blocklengths(axes(indices, i)); init=firsts[i] - one(firsts[i])), Val(N))
+  return CartesianIndices(_BlockedUnitRange.(firsts, blocklasts))
+end
+
+function Base.getindex(a::AbstractArray{<:Any,N}, indices::BlockIndices{N}) where {N}
+  return a[CartesianIndices(a)[indices]]
+end

--- a/test/test_blockindices.jl
+++ b/test/test_blockindices.jl
@@ -502,9 +502,8 @@ end
     @test B[BlockRange(1:2, 1:2)] == B
     @test B[BlockRange(1:2, 1:2)] isa BlockIndices{2}
 
-    # TODO: Should this make a `BlockIndices{1}`?
-    @test B[Block(2), Block.(1:2)] == mortar([[Block(2, 1)[1:3, 1:3]] [Block(2, 2)[1:3, 1:4]]])
-    @test B[Block(2), Block.(1:2)] isa BlockIndices{2}
+    @test B[Block.(2:2), Block.(1:2)] == mortar([[Block(2, 1)[1:3, 1:3]] [Block(2, 2)[1:3, 1:4]]])
+    @test B[Block.(2:2), Block.(1:2)] isa BlockIndices{2}
 
     @test B[2:4, 2:5][2:3, 2:3] == mortar([[Block(2, 1)[1:2, 3:3]] [Block(2, 2)[1:2, 1:1]]])
     @test B[2:4, 2:5][2:3, 2:3] isa BlockIndices{2}

--- a/test/test_blockindices.jl
+++ b/test/test_blockindices.jl
@@ -520,4 +520,25 @@ end
     @test blocklengths(only(axes(B[2:4]))) == [3]
     @test B[2:4] isa AbstractVector{<:BlockIndex{1}}
     @test B[2:4] isa BlockIndices{1}
+
+    A = BlockArray(randn(5, 5), [2, 3], [2, 3])
+    BA = BlockIndices(A)
+    r = BlockArrays._BlockedUnitRange(2, [2, 4])
+    B = BA[r, r]
+    @test B == BA[2:4, 2:4]
+    @test size(B) == (3, 3)
+    @test blocksize(B) == (2, 2)
+    @test blocklengths.(axes(B)) == ([1, 2], [1, 2])
+    CB = CartesianIndices(A)[B]
+    @test CB == CartesianIndices((2:4, 2:4))
+    @test size(CB) == (3, 3)
+    @test blocksize(CB) == (2, 2)
+    @test blocklengths.(axes(CB)) == ([1, 2], [1, 2])
+    @test all(blockisequal.(axes(CB), axes(B)))
+    AB = A[B]
+    @test AB == A[2:4, 2:4]
+    @test size(AB) == (3, 3)
+    @test blocksize(AB) == (2, 2)
+    @test blocklengths.(axes(AB)) == ([1, 2], [1, 2])
+    @test all(blockisequal.(axes(AB), axes(B)))
 end

--- a/test/test_blockindices.jl
+++ b/test/test_blockindices.jl
@@ -457,7 +457,7 @@ end
     @test axes(B) == (1:5, 1:7)
     @test blocklengths.(axes(B)) == ([2, 3], [3, 4])
     @test blocksize(B) == (2, 2)
-    @test blockaxes(B) == (Block(1):Block(2), Block(1):Block(2))
+    @test blockaxes(B) == (Block.(1:2), Block.(1:2))
     @test B[1, 1] == Block(1, 1)[1, 1]
     @test B[4, 6] == Block(2, 2)[2, 3]
 
@@ -478,24 +478,33 @@ end
 
     B23_24 = mortar([[Block(1, 1)[2:2, 2:3]] [Block(1, 2)[2:2, 1:1]]
                      [Block(2, 1)[1:1, 2:3]] [Block(2, 2)[1:1, 1:1]]])
-    @test B[2:3, 2:4] == B23_24
-    @test B[2:3, 2:4] isa BlockIndices{2}
-    @test B[CartesianIndices((2:3,)), CartesianIndices((2:4,))] == B23_24
-    @test B[CartesianIndices((2:3,)), CartesianIndices((2:4,))] isa BlockIndices{2}
-    @test B[CartesianIndices((2:3, 2:4))] == B23_24
-    @test B[CartesianIndices((2:3, 2:4))] isa BlockIndices{2}
+    Br = B[2:3, 2:4]
+    @test Br == B23_24
+    @test blocksize(Br) == (1, 1)
+    @test Br isa AbstractMatrix{<:BlockIndex{2}}
+    @test Br isa BlockIndices{2}
+    Br = B[CartesianIndices((2:3,)), CartesianIndices((2:4,))]
+    @test Br == B23_24
+    @test blocksize(Br) == (1, 1)
+    @test Br isa AbstractMatrix{<:BlockIndex{2}}
+    @test Br isa BlockIndices{2}
+    Br = B[CartesianIndices((2:3, 2:4))]
+    @test Br == B23_24
+    @test Br isa AbstractMatrix{<:BlockIndex{2}}
+    @test Br isa BlockIndices{2}
 
     @test B[Block(2, 2)[2:3, 2:3]] == Block(2, 2)[2:3, 2:3]
     @test B[Block(2, 2)[2:3, 2:3]] isa BlockIndexRange{2}
 
-    @test B[Block(1):Block(2), Block(1):Block(2)] == B
-    @test B[Block(1):Block(2), Block(1):Block(2)] isa BlockIndices{2}
+    @test B[Block.(1:2), Block.(1:2)] == B
+    @test B[Block.(1:2), Block.(1:2)] isa BlockIndices{2}
 
     @test B[BlockRange(1:2, 1:2)] == B
     @test B[BlockRange(1:2, 1:2)] isa BlockIndices{2}
 
-    @test B[Block(2), Block(1):Block(2)] == mortar([[Block(2, 1)[1:3, 1:3]] [Block(2, 2)[1:3, 1:4]]])
-    @test B[Block(2), Block(1):Block(2)] isa BlockIndices{2}
+    # TODO: Should this make a `BlockIndices{1}`?
+    @test B[Block(2), Block.(1:2)] == mortar([[Block(2, 1)[1:3, 1:3]] [Block(2, 2)[1:3, 1:4]]])
+    @test B[Block(2), Block.(1:2)] isa BlockIndices{2}
 
     @test B[2:4, 2:5][2:3, 2:3] == mortar([[Block(2, 1)[1:2, 3:3]] [Block(2, 2)[1:2, 1:1]]])
     @test B[2:4, 2:5][2:3, 2:3] isa BlockIndices{2}
@@ -508,6 +517,8 @@ end
     @test B[Block(2)] == Block(2)[1:3]
     @test B[Block(2)] isa BlockIndexRange{1}
     @test B[2:4] == [Block(1)[2], Block(2)[1], Block(2)[2]]
-    @test blocklengths(only(axes(B[2:4]))) == [1, 2]
+    @test blocklength(only(axes(B[2:4]))) == 1
+    @test blocklengths(only(axes(B[2:4]))) == [3]
+    @test B[2:4] isa AbstractVector{<:BlockIndex{1}}
     @test B[2:4] isa BlockIndices{1}
 end

--- a/test/test_blockindices.jl
+++ b/test/test_blockindices.jl
@@ -1,6 +1,6 @@
 using BlockArrays, FillArrays, Test, StaticArrays, ArrayLayouts
 using OffsetArrays
-import BlockArrays: BlockIndex, BlockIndexRange, BlockSlice
+import BlockArrays: BlockIndex, BlockIndexRange, BlockIndices, BlockSlice
 
 @testset "Blocks" begin
     @test Int(Block(2)) === Integer(Block(2)) === Number(Block(2)) === 2
@@ -445,4 +445,33 @@ end
     @test A[1,2] == 0
     first(eachblock(B))[1,2] = 0
     @test B[1,2] == 0
+end
+
+@testset "BlockIndices" begin
+    v = Array(reshape(1:35, (5, 7)))
+    A = BlockArray(v, [2,3], [3,4])
+    B = BlockIndices(A)
+    @test B == BlockIndices((blockedrange([2,3]), blockedrange([3,4])))
+    @test eltype(B) === BlockIndex{2}
+    @test size(B) == (5, 7)
+    @test axes(B) == (1:5, 1:7)
+    @test blocksize(B) == (2, 2)
+    @test blockaxes(B) == (Block(1):Block(2), Block(1):Block(2))
+    @test B[1, 1] == Block(1, 1)[1, 1]
+    @test B[4, 6] == Block(2, 2)[2, 3]
+
+    @test B[Block(1, 1)] isa BlockArrays.BlockIndexRange{2}
+    @test B[Block(1, 1)] == Block(1, 1)[1:2, 1:3]
+    @test B[Block(2, 1)] == Block(2, 1)[1:3, 1:3]
+    @test B[Block(1, 2)] == Block(1, 2)[1:2, 1:4]
+    @test B[Block(2, 2)] == Block(2, 2)[1:3, 1:4]
+
+    @test view(B, Block(1, 2)) isa BlockArrays.BlockIndexRange{2}
+    @test view(B, Block(1, 2)) == Block(1, 2)[1:2, 1:4]
+
+    @test B[Block(1), Block(2)] isa BlockArrays.BlockIndexRange{2}
+    @test B[Block(1), Block(2)] == Block(1, 2)[1:2, 1:4]
+
+    @test view(B, Block(1), Block(2)) isa BlockArrays.BlockIndexRange{2}
+    @test view(B, Block(1), Block(2)) == Block(1, 2)[1:2, 1:4]
 end

--- a/test/test_blockindices.jl
+++ b/test/test_blockindices.jl
@@ -460,18 +460,32 @@ end
     @test B[1, 1] == Block(1, 1)[1, 1]
     @test B[4, 6] == Block(2, 2)[2, 3]
 
-    @test B[Block(1, 1)] isa BlockArrays.BlockIndexRange{2}
+    @test B[Block(1, 1)] isa BlockIndexRange{2}
     @test B[Block(1, 1)] == Block(1, 1)[1:2, 1:3]
     @test B[Block(2, 1)] == Block(2, 1)[1:3, 1:3]
     @test B[Block(1, 2)] == Block(1, 2)[1:2, 1:4]
     @test B[Block(2, 2)] == Block(2, 2)[1:3, 1:4]
 
-    @test view(B, Block(1, 2)) isa BlockArrays.BlockIndexRange{2}
+    @test view(B, Block(1, 2)) isa BlockIndexRange{2}
     @test view(B, Block(1, 2)) == Block(1, 2)[1:2, 1:4]
 
-    @test B[Block(1), Block(2)] isa BlockArrays.BlockIndexRange{2}
+    @test B[Block(1), Block(2)] isa BlockIndexRange{2}
     @test B[Block(1), Block(2)] == Block(1, 2)[1:2, 1:4]
 
-    @test view(B, Block(1), Block(2)) isa BlockArrays.BlockIndexRange{2}
+    @test view(B, Block(1), Block(2)) isa BlockIndexRange{2}
     @test view(B, Block(1), Block(2)) == Block(1, 2)[1:2, 1:4]
+
+    r1 = BlockArrays._BlockedUnitRange(2, [2, 3])
+    r2 = BlockArrays._BlockedUnitRange(2, [3, 4])
+    @test B[2:3, 2:4] == BlockIndices((r1, r2))
+    @test_broken B[2:3, 2:4] isa BlockIndices{2}
+
+    @test B[Block(2, 2)[2:3, 2:3]] == Block(2, 2)[2:3, 2:3]
+    @test_broken B[Block(2, 2)[2:3, 2:3]] isa BlockedIndexRange{2}
+
+    @test B[Block(1):Block(2), Block(1):Block(2)] == B
+    @test_broken B[Block(1):Block(2), Block(1):Block(2)] isa BlockedIndices{2}
+
+    @test B[Block(2), Block(1):Block(2)] == mortar([[Block(2, 1)[1:3, 1:3]] [Block(2, 2)[1:3, 1:4]]])
+    @test_broken B[Block(2), Block(1):Block(2)] isa BlockedIndices{2}
 end


### PR DESCRIPTION
This is an implementation of #346.

TODO:
- [ ] When indexing an `AbstractArray` with `BlockIndices` (i.e. `getindex(a::AbstractArray, indices::BlockIndices)`) check that the block indices are compatible, say with `blockisequal`.
- [ ] Implement `view(a::CartesianIndices, indices::BlockIndices)`.
- [ ] Implement `getindex(a::AbstractArray, indices::BlockIndices{1}...)`.
- [ ] Fix indexing into `BlockIndices` with offset axes (https://github.com/JuliaArrays/BlockArrays.jl/pull/356#issuecomment-2027457046).

Here is a demonstration of what works so far:
```julia
julia> using BlockArrays

julia> using BlockArrays: BlockIndices

julia> A = BlockArray(randn(4, 4), [2, 2], [2, 2])
2×2-blocked 4×4 BlockMatrix{Float64}:
 -1.74603    0.659762  │  -1.08084    1.75196 
  0.257445   0.793993  │  -0.922037  -0.802863
 ──────────────────────┼──────────────────────
  1.40111   -0.570552  │  -2.91592    0.415012
 -2.30074    1.10324   │   1.52008   -0.846554

julia> B = BlockIndices(A)
2×2-blocked 4×4 BlockIndices{2, Tuple{BlockedUnitRange{Vector{Int64}}, BlockedUnitRange{Vector{Int64}}}}:
 Block(1, 1)[1, 1]  Block(1, 1)[1, 2]  │  Block(1, 2)[1, 1]  Block(1, 2)[1, 2]
 Block(1, 1)[2, 1]  Block(1, 1)[2, 2]  │  Block(1, 2)[2, 1]  Block(1, 2)[2, 2]
 ──────────────────────────────────────┼──────────────────────────────────────
 Block(2, 1)[1, 1]  Block(2, 1)[1, 2]  │  Block(2, 2)[1, 1]  Block(2, 2)[1, 2]
 Block(2, 1)[2, 1]  Block(2, 1)[2, 2]  │  Block(2, 2)[2, 1]  Block(2, 2)[2, 2]

julia> B[Block(2, 1)]
2×2 BlockArrays.BlockIndexRange{2, Tuple{Base.OneTo{Int64}, Base.OneTo{Int64}}}:
 Block(2, 1)[1, 1]  Block(2, 1)[1, 2]
 Block(2, 1)[2, 1]  Block(2, 1)[2, 2]

julia> B[2, 3]
Block(1, 2)[2, 1]

julia> B[Block(2, 1)[1, 2]]
Block(2, 1)[1, 2]
```

This is the current slicing behavior:
```julia
julia> B[Block(1, 1)[1:2, 1:2]]
2×2 Matrix{BlockIndex{2}}:
 Block(1, 1)[1, 1]  Block(1, 1)[1, 2]
 Block(1, 1)[2, 1]  Block(1, 1)[2, 2]

julia> B[2:3, 2:3]
2×2 Matrix{BlockIndex{2}}:
 Block(1, 1)[2, 2]  Block(1, 2)[2, 1]
 Block(2, 1)[1, 2]  Block(2, 2)[1, 1]

julia> B[Block(1):Block(2), Block(1):Block(2)]
2×2-blocked 4×4 PseudoBlockMatrix{BlockIndex{2}}:
 Block(1, 1)[1, 1]  Block(1, 1)[1, 2]  │  Block(1, 2)[1, 1]  Block(1, 2)[1, 2]
 Block(1, 1)[2, 1]  Block(1, 1)[2, 2]  │  Block(1, 2)[2, 1]  Block(1, 2)[2, 2]
 ──────────────────────────────────────┼──────────────────────────────────────
 Block(2, 1)[1, 1]  Block(2, 1)[1, 2]  │  Block(2, 2)[1, 1]  Block(2, 2)[1, 2]
 Block(2, 1)[2, 1]  Block(2, 1)[2, 2]  │  Block(2, 2)[2, 1]  Block(2, 2)[2, 2]
```
Ideally, any slicing operation that can get mapped to slicing with a unit range in each dimension (say slicing with `AbstractUnitRange`, `BlockRange`, `BlockIndexRange`, etc.) would output `BlockIndices` or `BlockIndexRange`, but that isn't implemented yet. I think ideally that would be implemented as something like this:
```julia
function Base.getindex(a::BlockIndices, indices::Union{AbstractUnitRange,BlockRange,BlockIndexRange}...)
    return BlockIndices(getindex.(a.indices, to_indices(a, indices)))
end
```
i.e. slicing a `BlockIndices` slices the indices in each dimension, similar to the definition for `Base.CartesianIndices`: https://github.com/JuliaLang/julia/blob/64de065a183ac70bb049f7f9e30d790f8845dd2b/base/multidimensional.jl#L384-L391. However, slicing blocked unit ranges doesn't always preserve blocking information right now, see for example #347 and #355.