### PR TITLE
Don't sort inplace in sortedunion

### DIFF
--- a/src/blockbroadcast.jl
+++ b/src/blockbroadcast.jl
@@ -29,7 +29,9 @@ BroadcastStyle(::PseudoBlockStyle{M}, ::BlockStyle{N}) where {M,N} = BlockStyle(
 
 
 # sortedunion can assume inputs are already sorted so this could be improved
-sortedunion(a,b) = sort!(union(a,b))
+maybeinplacesort(v::Vector) = sort!(v)
+maybeinplacesort(v) = sort(v)
+sortedunion(a,b) = maybeinplacesort(union(a,b))
 sortedunion(a::Base.OneTo, b::Base.OneTo) = Base.OneTo(max(last(a),last(b)))
 sortedunion(a::AbstractUnitRange, b::AbstractUnitRange) = min(first(a),first(b)):max(last(a),last(b))
 combine_blockaxes(a, b) = _BlockedUnitRange(sortedunion(blocklasts(a), blocklasts(b)))


### PR DESCRIPTION
In general, we should be sorting out-of-place, as the argument may not support in-place sorting. Vectors are special cased.