### PR TITLE
Vector indexing a `PseudoBlockArray` of a `FillArray`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BlockArrays"
 uuid = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
-version = "0.16.43"
+version = "0.16.44-dev"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/pseudo_blockarray.jl
+++ b/src/pseudo_blockarray.jl
@@ -356,3 +356,9 @@ Base.replace_in_print_matrix(f::PseudoBlockVecOrMat, i::Integer, j::Integer, s::
 
 
 LinearAlgebra.norm(A::PseudoBlockArray, p::Real=2) = norm(A.blocks, p)
+
+###########################
+# FillArrays interface #
+###########################
+
+FillArrays.getindex_value(P::PseudoBlockArray) = FillArrays.getindex_value(P.blocks)

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -555,6 +555,13 @@ end
         @test BLAS.gemv!('N', 2.0, A, x, 0.0, y) ≈ 2A*x
     end
 
+    @testset "FillArrays interface" begin
+        P = PseudoBlockArray(Fill(3,4,4), [1,3], [1,3])
+        @test P[1:3, 2:3] === Fill(3,3,2)
+        @test P[1:3, 1] == Fill(3,3)
+        @test P[2, 1:3] == Fill(3,3)
+    end
+
     @testset "lmul!/rmul!" begin
         A = PseudoBlockArray{Float64}(undef, 1:3)
         @test fill!(A, NaN) === A


### PR DESCRIPTION
Fixes
```julia
julia> P = PseudoBlockArray(Fill(3,4,4), [1,3], [1,3])
2×2-blocked 4×4 PseudoBlockMatrix{Int64, Fill{Int64, 2, Tuple{Base.OneTo{Int64}, Base.OneTo{Int64}}}, Tuple{BlockedUnitRange{Vector{Int64}}, BlockedUnitRange{Vector{Int64}}}}:
 3  │  3  3  3
 ───┼─────────
 3  │  3  3  3
 3  │  3  3  3
 3  │  3  3  3

julia> P[1:3, 1:3]
ERROR: MethodError: no method matching getindex_value(::PseudoBlockMatrix{Int64, Fill{Int64, 2, Tuple{…}}, Tuple{BlockedUnitRange{…}, BlockedUnitRange{…}}})

Closest candidates are:
  getindex_value(::LinearAlgebra.Adjoint)
   @ FillArrays ~/.julia/packages/FillArrays/oXkMk/src/FillArrays.jl:761
  getindex_value(::FillArrays.AbstractOnes{T}) where T
   @ FillArrays ~/.julia/packages/FillArrays/oXkMk/src/FillArrays.jl:321
  getindex_value(::Fill)
   @ FillArrays ~/.julia/packages/FillArrays/oXkMk/src/FillArrays.jl:164
  ...

Stacktrace:
 [1] getindex_value(a::SubArray{Int64, 2, PseudoBlockMatrix{Int64, Fill{…}, Tuple{…}}, Tuple{UnitRange{…}, UnitRange{…}}, false})
   @ FillArrays ~/.julia/packages/FillArrays/oXkMk/src/FillArrays.jl:763
 [2] sub_materialize(::ArrayLayouts.FillLayout, V::SubArray{Int64, 2, PseudoBlockMatrix{…}, Tuple{…}, false}, ax::Tuple{Base.OneTo{…}, Base.OneTo{…}})
   @ ArrayLayouts ~/.julia/packages/ArrayLayouts/sP5Ce/src/memorylayout.jl:547
 [3] sub_materialize
   @ ~/.julia/packages/ArrayLayouts/sP5Ce/src/ArrayLayouts.jl:127 [inlined]
 [4] sub_materialize
   @ ~/.julia/packages/ArrayLayouts/sP5Ce/src/ArrayLayouts.jl:128 [inlined]
 [5] layout_getindex
   @ ~/.julia/packages/ArrayLayouts/sP5Ce/src/ArrayLayouts.jl:134 [inlined]
 [6] getindex(A::PseudoBlockMatrix{Int64, Fill{…}, Tuple{…}}, kr::UnitRange{Int64}, jr::UnitRange{Int64})
   @ ArrayLayouts ~/.julia/packages/ArrayLayouts/sP5Ce/src/ArrayLayouts.jl:149
 [7] top-level scope
   @ REPL[5]:1
Some type information was truncated. Use `show(err)` to see complete types.
```