### PR TITLE
Remove unused Fill indexing methods

### DIFF
--- a/src/blocklinalg.jl
+++ b/src/blocklinalg.jl
@@ -117,19 +117,6 @@ LinearAlgebra.fill!(V::SubArray{T,1,<:BlockArray,<:Tuple{BlockSlice1}}, x) where
 FillArrays.getindex_value(V::SubArray{T,1,<:BlockArray,<:Tuple{BlockSlice1}}) where T =
     FillArrays.getindex_value(view(parent(V), block(parentindices(V)[1])))
 
-sub_materialize(::ArrayLayouts.AbstractFillLayout, V, ax::Tuple{<:BlockedUnitRange,<:AbstractUnitRange}) =
-    Fill(FillArrays.getindex_value(V), ax)
-sub_materialize(::ArrayLayouts.OnesLayout, V, ax::Tuple{<:BlockedUnitRange,<:AbstractUnitRange}) =
-    Ones{eltype(V)}(ax)
-sub_materialize(::ArrayLayouts.ZerosLayout, V, ax::Tuple{<:BlockedUnitRange,<:AbstractUnitRange}) =
-    Zeros{eltype(V)}(ax)
-sub_materialize(::ArrayLayouts.AbstractFillLayout, V, ax::Tuple{<:AbstractUnitRange,<:BlockedUnitRange}) =
-    Fill(FillArrays.getindex_value(V), ax)
-sub_materialize(::ArrayLayouts.OnesLayout, V, ax::Tuple{<:AbstractUnitRange,<:BlockedUnitRange}) =
-    Ones{eltype(V)}(ax)
-sub_materialize(::ArrayLayouts.ZerosLayout, V, ax::Tuple{<:AbstractUnitRange,<:BlockedUnitRange}) =
-    Zeros{eltype(V)}(ax)
-
 conjlayout(::Type{T}, ::BlockLayout{MLAY,BLAY}) where {T<:Complex,MLAY,BLAY} = BlockLayout{MLAY,typeof(conjlayout(T,BLAY()))}()
 conjlayout(::Type{T}, ::BlockLayout{MLAY,BLAY}) where {T<:Real,MLAY,BLAY} = BlockLayout{MLAY,BLAY}()
 

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -357,6 +357,25 @@ end
         @test blockcheckbounds(Bool, BA_4, 1, 1, 1)
         @test blockcheckbounds(Bool, BA_4, 1, 1, 1, 1)
         @test_throws BlockBoundsError blockcheckbounds(BA_3, 1, 2)
+
+        @testset for (T,F) in ((Fill, Fill(3,4,4)), (Ones, Ones(4,4)), (Zeros, Zeros(4,4)))
+            P = PseudoBlockArray(F, [1,3], [1,3])
+            V = P[axes(P)...]
+            @test V isa T
+            @test V == F
+            @test axes(P) == axes(V)
+            @test blocks.(axes(P)) == blocks.(axes(V))
+            V = P[axes(P,1), 1:2]
+            @test V isa T
+            @test size(V) == (size(P,1), 2)
+            @test blocks(axes(V,1)) == blocks(axes(P,1))
+            @test blocks(axes(V,2)) == blocks(1:2)
+            V = P[1:2, axes(P,2)]
+            @test V isa T
+            @test size(V) == (2, size(P,2))
+            @test blocks(axes(V,1)) == blocks(1:2)
+            @test blocks(axes(V,2)) == blocks(axes(P,2))
+        end
     end
 
     @testset "misc block tests" begin


### PR DESCRIPTION
These methods seem unnecessary, as the fallback methods in `ArrayLayouts` handle the indexing identically. An example:
```julia
julia> P = PseudoBlockArray(Ones(4,4), [1,3], [1,3])
2×2-blocked 4×4 PseudoBlockMatrix{Float64, Ones{Float64, 2, Tuple{Base.OneTo{Int64}, Base.OneTo{Int64}}}, Tuple{BlockedUnitRange{Vector{Int64}}, BlockedUnitRange{Vector{Int64}}}}:
 1.0  │  1.0  1.0  1.0
 ─────┼───────────────
 1.0  │  1.0  1.0  1.0
 1.0  │  1.0  1.0  1.0
 1.0  │  1.0  1.0  1.0

julia> P[axes(P,1), 1:2]
4×2 Ones{Float64, 2, Tuple{BlockedUnitRange{Vector{Int64}}, Base.OneTo{Int64}}} with indices 1:1:4×Base.OneTo(2)
```