### PR TITLE
Revert "Define dataids for PseudoBlockArrays"

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -32,6 +32,7 @@ jobs:
         package:
           - {repo: BlockBandedMatrices.jl, group: JuliaLinearAlgebra}
           - {repo: ApproxFunBase.jl, group: JuliaApproximation}
+          - {repo: LazyBandedMatrices.jl, group: JuliaLinearAlgebra}
           # - {repo: InfiniteLinearAlgebra.jl, group: JuliaLinearAlgebra}
 
     steps:

--- a/src/pseudo_blockarray.jl
+++ b/src/pseudo_blockarray.jl
@@ -192,8 +192,6 @@ AbstractArray{T,N}(A::PseudoBlockArray) where {T,N} = PseudoBlockArray(AbstractA
 
 copy(A::PseudoBlockArray) = PseudoBlockArray(copy(A.blocks), A.axes)
 
-Base.dataids(A::PseudoBlockArray) = (Base.dataids(A.blocks)..., mapreduce(Base.dataids, (x,y) -> (x..., y...), A.axes)...)
-
 ###########################
 # AbstractArray Interface #
 ###########################

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -379,9 +379,6 @@ end
                 fill!(q2, 0)
                 copyto!(q2, view(BA_1, Block(1)))
                 @test q2 == q
-
-                @test Base.mightalias(BA_1, view(BA_1, Block(1,1)))
-                @test Base.mightalias(BA_1, axes(BA_1, 1))
             end
             fill!(BA_1, 1.0)
             @test BA_1 == ones(size(BA_1))


### PR DESCRIPTION
This seems to have broken `LazyBandedMatrices`. Although this is the correct approach, let's revert this for now until that package is fixed.