### PR TITLE
Blockisequal for 1-element tuple

### DIFF
--- a/src/blockaxis.jl
+++ b/src/blockaxis.jl
@@ -85,8 +85,8 @@ Check if `a` and `b` have the same block structure.
 
 # Examples
 ```jldoctest
-julia> b1 = blockedrange(1:2)
-2-blocked 3-element BlockedUnitRange{ArrayLayouts.RangeCumsum{Int64, UnitRange{Int64}}}:
+julia> b1 = blockedrange([1,2])
+2-blocked 3-element BlockedUnitRange{Vector{Int64}}:
  1
  ─
  2
@@ -112,9 +112,12 @@ blockisequal(a, b, c, d...) = blockisequal(a,b) && blockisequal(b,c,d...)
 """
     blockisequal(a::Tuple, b::Tuple)
 
-Return `all(blockisequal.(a,b))``
+Return if the tuples satisfy `blockisequal` elementwise.
 """
-blockisequal(a::Tuple, b::Tuple) = all(blockisequal.(a, b))
+blockisequal(a::Tuple, b::Tuple) = blockisequal(first(a), first(b)) && blockisequal(Base.tail(a), Base.tail(b))
+blockisequal(::Tuple{}, ::Tuple{}) = true
+blockisequal(::Tuple, ::Tuple{}) = false
+blockisequal(::Tuple{}, ::Tuple) = false
 
 
 _shift_blocklengths(::BlockedUnitRange, bl, f) = bl

--- a/test/test_blockindices.jl
+++ b/test/test_blockindices.jl
@@ -505,3 +505,14 @@ end
     first(eachblock(B))[1,2] = 0
     @test B[1,2] == 0
 end
+
+@testset "blockisequal" begin
+    B = BlockArray(rand(4,4), [1,3], [1,3])
+    v = BlockArray(rand(4), [1,3])
+    axB = axes(B)
+    axv = axes(v)
+    @test blockisequal(axB, axB)
+    @test blockisequal(axv, axv)
+    @test !blockisequal(axB, axv)
+    @test !blockisequal(axv, axB)
+end


### PR DESCRIPTION
The following holds on master:
```julia
julia> r = blockedrange([1,2]);

julia> blockisequal((r,r), (r,))
true
```
This is probably an unintentional result that arises from the broadcasting rules for 1-element tuples. This PR changes the result to `false` 