### PR TITLE
BlockArray construction from immutable array

### DIFF
--- a/src/blockarray.jl
+++ b/src/blockarray.jl
@@ -175,8 +175,8 @@ BlockArray(arr::AbstractArray{T, N}, block_sizes::Vararg{AbstractVector{<:Intege
     BlockArray{T}(arr, block_sizes...)
 
 function BlockArray{T}(arr::AbstractArray{T, N}, baxes::NTuple{N,AbstractUnitRange{Int}}) where {T,N}
-    blocks = map(Iterators.product(blockaxes.(baxes,1)...)) do block_index
-        indices = getindex.(baxes,block_index)
+    blocks = map(Iterators.product(map(x -> blockaxes(x,1), baxes)...)) do block_index
+        indices = map((x,y) -> x[y], baxes, block_index)
         arr[indices...]
     end
     return _BlockArray(blocks, baxes)

--- a/src/blockarray.jl
+++ b/src/blockarray.jl
@@ -175,12 +175,11 @@ BlockArray(arr::AbstractArray{T, N}, block_sizes::Vararg{AbstractVector{<:Intege
     BlockArray{T}(arr, block_sizes...)
 
 function BlockArray{T}(arr::AbstractArray{T, N}, baxes::NTuple{N,AbstractUnitRange{Int}}) where {T,N}
-    block_arr = _BlockArray(Array{typeof(arr),N}, baxes)
-    for block_index in Iterators.product(blockaxes.(baxes,1)...)
+    blocks = map(Iterators.product(blockaxes.(baxes,1)...)) do block_index
         indices = getindex.(baxes,block_index)
-        block_arr[block_index...] = arr[indices...]
+        arr[indices...]
     end
-    return block_arr
+    return _BlockArray(blocks, baxes)
 end
 
 BlockArray{T}(arr::AbstractArray{<:Any, N}, baxes::NTuple{N,AbstractUnitRange{Int}}) where {T,N} =

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -80,6 +80,12 @@ end
             B = mortar(fill(S,2,2))
             A = Array(B)
             @test A isa Matrix
+
+            # test that BlockArrays may be created from immutable arrays
+            B = BlockArray(reshape([1:9;],3,3), [2,1], [2,1])
+            @test blocksizes(B) == ([2,1], [2,1])
+            @test B == reshape([1:9;],3,3)
+            @test blocks(B) isa Matrix{Matrix{Int}}
         end
 
         @testset "PseudoBlockArray constructors" begin

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -82,7 +82,7 @@ end
             @test A isa Matrix
 
             # test that BlockArrays may be created from immutable arrays
-            B = BlockArray(reshape([1:9;],3,3), [2,1], [2,1])
+            B = BlockArray(reshape(1:9,3,3), [2,1], [2,1])
             @test blocksizes(B) == ([2,1], [2,1])
             @test B == reshape([1:9;],3,3)
             @test blocks(B) isa Matrix{Matrix{Int}}


### PR DESCRIPTION
The following errors on master, but works after this PR:
```julia
julia> BlockArray(reshape(1:6, 2, 3), [1,1], [1,1,1])
2×3-blocked 2×3 BlockMatrix{Int64}:
 1  │  3  │  5
 ───┼─────┼───
 2  │  4  │  6
```
The container is allocated after computing the blocks, and not before it. This lets us obtain the type implicitly from the blocks.
