### PR TITLE
Define dataids for PseudoBlockArrays

### DIFF
--- a/src/pseudo_blockarray.jl
+++ b/src/pseudo_blockarray.jl
@@ -192,6 +192,8 @@ AbstractArray{T,N}(A::PseudoBlockArray) where {T,N} = PseudoBlockArray(AbstractA
 
 copy(A::PseudoBlockArray) = PseudoBlockArray(copy(A.blocks), A.axes)
 
+Base.dataids(A::PseudoBlockArray) = (Base.dataids(A.blocks)..., mapreduce(Base.dataids, (x,y) -> (x..., y...), A.axes)...)
+
 ###########################
 # AbstractArray Interface #
 ###########################

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -379,6 +379,9 @@ end
                 fill!(q2, 0)
                 copyto!(q2, view(BA_1, Block(1)))
                 @test q2 == q
+
+                @test Base.mightalias(BA_1, view(BA_1, Block(1,1)))
+                @test Base.mightalias(BA_1, axes(BA_1, 1))
             end
             fill!(BA_1, 1.0)
             @test BA_1 == ones(size(BA_1))


### PR DESCRIPTION
This avoids various bugs that arise from aliasing.
An example on the current master:
```julia
julia> P = PseudoBlockArray(rand(4,4), [1,3], [1,3]);

julia> x1 = view(P, 2:4, 2:4);

julia> x2 = view(P, Block(2,2));

julia> x1 == x2
true

julia> x1copy = Array(x1);

julia> copyto!(x1, x2');

julia> x1 == x1copy'
false
```