### PR TITLE
Infinite broadcast tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,7 @@ Aqua = "0.8"
 ArrayLayouts = "1.0.8"
 Documenter = "1"
 FillArrays = "1"
+InfiniteArrays = "0.13"
 LinearAlgebra = "1.6"
 OffsetArrays = "1"
 Random = "1.6"
@@ -23,6 +24,7 @@ julia = "1.6"
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+InfiniteArrays = "4858937d-0d70-526a-a4dd-2d5cb5dd786c"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
@@ -30,4 +32,4 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "Documenter", "OffsetArrays", "SparseArrays", "StaticArrays", "Test", "Random"]
+test = ["Aqua", "Documenter", "InfiniteArrays", "OffsetArrays", "SparseArrays", "StaticArrays", "Test", "Random"]

--- a/docs/src/lib/internals.md
+++ b/docs/src/lib/internals.md
@@ -21,6 +21,8 @@ Pages = ["internals.md"]
 ```@docs
 blockcolsupport
 blockrowsupport
+blockedrange
+BlockedOneTo
 BlockedUnitRange
 BlockRange
 BlockIndexRange

--- a/docs/src/man/abstractblockarrayinterface.md
+++ b/docs/src/man/abstractblockarrayinterface.md
@@ -1,8 +1,8 @@
 # The block axis interface
 
-A block array's block structure is dictated by its axes, which
-are typically a `BlockedUnitRange` but may also be a `UnitRange`, 
-which is assumed to be a single block, or other type that implements
+A block array's block structure is dictated by its axes. These
+are typically `BlockedOneTo`s, but may also be standard and non-blocked `AbstractUnitRange`s
+(which are assumed to correspond to a single block), or other type that implements
 the block axis interface.
 
 

--- a/docs/src/man/blockarrays.md
+++ b/docs/src/man/blockarrays.md
@@ -11,18 +11,18 @@ end
 An `AbstractArray` can be repacked into a `BlockArray` with `BlockArray(array, block_sizes...)`.  The block sizes are each an `AbstractVector{Int}` which determines the size of the blocks in that dimension (so the sum of `block_sizes` in every dimension must match the size of `array` in that dimension).
 
 ```jldoctest
-julia> BlockArray(Array(reshape(1:16, 4, 4)), [2,2], [1,1,2])
+julia> BlockArray(Array(reshape(1:16, 4, 4)), [1,3], [1,1,2])
 2×3-blocked 4×4 BlockMatrix{Int64}:
  1  │  5  │   9  13
- 2  │  6  │  10  14
  ───┼─────┼────────
+ 2  │  6  │  10  14
  3  │  7  │  11  15
  4  │  8  │  12  16
 
 julia> S = spzeros(4,5); S[1,2] = S[4,3] = 1;
 
 julia> block_array_sparse = BlockArray(S, [1,3], [2,3])
-2×2-blocked 4×5 BlockMatrix{Float64, Matrix{SparseMatrixCSC{Float64, Int64}}, Tuple{BlockedUnitRange{Vector{Int64}}, BlockedUnitRange{Vector{Int64}}}}:
+2×2-blocked 4×5 BlockMatrix{Float64, Matrix{SparseMatrixCSC{Float64, Int64}}, Tuple{BlockedOneTo{Vector{Int64}}, BlockedOneTo{Vector{Int64}}}}:
   ⋅   1.0  │   ⋅    ⋅    ⋅ 
  ──────────┼───────────────
   ⋅    ⋅   │   ⋅    ⋅    ⋅ 
@@ -67,7 +67,7 @@ The `block_type` should be an array type.  It specifies the internal block type,
 
 ```jldoctest
 julia> BlockArray(undef_blocks, SparseVector{Float64, Int}, [1,2])
-2-blocked 3-element BlockVector{Float64, Vector{SparseVector{Float64, Int64}}, Tuple{BlockedUnitRange{Vector{Int64}}}}:
+2-blocked 3-element BlockVector{Float64, Vector{SparseVector{Float64, Int64}}, Tuple{BlockedOneTo{Vector{Int64}}}}:
  #undef
  ──────
  #undef
@@ -138,26 +138,35 @@ julia> block_array[1, 2]
 
 To view and modify blocks of `BlockArray` use the `view` syntax.
 ```jldoctest
-julia> A = BlockArray(ones(6), 1:3);
+julia> A = BlockArray([11:16;], 1:3)
+3-blocked 6-element BlockVector{Int64, Vector{Vector{Int64}}, Tuple{BlockedOneTo{ArrayLayouts.RangeCumsum{Int64, UnitRange{Int64}}}}}:
+ 11
+ ──
+ 12
+ 13
+ ──
+ 14
+ 15
+ 16
 
 julia> view(A, Block(2))
-2-element Vector{Float64}:
- 1.0
- 1.0
+2-element Vector{Int64}:
+ 12
+ 13
 
-julia> view(A, Block(2)) .= [3,4]; A[Block(2)]
-2-element Vector{Float64}:
- 3.0
- 4.0
+julia> view(A, Block(2)) .= [3,4];
+
+julia> A[Block(2)]
+2-element Vector{Int64}:
+ 3
+ 4
 
 julia> view(A, Block.(1:2))
-3-element view(::BlockVector{Float64, Vector{Vector{Float64}}, Tuple{BlockedUnitRange{ArrayLayouts.RangeCumsum{Int64, UnitRange{Int64}}}}}, BlockSlice(BlockRange(1:2),1:1:3)) with eltype Float64 with indices 1:1:3:
- 1.0
- 3.0
- 4.0
+3-element view(::BlockVector{Int64, Vector{Vector{Int64}}, Tuple{BlockedOneTo{ArrayLayouts.RangeCumsum{Int64, UnitRange{Int64}}}}}, BlockSlice(BlockRange(1:2),1:1:3)) with eltype Int64 with indices BlockedOneTo([1, 3]):
+ 11
+  3
+  4
 ```
-
-
 
 ## Converting between `BlockArray` and normal arrays
 
@@ -167,7 +176,7 @@ An array can be repacked into a `BlockArray` with `BlockArray(array, block_sizes
 julia> S = spzeros(4,5); S[1,2] = S[4,3] = 1;
 
 julia> block_array_sparse = BlockArray(S, [1,3], [2,3])
-2×2-blocked 4×5 BlockMatrix{Float64, Matrix{SparseMatrixCSC{Float64, Int64}}, Tuple{BlockedUnitRange{Vector{Int64}}, BlockedUnitRange{Vector{Int64}}}}:
+2×2-blocked 4×5 BlockMatrix{Float64, Matrix{SparseMatrixCSC{Float64, Int64}}, Tuple{BlockedOneTo{Vector{Int64}}, BlockedOneTo{Vector{Int64}}}}:
   ⋅   1.0  │   ⋅    ⋅    ⋅ 
  ──────────┼───────────────
   ⋅    ⋅   │   ⋅    ⋅    ⋅ 

--- a/docs/src/man/blockarrays.md
+++ b/docs/src/man/blockarrays.md
@@ -11,11 +11,11 @@ end
 An `AbstractArray` can be repacked into a `BlockArray` with `BlockArray(array, block_sizes...)`.  The block sizes are each an `AbstractVector{Int}` which determines the size of the blocks in that dimension (so the sum of `block_sizes` in every dimension must match the size of `array` in that dimension).
 
 ```jldoctest
-julia> BlockArray(Array(reshape(1:16, 4, 4)), [1,3], [1,1,2])
+julia> BlockArray(Array(reshape(1:16, 4, 4)), [2,2], [1,1,2])
 2×3-blocked 4×4 BlockMatrix{Int64}:
  1  │  5  │   9  13
- ───┼─────┼────────
  2  │  6  │  10  14
+ ───┼─────┼────────
  3  │  7  │  11  15
  4  │  8  │  12  16
 
@@ -138,35 +138,26 @@ julia> block_array[1, 2]
 
 To view and modify blocks of `BlockArray` use the `view` syntax.
 ```jldoctest
-julia> A = BlockArray([11:16;], 1:3)
-3-blocked 6-element BlockVector{Int64, Vector{Vector{Int64}}, Tuple{BlockedOneTo{ArrayLayouts.RangeCumsum{Int64, UnitRange{Int64}}}}}:
- 11
- ──
- 12
- 13
- ──
- 14
- 15
- 16
+julia> A = BlockArray(ones(6), 1:3);
 
 julia> view(A, Block(2))
-2-element Vector{Int64}:
- 12
- 13
+2-element Vector{Float64}:
+ 1.0
+ 1.0
 
-julia> view(A, Block(2)) .= [3,4];
-
-julia> A[Block(2)]
-2-element Vector{Int64}:
- 3
- 4
+julia> view(A, Block(2)) .= [3,4]; A[Block(2)]
+2-element Vector{Float64}:
+ 3.0
+ 4.0
 
 julia> view(A, Block.(1:2))
-3-element view(::BlockVector{Int64, Vector{Vector{Int64}}, Tuple{BlockedOneTo{ArrayLayouts.RangeCumsum{Int64, UnitRange{Int64}}}}}, BlockSlice(BlockRange(1:2),1:1:3)) with eltype Int64 with indices BlockedOneTo([1, 3]):
- 11
-  3
-  4
+3-element view(::BlockVector{Float64, Vector{Vector{Float64}}, Tuple{BlockedOneTo{ArrayLayouts.RangeCumsum{Int64, UnitRange{Int64}}}}}, BlockSlice(BlockRange(1:2),1:1:3)) with eltype Float64 with indices BlockedOneTo([1, 3]):
+ 1.0
+ 3.0
+ 4.0
 ```
+
+
 
 ## Converting between `BlockArray` and normal arrays
 

--- a/src/BlockArrays.jl
+++ b/src/BlockArrays.jl
@@ -7,7 +7,7 @@ export AbstractBlockArray, AbstractBlockMatrix, AbstractBlockVector, AbstractBlo
 export Block, getblock, getblock!, setblock!, eachblock, blocks
 export blockaxes, blocksize, blocklength, blockcheckbounds, BlockBoundsError, BlockIndex
 export blocksizes, blocklengths, blocklasts, blockfirsts, blockisequal
-export BlockRange, blockedrange, BlockedUnitRange
+export BlockRange, blockedrange, BlockedUnitRange, BlockedOneTo
 
 export BlockArray, BlockMatrix, BlockVector, BlockVecOrMat, mortar
 export PseudoBlockArray, PseudoBlockMatrix, PseudoBlockVector, PseudoBlockVecOrMat

--- a/src/blockarray.jl
+++ b/src/blockarray.jl
@@ -428,18 +428,18 @@ end
 ###########################
 
 
-@inline Base.similar(block_array::AbstractArray, ::Type{T}, axes::Tuple{BlockedUnitRange,Vararg{Union{AbstractUnitRange{Int},Integer}}}) where T =
+@inline Base.similar(block_array::AbstractArray, ::Type{T}, axes::Tuple{AbstractBlockedUnitRange,Vararg{Union{AbstractUnitRange{Int},Integer}}}) where T =
     BlockArray{T}(undef, map(to_axes,axes))
-@inline Base.similar(block_array::AbstractArray, ::Type{T}, axes::Tuple{BlockedUnitRange,BlockedUnitRange,Vararg{Union{AbstractUnitRange{Int},Integer}}}) where T =
+@inline Base.similar(block_array::AbstractArray, ::Type{T}, axes::Tuple{AbstractBlockedUnitRange,AbstractBlockedUnitRange,Vararg{Union{AbstractUnitRange{Int},Integer}}}) where T =
     BlockArray{T}(undef, map(to_axes,axes))
-@inline Base.similar(block_array::AbstractArray, ::Type{T}, axes::Tuple{Union{AbstractUnitRange{Int},Integer},BlockedUnitRange,Vararg{Union{AbstractUnitRange{Int},Integer}}}) where T =
+@inline Base.similar(block_array::AbstractArray, ::Type{T}, axes::Tuple{Union{AbstractUnitRange{Int},Integer},AbstractBlockedUnitRange,Vararg{Union{AbstractUnitRange{Int},Integer}}}) where T =
     BlockArray{T}(undef, map(to_axes,axes))
 
-@inline Base.similar(block_array::Type{<:AbstractArray{T}}, axes::Tuple{BlockedUnitRange,Vararg{Union{AbstractUnitRange{Int},Integer}}}) where T =
+@inline Base.similar(block_array::Type{<:AbstractArray{T}}, axes::Tuple{AbstractBlockedUnitRange,Vararg{Union{AbstractUnitRange{Int},Integer}}}) where T =
     BlockArray{T}(undef, map(to_axes,axes))
-@inline Base.similar(block_array::Type{<:AbstractArray{T}}, axes::Tuple{BlockedUnitRange,BlockedUnitRange,Vararg{Union{AbstractUnitRange{Int},Integer}}}) where T =
+@inline Base.similar(block_array::Type{<:AbstractArray{T}}, axes::Tuple{AbstractBlockedUnitRange,AbstractBlockedUnitRange,Vararg{Union{AbstractUnitRange{Int},Integer}}}) where T =
     BlockArray{T}(undef, map(to_axes,axes))
-@inline Base.similar(block_array::Type{<:AbstractArray{T}}, axes::Tuple{Union{AbstractUnitRange{Int},Integer},BlockedUnitRange,Vararg{Union{AbstractUnitRange{Int},Integer}}}) where T =
+@inline Base.similar(block_array::Type{<:AbstractArray{T}}, axes::Tuple{Union{AbstractUnitRange{Int},Integer},AbstractBlockedUnitRange,Vararg{Union{AbstractUnitRange{Int},Integer}}}) where T =
     BlockArray{T}(undef, map(to_axes,axes))
 
 @inline Base.similar(B::BlockArray, ::Type{T}) where {T} = mortar(similar.(blocks(B), T))

--- a/src/blockarray.jl
+++ b/src/blockarray.jl
@@ -62,13 +62,16 @@ struct BlockArray{T, N, R <: AbstractArray{<:AbstractArray{T,N},N}, BS<:NTuple{N
     blocks::R
     axes::BS
 
-    global @inline _BlockArray(blocks::R, block_sizes::BS) where {T, N, R<:AbstractArray{<:AbstractArray{T,N},N}, BS<:NTuple{N,AbstractUnitRange{Int}}} =
-        new{T, N, R, BS}(blocks, block_sizes)
+    global @inline function _BlockArray(blocks::R, block_axes::BS) where {T, N, R<:AbstractArray{<:AbstractArray{T,N},N}, BS<:NTuple{N,AbstractUnitRange{Int}}}
+        Base.require_one_based_indexing(block_axes...)
+        Base.require_one_based_indexing(blocks)
+        new{T, N, R, BS}(blocks, block_axes)
+    end
 end
 
 # Auxiliary outer constructors
-@inline _BlockArray(blocks::R, block_sizes::Vararg{AbstractVector{<:Integer}, N}) where {T, N, R<:AbstractArray{<:AbstractArray{T,N},N}} =
-    _BlockArray(blocks, map(blockedrange, block_sizes))
+@inline _BlockArray(blocks::R, block_axes::Vararg{AbstractVector{<:Integer}, N}) where {T, N, R<:AbstractArray{<:AbstractArray{T,N},N}} =
+    _BlockArray(blocks, map(blockedrange, block_axes))
 
 # support non-concrete eltypes in blocks
 _BlockArray(blocks::R, block_axes::BS) where {N, R<:AbstractArray{<:AbstractArray{V,N} where V,N}, BS<:NTuple{N,AbstractUnitRange{Int}}} =

--- a/src/blockaxis.jl
+++ b/src/blockaxis.jl
@@ -146,7 +146,7 @@ julia> blockedrange(2, (1,2))
 _diff(a::AbstractVector) = diff(a)
 _diff(a::Tuple) = diff(collect(a))
 @inline _blocklengths(a, bl, dbl) = isempty(bl) ? [dbl;] : [first(bl)-first(a)+1; dbl]
-@inline function _blocklengths(a::BlockedOneTo, bl::RangeCumsum, ::AbstractUnitRange)
+@inline function _blocklengths(a::BlockedOneTo, bl::RangeCumsum, ::OrdinalRange)
     # the 1:0 is hardcoded here to enable conversions to a Base.OneTo
     isempty(bl) ? oftype(bl.range, 1:0) : bl.range
 end

--- a/src/blockaxis.jl
+++ b/src/blockaxis.jl
@@ -53,7 +53,11 @@ See also [`BlockedOneTo`](@ref).
 struct BlockedUnitRange{CS} <: AbstractBlockedUnitRange{Int,CS}
     first::Int
     lasts::CS
-    global _BlockedUnitRange(f, cs::CS) where CS = new{CS}(f, cs)
+    # assume that lasts is sorted, no checks carried out here
+    global function _BlockedUnitRange(f, cs::CS) where CS
+        Base.require_one_based_indexing(cs)
+        new{CS}(f, cs)
+    end
 end
 
 @inline _BlockedUnitRange(cs) = _BlockedUnitRange(1,cs)
@@ -102,8 +106,10 @@ See also [`BlockedUnitRange`](@ref).
 """
 struct BlockedOneTo{CS} <: AbstractBlockedUnitRange{Int,CS}
     lasts::CS
+    # assume that lasts is sorted, no checks carried out here
     function BlockedOneTo{CS}(lasts) where {CS}
         Base.require_one_based_indexing(lasts)
+        isempty(lasts) || first(lasts) >= 0 || throw(ArgumentError("blocklasts must be >= 0"))
         new{CS}(lasts)
     end
 end

--- a/src/blockaxis.jl
+++ b/src/blockaxis.jl
@@ -102,7 +102,12 @@ See also [`BlockedUnitRange`](@ref).
 """
 struct BlockedOneTo{CS} <: AbstractBlockedUnitRange{Int,CS}
     lasts::CS
+    function BlockedOneTo{CS}(lasts) where {CS}
+        Base.require_one_based_indexing(lasts)
+        new{CS}(lasts)
+    end
 end
+BlockedOneTo(lasts) = BlockedOneTo{typeof(lasts)}(lasts)
 
 const DefaultBlockAxis = BlockedOneTo{Vector{Int}}
 

--- a/src/blockaxis.jl
+++ b/src/blockaxis.jl
@@ -353,10 +353,6 @@ blocksizes(A) = map(blocklengths, axes(A))
 blocksizes(A,i) = blocklengths(axes(A,i))
 
 axes(b::AbstractBlockedUnitRange) = (BlockedOneTo(blocklasts(b) .- (first(b)-1)),)
-function axes(b::AbstractBlockedUnitRange{<:Any,<:RangeCumsum}, d::Int)
-    d <= 1 && return axes(b)[d]
-    return BlockedOneTo(oftype(b.lasts, RangeCumsum(Base.OneTo(1))))
-end
 unsafe_indices(b::AbstractBlockedUnitRange) = axes(b)
 # ::Integer works around case where blocklasts might return different type
 last(b::AbstractBlockedUnitRange)::Integer = isempty(blocklasts(b)) ? first(b)-1 : last(blocklasts(b))

--- a/src/blockaxis.jl
+++ b/src/blockaxis.jl
@@ -379,12 +379,14 @@ end
 
 @propagate_inbounds function getindex(b::AbstractBlockedUnitRange, KR::BlockRange{1,Tuple{Base.OneTo{Int}}})
     cs = blocklasts(b)
-    isempty(KR) && return _BlockedUnitRange(1,cs[Base.OneTo(0)])
+    _getindex(b, blocklengths) = _BlockedUnitRange(first(b), blocklengths)
+    _getindex(b::BlockedOneTo, blocklengths) = BlockedOneTo(blocklengths)
+    isempty(KR) && return _getindex(b, cs[Base.OneTo(0)])
     J = last(KR)
     j = Integer(J)
     bax = blockaxes(b,1)
     @boundscheck J in bax || throw(BlockBoundsError(b,J))
-    _BlockedUnitRange(first(b),cs[Base.OneTo(j)])
+    _getindex(b, cs[Base.OneTo(j)])
 end
 
 @propagate_inbounds getindex(b::AbstractBlockedUnitRange, KR::BlockSlice) = b[KR.block]

--- a/src/blockaxis.jl
+++ b/src/blockaxis.jl
@@ -227,16 +227,14 @@ Base.unitrange(b::AbstractBlockedUnitRange) = first(b):last(b)
 
 Base.promote_rule(::Type{<:AbstractBlockedUnitRange}, ::Type{Base.OneTo{Int}}) = UnitRange{Int}
 
-Base.convert(::Type{BlockedOneTo}, axis::BlockedOneTo) = axis
-_convert(::Type{BlockedOneTo}, axis::AbstractBlockedUnitRange) = BlockedOneTo(blocklasts(axis))
-_convert(::Type{BlockedOneTo}, axis::AbstractUnitRange{Int}) = BlockedOneTo(last(axis):last(axis))
 function Base.convert(::Type{BlockedOneTo}, axis::AbstractUnitRange{Int})
     first(axis) == 1 || throw(ArgumentError("first element of range is not 1"))
-    _convert(BlockedOneTo, axis)
+    BlockedOneTo(blocklasts(axis))
 end
-Base.convert(::Type{BlockedOneTo{CS}}, axis::BlockedOneTo{CS}) where CS = axis
-Base.convert(::Type{BlockedOneTo{CS}}, axis::BlockedOneTo) where CS = BlockedOneTo(convert(CS, blocklasts(axis)))
-Base.convert(::Type{BlockedOneTo{CS}}, axis::AbstractUnitRange{Int}) where CS = convert(BlockedOneTo{CS}, convert(BlockedOneTo, axis))
+function Base.convert(::Type{BlockedOneTo{CS}}, axis::AbstractUnitRange{Int}) where CS
+    first(axis) == 1 || throw(ArgumentError("first element of range is not 1"))
+    BlockedOneTo(convert(CS, blocklasts(axis)))
+end
 
 """
     blockaxes(A::AbstractArray)

--- a/src/blockaxis.jl
+++ b/src/blockaxis.jl
@@ -533,7 +533,6 @@ Base.summary(io::IO, a::AbstractBlockedUnitRange) =  _block_summary(io, a)
 
 Base.axes(S::Base.Slice{<:BlockedOneTo}) = (S.indices,)
 Base.unsafe_indices(S::Base.Slice{<:BlockedOneTo}) = (S.indices,)
-Base.axes1(S::Base.Slice{<:BlockedOneTo}) = S.indices
 blockaxes(S::Base.Slice) = blockaxes(S.indices)
 @propagate_inbounds getindex(S::Base.Slice, b::Block{1}) = S.indices[b]
 @propagate_inbounds getindex(S::Base.Slice, b::BlockRange{1}) = S.indices[b]

--- a/src/blockbroadcast.jl
+++ b/src/blockbroadcast.jl
@@ -35,10 +35,11 @@ sortedunion(a,b) = maybeinplacesort!(union(a,b))
 sortedunion(a::Base.OneTo, b::Base.OneTo) = Base.OneTo(max(last(a),last(b)))
 sortedunion(a::AbstractUnitRange, b::AbstractUnitRange) = min(first(a),first(b)):max(last(a),last(b))
 combine_blockaxes(a, b) = _BlockedUnitRange(sortedunion(blocklasts(a), blocklasts(b)))
+combine_blockaxes(a::BlockedOneTo, b::BlockedOneTo) = BlockedOneTo(sortedunion(blocklasts(a), blocklasts(b)))
 
-Base.Broadcast.axistype(a::BlockedUnitRange, b::BlockedUnitRange) = length(b) == 1 ? a : combine_blockaxes(a, b)
-Base.Broadcast.axistype(a::BlockedUnitRange, b) = length(b) == 1 ? a : combine_blockaxes(a, b)
-Base.Broadcast.axistype(a, b::BlockedUnitRange) = length(b) == 1 ? a : combine_blockaxes(a, b)
+Base.Broadcast.axistype(a::AbstractBlockedUnitRange, b::AbstractBlockedUnitRange) = length(b) == 1 ? a : combine_blockaxes(a, b)
+Base.Broadcast.axistype(a::AbstractBlockedUnitRange, b) = length(b) == 1 ? a : combine_blockaxes(a, b)
+Base.Broadcast.axistype(a, b::AbstractBlockedUnitRange) = length(b) == 1 ? a : combine_blockaxes(a, b)
 
 
 similar(bc::Broadcasted{<:AbstractBlockStyle{N}}, ::Type{T}) where {T,N} =
@@ -243,13 +244,13 @@ BroadcastStyle(::Type{<:SubArray{T,N,Arr,<:NTuple{N,BlockSlice1},false}}) where 
 
 
 # special cases for SubArrays which we want to broadcast by Block
-BroadcastStyle(::Type{<:SubArray{<:Any,N,<:Any,I}}) where {N,I<:Tuple{BlockSlice{<:Any,<:BlockedUnitRange},Vararg{Any}}} = BlockStyle{N}()
-BroadcastStyle(::Type{<:SubArray{<:Any,N,<:Any,I}}) where {N,I<:Tuple{BlockSlice{<:Any,<:BlockedUnitRange},BlockSlice{<:Any,<:BlockedUnitRange},Vararg{Any}}} = BlockStyle{N}()
-BroadcastStyle(::Type{<:SubArray{<:Any,N,<:Any,I}}) where {N,I<:Tuple{Any,BlockSlice{<:Any,<:BlockedUnitRange},Vararg{Any}}} = BlockStyle{N}()
+BroadcastStyle(::Type{<:SubArray{<:Any,N,<:Any,I}}) where {N,I<:Tuple{BlockSlice{<:Any,<:AbstractBlockedUnitRange},Vararg{Any}}} = BlockStyle{N}()
+BroadcastStyle(::Type{<:SubArray{<:Any,N,<:Any,I}}) where {N,I<:Tuple{BlockSlice{<:Any,<:AbstractBlockedUnitRange},BlockSlice{<:Any,<:AbstractBlockedUnitRange},Vararg{Any}}} = BlockStyle{N}()
+BroadcastStyle(::Type{<:SubArray{<:Any,N,<:Any,I}}) where {N,I<:Tuple{Any,BlockSlice{<:Any,<:AbstractBlockedUnitRange},Vararg{Any}}} = BlockStyle{N}()
 
-BroadcastStyle(::Type{<:SubArray{<:Any,N,<:PseudoBlockArray,I}}) where {N,I<:Tuple{BlockSlice{<:Any,<:BlockedUnitRange},Vararg{Any}}} = PseudoBlockStyle{N}()
-BroadcastStyle(::Type{<:SubArray{<:Any,N,<:PseudoBlockArray,I}}) where {N,I<:Tuple{BlockSlice{<:Any,<:BlockedUnitRange},BlockSlice{<:Any,<:BlockedUnitRange},Vararg{Any}}} = PseudoBlockStyle{N}()
-BroadcastStyle(::Type{<:SubArray{<:Any,N,<:PseudoBlockArray,I}}) where {N,I<:Tuple{Any,BlockSlice{<:Any,<:BlockedUnitRange},Vararg{Any}}} = PseudoBlockStyle{N}()
+BroadcastStyle(::Type{<:SubArray{<:Any,N,<:PseudoBlockArray,I}}) where {N,I<:Tuple{BlockSlice{<:Any,<:AbstractBlockedUnitRange},Vararg{Any}}} = PseudoBlockStyle{N}()
+BroadcastStyle(::Type{<:SubArray{<:Any,N,<:PseudoBlockArray,I}}) where {N,I<:Tuple{BlockSlice{<:Any,<:AbstractBlockedUnitRange},BlockSlice{<:Any,<:AbstractBlockedUnitRange},Vararg{Any}}} = PseudoBlockStyle{N}()
+BroadcastStyle(::Type{<:SubArray{<:Any,N,<:PseudoBlockArray,I}}) where {N,I<:Tuple{Any,BlockSlice{<:Any,<:AbstractBlockedUnitRange},Vararg{Any}}} = PseudoBlockStyle{N}()
 
 
 

--- a/src/blockcholesky.jl
+++ b/src/blockcholesky.jl
@@ -81,7 +81,7 @@ function _block_chol!(A::AbstractArray{T}, ::Type{LowerTriangular}) where T<:Rea
     return LowerTriangular(transpose(A)), 0
 end
 
-function ArrayLayouts._cholesky!(layout, ::NTuple{2,BlockedUnitRange}, A::RealHermSymComplexHerm, ::ArrayLayouts.CNoPivot; check::Bool = true)
+function ArrayLayouts._cholesky!(layout, ::NTuple{2,AbstractBlockedUnitRange}, A::RealHermSymComplexHerm, ::ArrayLayouts.CNoPivot; check::Bool = true)
     C, info = _block_chol!(A.data, A.uplo == 'U' ? UpperTriangular : LowerTriangular)
     check && LinearAlgebra.checkpositivedefinite(info)
     return Cholesky(C.data, A.uplo, info)

--- a/src/blocklinalg.jl
+++ b/src/blocklinalg.jl
@@ -96,17 +96,17 @@ sublayout(BL::BlockLayout{MLAY,BLAY}, ::Type{<:Tuple{<:BlockSlice{BlockRange{1,T
     BlockLayout{typeof(sublayout(MLAY(),Tuple{II,Sl})), BLAY}()
 sublayout(BL::BlockLayout{MLAY,BLAY}, ::Type{<:Tuple{Sl1,Sl2}}) where {MLAY,BLAY,Sl1<:Slice,Sl2<:Slice} =
     BlockLayout{typeof(sublayout(MLAY(),Tuple{Sl1,Sl2})), BLAY}()
-sublayout(BL::BlockLayout{MLAY,BLAY}, ::Type{<:NTuple{N,<:BlockedUnitRange}}) where {N,MLAY,BLAY} =
+sublayout(BL::BlockLayout{MLAY,BLAY}, ::Type{<:NTuple{N,<:AbstractBlockedUnitRange}}) where {N,MLAY,BLAY} =
     BlockLayout{typeof(sublayout(MLAY(),NTuple{N,Base.OneTo{Int}})), BLAY}()
 
 # materialize views, used for `getindex`
 sub_materialize(::AbstractBlockLayout, V, _) = BlockArray(V)
 
 # if it's not a block layout, best to use PseudoBlockArray to take advantage of strideness
-sub_materialize_axes(V, ::Tuple{BlockedUnitRange}) = PseudoBlockArray(V)
-sub_materialize_axes(V, ::Tuple{BlockedUnitRange,BlockedUnitRange}) = PseudoBlockArray(V)
-sub_materialize_axes(V, ::Tuple{AbstractUnitRange,BlockedUnitRange}) = PseudoBlockArray(V)
-sub_materialize_axes(V, ::Tuple{BlockedUnitRange,AbstractUnitRange}) = PseudoBlockArray(V)
+sub_materialize_axes(V, ::Tuple{AbstractBlockedUnitRange}) = PseudoBlockArray(V)
+sub_materialize_axes(V, ::Tuple{AbstractBlockedUnitRange,AbstractBlockedUnitRange}) = PseudoBlockArray(V)
+sub_materialize_axes(V, ::Tuple{AbstractUnitRange,AbstractBlockedUnitRange}) = PseudoBlockArray(V)
+sub_materialize_axes(V, ::Tuple{AbstractBlockedUnitRange,AbstractUnitRange}) = PseudoBlockArray(V)
 
 # Special for FillArrays.jl
 

--- a/src/blockproduct.jl
+++ b/src/blockproduct.jl
@@ -151,7 +151,7 @@ julia> A = reshape(1:9, 3, 3)
  3  6  9
 
 julia> BlockArrays.blockvec(A)
-3-blocked 9-element PseudoBlockVector{Int64, UnitRange{Int64}, Tuple{BlockedUnitRange{StepRangeLen{Int64, Int64, Int64, Int64}}}}:
+3-blocked 9-element PseudoBlockVector{Int64, UnitRange{Int64}, Tuple{BlockedOneTo{StepRangeLen{Int64, Int64, Int64, Int64}}}}:
  1
  2
  3

--- a/src/blockreduce.jl
+++ b/src/blockreduce.jl
@@ -18,4 +18,4 @@ Base.mapreduce(f::F, op::OP, B::PseudoBlockArray; kw...) where {F, OP} =
     mapreduce(f, op, B.blocks; kw...)
 
 # support sum, need to return something analogous to Base.OneTo(1) but same type
-Base.reduced_index(::BR) where BR<:BlockedUnitRange = convert(BR, Base.OneTo(1))
+Base.reduced_index(::BR) where BR<:AbstractBlockedUnitRange = convert(BR, Base.OneTo(1))

--- a/src/pseudo_blockarray.jl
+++ b/src/pseudo_blockarray.jl
@@ -203,25 +203,25 @@ end
 to_axes(r::AbstractUnitRange) = r
 to_axes(n::Integer) = Base.oneto(n)
 
-@inline Base.similar(block_array::Type{<:StridedArray{T}}, axes::Tuple{BlockedUnitRange,Vararg{Union{Integer,AbstractUnitRange{Int}}}}) where T =
+@inline Base.similar(block_array::Type{<:StridedArray{T}}, axes::Tuple{AbstractBlockedUnitRange,Vararg{Union{Integer,AbstractUnitRange{Int}}}}) where T =
     PseudoBlockArray{T}(undef, map(to_axes,axes))
-@inline Base.similar(block_array::Type{<:StridedArray{T}}, axes::Tuple{BlockedUnitRange,BlockedUnitRange,Vararg{Union{Integer,AbstractUnitRange{Int}}}}) where T =
+@inline Base.similar(block_array::Type{<:StridedArray{T}}, axes::Tuple{AbstractBlockedUnitRange,AbstractBlockedUnitRange,Vararg{Union{Integer,AbstractUnitRange{Int}}}}) where T =
     PseudoBlockArray{T}(undef, map(to_axes,axes))
-@inline Base.similar(block_array::Type{<:StridedArray{T}}, axes::Tuple{Union{Integer,AbstractUnitRange{Int}},BlockedUnitRange,Vararg{Union{Integer,AbstractUnitRange{Int}}}}) where T =
-    PseudoBlockArray{T}(undef, map(to_axes,axes))
-
-@inline Base.similar(block_array::StridedArray, ::Type{T}, axes::Tuple{BlockedUnitRange,Vararg{Union{Integer,AbstractUnitRange{Int}}}}) where T =
-    PseudoBlockArray{T}(undef, map(to_axes,axes))
-@inline Base.similar(block_array::StridedArray, ::Type{T}, axes::Tuple{BlockedUnitRange,BlockedUnitRange,Vararg{Union{Integer,AbstractUnitRange{Int}}}}) where T =
-    PseudoBlockArray{T}(undef, map(to_axes,axes))
-@inline Base.similar(block_array::StridedArray, ::Type{T}, axes::Tuple{Union{Integer,AbstractUnitRange{Int}},BlockedUnitRange,Vararg{Union{Integer,AbstractUnitRange{Int}}}}) where T =
+@inline Base.similar(block_array::Type{<:StridedArray{T}}, axes::Tuple{Union{Integer,AbstractUnitRange{Int}},AbstractBlockedUnitRange,Vararg{Union{Integer,AbstractUnitRange{Int}}}}) where T =
     PseudoBlockArray{T}(undef, map(to_axes,axes))
 
-@inline Base.similar(block_array::PseudoBlockArray, ::Type{T}, axes::Tuple{BlockedUnitRange,Vararg{Union{Integer,AbstractUnitRange{Int}}}}) where T =
+@inline Base.similar(block_array::StridedArray, ::Type{T}, axes::Tuple{AbstractBlockedUnitRange,Vararg{Union{Integer,AbstractUnitRange{Int}}}}) where T =
     PseudoBlockArray{T}(undef, map(to_axes,axes))
-@inline Base.similar(block_array::PseudoBlockArray, ::Type{T}, axes::Tuple{BlockedUnitRange,BlockedUnitRange,Vararg{Union{Integer,AbstractUnitRange{Int}}}}) where T =
+@inline Base.similar(block_array::StridedArray, ::Type{T}, axes::Tuple{AbstractBlockedUnitRange,AbstractBlockedUnitRange,Vararg{Union{Integer,AbstractUnitRange{Int}}}}) where T =
     PseudoBlockArray{T}(undef, map(to_axes,axes))
-@inline Base.similar(block_array::PseudoBlockArray, ::Type{T}, axes::Tuple{Union{Integer,AbstractUnitRange{Int}},BlockedUnitRange,Vararg{Union{Integer,AbstractUnitRange{Int}}}}) where T =
+@inline Base.similar(block_array::StridedArray, ::Type{T}, axes::Tuple{Union{Integer,AbstractUnitRange{Int}},AbstractBlockedUnitRange,Vararg{Union{Integer,AbstractUnitRange{Int}}}}) where T =
+    PseudoBlockArray{T}(undef, map(to_axes,axes))
+
+@inline Base.similar(block_array::PseudoBlockArray, ::Type{T}, axes::Tuple{AbstractBlockedUnitRange,Vararg{Union{Integer,AbstractUnitRange{Int}}}}) where T =
+    PseudoBlockArray{T}(undef, map(to_axes,axes))
+@inline Base.similar(block_array::PseudoBlockArray, ::Type{T}, axes::Tuple{AbstractBlockedUnitRange,AbstractBlockedUnitRange,Vararg{Union{Integer,AbstractUnitRange{Int}}}}) where T =
+    PseudoBlockArray{T}(undef, map(to_axes,axes))
+@inline Base.similar(block_array::PseudoBlockArray, ::Type{T}, axes::Tuple{Union{Integer,AbstractUnitRange{Int}},AbstractBlockedUnitRange,Vararg{Union{Integer,AbstractUnitRange{Int}}}}) where T =
     PseudoBlockArray{T}(undef, map(to_axes,axes))
 
 @propagate_inbounds getindex(block_arr::PseudoBlockArray{T, N}, i::Vararg{Integer, N}) where {T,N} = block_arr.blocks[i...]
@@ -338,7 +338,7 @@ rowsupport(A::PseudoBlockArray, j) = rowsupport(A.blocks, j)
 ###
 
 for op in (:zeros, :ones)
-    @eval $op(::Type{T}, axs::Tuple{BlockedUnitRange,Vararg{Union{Integer,AbstractUnitRange}}}) where T = PseudoBlockArray($op(T, map(length,axs)...), axs)
+    @eval $op(::Type{T}, axs::Tuple{BlockedOneTo,Vararg{Union{Integer,AbstractUnitRange}}}) where T = PseudoBlockArray($op(T, map(length,axs)...), axs)
 end
 
 Base.replace_in_print_matrix(f::PseudoBlockVecOrMat, i::Integer, j::Integer, s::AbstractString) =

--- a/src/show.jl
+++ b/src/show.jl
@@ -109,17 +109,17 @@ function _show_typeof(io::IO, a::BlockArray{T,N,Array{Array{T,N},N},NTuple{N,Def
 end
 
 # LayoutArray with blocked axes will dispatch to here
-axes_print_matrix_row(::Tuple{BlockedUnitRange}, io, X, A, i, cols, sep) =
+axes_print_matrix_row(::Tuple{AbstractBlockedUnitRange}, io, X, A, i, cols, sep) =
         _blockarray_print_matrix_row(io, X, A, i, cols, sep)
-axes_print_matrix_row(::NTuple{2,BlockedUnitRange}, io, X, A, i, cols, sep) =
+axes_print_matrix_row(::NTuple{2,AbstractBlockedUnitRange}, io, X, A, i, cols, sep) =
         _blockarray_print_matrix_row(io, X, A, i, cols, sep)
-axes_print_matrix_row(::Tuple{AbstractUnitRange,BlockedUnitRange}, io, X, A, i, cols, sep) =
+axes_print_matrix_row(::Tuple{AbstractUnitRange,AbstractBlockedUnitRange}, io, X, A, i, cols, sep) =
         _blockarray_print_matrix_row(io, X, A, i, cols, sep)
-axes_print_matrix_row(::Tuple{BlockedUnitRange,AbstractUnitRange}, io, X, A, i, cols, sep) =
+axes_print_matrix_row(::Tuple{AbstractBlockedUnitRange,AbstractUnitRange}, io, X, A, i, cols, sep) =
         _blockarray_print_matrix_row(io, X, A, i, cols, sep)
 
-# Need to handled BlockedUnitRange, which is not a LayoutVector
-Base.print_matrix_row(io::IO, X::BlockedUnitRange, A::Vector, i::Integer, cols::AbstractVector, sep::AbstractString, idxlast::Integer=last(axes(X, 2))) =
+# Need to handled AbstractBlockedUnitRange, which is not a LayoutVector
+Base.print_matrix_row(io::IO, X::AbstractBlockedUnitRange, A::Vector, i::Integer, cols::AbstractVector, sep::AbstractString, idxlast::Integer=last(axes(X, 2))) =
         _blockarray_print_matrix_row(io, X, A, i, cols, sep)
 
 function _show_typeof(io::IO, a::PseudoBlockVector{T,Vector{T},Tuple{DefaultBlockAxis}}) where T
@@ -194,7 +194,7 @@ function Base.show(io::IO, B::BlockIndexRange)
 end
 Base.show(io::IO, ::MIME"text/plain", B::BlockIndexRange) = show(io, B)
 
-Base.show(io::IO, mimetype::MIME"text/plain", a::BlockedUnitRange) =
+Base.show(io::IO, mimetype::MIME"text/plain", a::AbstractBlockedUnitRange) =
     Base.invoke(show, Tuple{typeof(io),MIME"text/plain",AbstractArray},io, mimetype, a)
 
 show(io::IO, r::BlockSlice) = print(io, "BlockSlice(", r.block, ",", r.indices, ")")

--- a/src/show.jl
+++ b/src/show.jl
@@ -214,3 +214,6 @@ end
 
 Base.show(io::IO, br::BlockRange) = print(io, "BlockRange(", join(br.indices, ", "), ")")
 Base.show(io::IO, ::MIME"text/plain", br::BlockRange) = show(io, br)
+
+# AbstractBlockedUnitRange
+Base.show(io::IO, b::BlockedOneTo) = print(io, BlockedOneTo, "(", blocklasts(b), ")")

--- a/src/views.jl
+++ b/src/views.jl
@@ -57,7 +57,7 @@ to_index(::BlockRange) = throw(ArgumentError("BlockRange must be converted by to
                                             idxs[1].indices[subidxs[1].indices]),
                                 reindex(tail(idxs), tail(subidxs))...)
 
-@propagate_inbounds reindex(idxs::Tuple{BlockedUnitRange, Vararg{Any}},
+@propagate_inbounds reindex(idxs::Tuple{AbstractBlockedUnitRange, Vararg{Any}},
         subidxs::Tuple{BlockSlice{<:Block}, Vararg{Any}}) =
     (BlockSlice(subidxs[1].block,
                                             idxs[1][subidxs[1].block]),

--- a/test/test_blockarrayinterface.jl
+++ b/test/test_blockarrayinterface.jl
@@ -130,11 +130,11 @@ end
     @test_throws BlockBoundsError A[Block(1, 3)]
     @test A == [1 2 0 0; 0 0 1 2]
     @test BlockArray(A) == A
-    @test sprint(show, "text/plain", A) == "2×2-blocked 2×4 BlockMatrix{$Int, Diagonal{Matrix{$Int}, Vector{Matrix{$Int}}}, Tuple{BlockedUnitRange{Vector{$Int}}, BlockedUnitRange{Vector{$Int}}}}:\n 1  2  │  ⋅  ⋅\n ──────┼──────\n ⋅  ⋅  │  1  2"
+    @test sprint(show, "text/plain", A) == "2×2-blocked 2×4 BlockMatrix{$Int, Diagonal{Matrix{$Int}, Vector{Matrix{$Int}}}, Tuple{BlockedOneTo{Vector{$Int}}, BlockedOneTo{Vector{$Int}}}}:\n 1  2  │  ⋅  ⋅\n ──────┼──────\n ⋅  ⋅  │  1  2"
 
     N = 3
     D = Diagonal(mortar(Fill.(-(0:N) - (0:N) .^ 2, 1:2:2N+1)))
-    @test axes(D) isa NTuple{2,BlockedUnitRange}
+    @test axes(D) isa NTuple{2,BlockedOneTo}
     @test blockisequal(axes(D, 1), axes(parent(D), 1))
     @test D == Diagonal(Vector(parent(D)))
     @test MemoryLayout(D) isa BlockArrays.DiagonalLayout{<:BlockArrays.BlockLayout}
@@ -142,9 +142,9 @@ end
 
 @testset "non-standard block axes" begin
     A = BlockArray([1 2; 3 4], Fill(1, 2), Fill(1, 2))
-    @test A isa BlockMatrix{Int,Matrix{Matrix{Int}},<:NTuple{2,BlockedUnitRange{<:AbstractRange}}}
+    @test A isa BlockMatrix{Int,Matrix{Matrix{Int}},<:NTuple{2,BlockedOneTo{<:AbstractRange}}}
     A = BlockArray([1 2; 3 4], Fill(1, 2), [1, 1])
-    @test A isa BlockMatrix{Int,Matrix{Matrix{Int}},<:Tuple{BlockedUnitRange{<:AbstractRange},BlockedUnitRange{Vector{Int}}}}
+    @test A isa BlockMatrix{Int,Matrix{Matrix{Int}},<:Tuple{BlockedOneTo{<:AbstractRange},BlockedOneTo{Vector{Int}}}}
 end
 
 @testset "block Fill" begin
@@ -187,9 +187,9 @@ end
 
     U = UpperTriangular(Ones((blockedrange([1, 2]), blockedrange([2, 1]))))
 
-    @test sprint(show, "text/plain", A) == "5-element Fill{$Int, 1, Tuple{BlockedUnitRange{Vector{$Int}}}} with indices 1:1:5, with entries equal to 2"
-    @test sprint(show, "text/plain", B) == "3×3 Diagonal{Float64, Ones{Float64, 1, Tuple{BlockedUnitRange{Vector{$Int}}}}} with indices 1:1:3×1:1:3"
-    @test sprint(show, "text/plain", U) == "3×3 UpperTriangular{Float64, Ones{Float64, 2, Tuple{BlockedUnitRange{Vector{$Int}}, BlockedUnitRange{Vector{$Int}}}}} with indices 1:1:3×1:1:3:\n 1.0  1.0  │  1.0\n ──────────┼─────\n  ⋅   1.0  │  1.0\n  ⋅    ⋅   │  1.0"
+    @test sprint(show, "text/plain", A) == "5-element Fill{$Int, 1, Tuple{BlockedOneTo{Vector{$Int}}}} with indices 1:1:5, with entries equal to 2"
+    @test sprint(show, "text/plain", B) == "3×3 Diagonal{Float64, Ones{Float64, 1, Tuple{BlockedOneTo{Vector{$Int}}}}} with indices 1:1:3×1:1:3"
+    @test sprint(show, "text/plain", U) == "3×3 UpperTriangular{Float64, Ones{Float64, 2, Tuple{BlockedOneTo{Vector{$Int}}, BlockedOneTo{Vector{$Int}}}}} with indices 1:1:3×1:1:3:\n 1.0  1.0  │  1.0\n ──────────┼─────\n  ⋅   1.0  │  1.0\n  ⋅    ⋅   │  1.0"
 
     @testset "views" begin
         # This in theory can be dropped because `view` returns the block, but we keep in case needed

--- a/test/test_blockarrayinterface.jl
+++ b/test/test_blockarrayinterface.jl
@@ -1,4 +1,4 @@
-using BlockArrays, LinearAlgebra, FillArrays, Test
+using BlockArrays, LinearAlgebra, FillArrays, Test, ArrayLayouts
 
 # avoid fast-paths for view
 bview(a, b) = Base.invoke(view, Tuple{AbstractArray,Any}, a, b)
@@ -51,10 +51,13 @@ end
         @test H[Block(2, 3)] == A[2:3, 4:6]
         @test H[Block(3, 2)] == A[2:3, 4:6]'
 
-        @test sprint(show, "text/plain", UpperTriangular(A)) == "10×10 UpperTriangular{ComplexF64, PseudoBlockMatrix{ComplexF64, Matrix{ComplexF64}, $(typeof(axes(A)))}} with indices 1:1:10×1:1:10:\n 1.0+0.0im  │  11.0+0.0im  21.0+0.0im  │  31.0+0.0im  41.0+0.0im  51.0+0.0im  │  61.0+0.0im  71.0+0.0im  81.0+0.0im   91.0+0.0im\n ───────────┼──────────────────────────┼──────────────────────────────────────┼─────────────────────────────────────────────────\n     ⋅      │  12.0+0.0im  22.0+0.0im  │  32.0+0.0im  42.0+0.0im  52.0+0.0im  │  62.0+0.0im  72.0+0.0im  82.0+0.0im   92.0+0.0im\n     ⋅      │       ⋅      23.0+0.0im  │  33.0+0.0im  43.0+0.0im  53.0+0.0im  │  63.0+0.0im  73.0+0.0im  83.0+0.0im   93.0+0.0im\n ───────────┼──────────────────────────┼──────────────────────────────────────┼─────────────────────────────────────────────────\n     ⋅      │       ⋅           ⋅      │  34.0+0.0im  44.0+0.0im  54.0+0.0im  │  64.0+0.0im  74.0+0.0im  84.0+0.0im   94.0+0.0im\n     ⋅      │       ⋅           ⋅      │       ⋅      45.0+0.0im  55.0+0.0im  │  65.0+0.0im  75.0+0.0im  85.0+0.0im   95.0+0.0im\n     ⋅      │       ⋅           ⋅      │       ⋅           ⋅      56.0+0.0im  │  66.0+0.0im  76.0+0.0im  86.0+0.0im   96.0+0.0im\n ───────────┼──────────────────────────┼──────────────────────────────────────┼─────────────────────────────────────────────────\n     ⋅      │       ⋅           ⋅      │       ⋅           ⋅           ⋅      │  67.0+0.0im  77.0+0.0im  87.0+0.0im   97.0+0.0im\n     ⋅      │       ⋅           ⋅      │       ⋅           ⋅           ⋅      │       ⋅      78.0+0.0im  88.0+0.0im   98.0+0.0im\n     ⋅      │       ⋅           ⋅      │       ⋅           ⋅           ⋅      │       ⋅           ⋅      89.0+0.0im   99.0+0.0im\n     ⋅      │       ⋅           ⋅      │       ⋅           ⋅           ⋅      │       ⋅           ⋅           ⋅      100.0+0.0im"
-
         V = view(A, Block.(1:2), Block.(1:2))
         @test blockisequal(axes(Symmetric(V)), axes(view(A, Block.(1:2), Block.(1:2))))
+
+        A = PseudoBlockArray{Int}(reshape([1:9;],3,3), 1:2, 1:2)
+        B = UpperTriangular(A)
+        str = sprint(show, "text/plain", B)
+        @test str == "$(summary(B)):\n 1  │  4  7\n ───┼──────\n ⋅  │  5  8\n ⋅  │  ⋅  9"
     end
 
     @testset "rect blocks" begin
@@ -130,7 +133,7 @@ end
     @test_throws BlockBoundsError A[Block(1, 3)]
     @test A == [1 2 0 0; 0 0 1 2]
     @test BlockArray(A) == A
-    @test sprint(show, "text/plain", A) == "2×2-blocked 2×4 BlockMatrix{$Int, Diagonal{Matrix{$Int}, Vector{Matrix{$Int}}}, Tuple{BlockedOneTo{Vector{$Int}}, BlockedOneTo{Vector{$Int}}}}:\n 1  2  │  ⋅  ⋅\n ──────┼──────\n ⋅  ⋅  │  1  2"
+    @test sprint(show, "text/plain", A) == "$(summary(A)):\n 1  2  │  ⋅  ⋅\n ──────┼──────\n ⋅  ⋅  │  1  2"
 
     N = 3
     D = Diagonal(mortar(Fill.(-(0:N) - (0:N) .^ 2, 1:2:2N+1)))
@@ -187,9 +190,9 @@ end
 
     U = UpperTriangular(Ones((blockedrange([1, 2]), blockedrange([2, 1]))))
 
-    @test sprint(show, "text/plain", A) == "5-element Fill{$Int, 1, Tuple{BlockedOneTo{Vector{$Int}}}} with indices 1:1:5, with entries equal to 2"
-    @test sprint(show, "text/plain", B) == "3×3 Diagonal{Float64, Ones{Float64, 1, Tuple{BlockedOneTo{Vector{$Int}}}}} with indices 1:1:3×1:1:3"
-    @test sprint(show, "text/plain", U) == "3×3 UpperTriangular{Float64, Ones{Float64, 2, Tuple{BlockedOneTo{Vector{$Int}}, BlockedOneTo{Vector{$Int}}}}} with indices 1:1:3×1:1:3:\n 1.0  1.0  │  1.0\n ──────────┼─────\n  ⋅   1.0  │  1.0\n  ⋅    ⋅   │  1.0"
+    @test sprint(show, "text/plain", A) == "$(summary(A)), with entries equal to 2"
+    @test sprint(show, "text/plain", B) == summary(B)
+    @test sprint(show, "text/plain", U) == "$(summary(U)):\n 1.0  1.0  │  1.0\n ──────────┼─────\n  ⋅   1.0  │  1.0\n  ⋅    ⋅   │  1.0"
 
     @testset "views" begin
         # This in theory can be dropped because `view` returns the block, but we keep in case needed

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -557,7 +557,7 @@ end
         A = PseudoBlockArray(design,[6],[4,5])
         @test sprint(show, "text/plain", A) == "1×2-blocked 6×9 PseudoBlockMatrix{Int16}:\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0"
         D = PseudoBlockArray(Diagonal(1:3), [1,2], [2,1])
-        @test sprint(show, "text/plain", D) == "2×2-blocked 3×3 $(PseudoBlockMatrix{Int, Diagonal{Int, UnitRange{Int}}, Tuple{BlockedUnitRange{Vector{Int}}, BlockedUnitRange{Vector{Int}}}}):\n 1  ⋅  │  ⋅\n ──────┼───\n ⋅  2  │  ⋅\n ⋅  ⋅  │  3"
+        @test sprint(show, "text/plain", D) == "2×2-blocked 3×3 $(PseudoBlockMatrix{Int, Diagonal{Int, UnitRange{Int}}, Tuple{BlockedOneTo{Vector{Int}}, BlockedOneTo{Vector{Int}}}}):\n 1  ⋅  │  ⋅\n ──────┼───\n ⋅  2  │  ⋅\n ⋅  ⋅  │  3"
 
         a = BlockArray{Int}(undef_blocks, [1,2])
         @test sprint(show, "text/plain", a) == "2-blocked 3-element BlockVector{Int64}:\n #undef\n ──────\n #undef\n #undef"

--- a/test/test_blockbroadcast.jl
+++ b/test/test_blockbroadcast.jl
@@ -1,5 +1,6 @@
 using BlockArrays, FillArrays, Test
 import BlockArrays: SubBlockIterator, BlockIndexRange, Diagonal
+import InfiniteArrays
 
 @testset "broadcast" begin
     @testset "BlockArray" begin

--- a/test/test_blockbroadcast.jl
+++ b/test/test_blockbroadcast.jl
@@ -122,6 +122,14 @@ import BlockArrays: SubBlockIterator, BlockIndexRange, Diagonal
         @test (@. z = x + y + z; z) == (@. z2 = x2 + y2 + z2; z2)
     end
 
+    @testset "blockedrange" begin
+        b = blockedrange(InfiniteArrays.OneToInf())
+        b2 = b .+ b
+        for i in 1:10
+            @test b2[Block(i)] == b[Block(i)] + b[Block(i)]
+        end
+    end
+
     @testset "Special broadcast" begin
         v = mortar([1:3,4:7])
         @test broadcast(+, v) isa BlockVector{Int,Vector{UnitRange{Int}}}

--- a/test/test_blockindices.jl
+++ b/test/test_blockindices.jl
@@ -708,6 +708,11 @@ end
         y = blockedrange([2:4;])
         @test blocksizes(x,1) == blocksizes(y,1)
     end
+
+    @testset "show" begin
+        b = blockedrange([1,2])
+        @test repr(b) == "$BlockedOneTo($([1,3]))"
+    end
 end
 
 @testset "BlockSlice" begin

--- a/test/test_blockindices.jl
+++ b/test/test_blockindices.jl
@@ -462,20 +462,6 @@ end
         @test_throws BlockBoundsError b[Block(4)]
         @test_throws BlockBoundsError view(b, Block(4))
 
-        b = blockedrange(1:3)
-        bpart = @inferred(b[Block.(1:2)])
-        @test bpart isa BlockedUnitRange
-        @test bpart == blockedrange(1:2)
-        bpart = @inferred(b[Block.(1:0)])
-        @test bpart isa BlockedUnitRange
-        @test bpart == blockedrange(1:0)
-        bpart = @inferred(b[Block.(Base.OneTo(2))])
-        @test bpart isa BlockedOneTo
-        @test bpart == blockedrange(1:2)
-        bpart = @inferred(b[Block.(Base.OneTo(0))])
-        @test bpart isa BlockedOneTo
-        @test bpart == blockedrange(1:0)
-
         o = OffsetArray([2,2,3],-1:1)
         b = blockedrange(o)
         @test axes(b) == (b,)
@@ -584,36 +570,7 @@ end
         @test_throws BoundsError findblockindex(b,7)
 
         o = OffsetArray([2,2,3],-1:1)
-        b = blockedrange(o)
-        @test @inferred(findblock(b,1)) == Block(-1)
-        @test @inferred(findblockindex(b,1)) == Block(-1)[1]
-        @test findblock.(Ref(b),1:7) == Block.([-1,-1,0,0,1,1,1])
-        @test findblockindex.(Ref(b),1:7) == BlockIndex.([-1,-1,0,0,1,1,1], [1,2,1,2,1,2,3])
-        @test_throws BoundsError findblock(b,0)
-        @test_throws BoundsError findblock(b,8)
-        @test_throws BoundsError findblockindex(b,0)
-        @test_throws BoundsError findblockindex(b,8)
-
-        b = BlockArrays._BlockedUnitRange(-1,[-1,1,4])
-        @test @inferred(findblock(b,-1)) == Block(1)
-        @test @inferred(findblockindex(b,-1)) == Block(1)[1]
-        @test findblock.(Ref(b),-1:4) == Block.([1,2,2,3,3,3])
-        @test findblockindex.(Ref(b),-1:4) == BlockIndex.([1,2,2,3,3,3],[1,1,2,1,2,3])
-        @test_throws BoundsError findblock(b,-2)
-        @test_throws BoundsError findblock(b,5)
-        @test_throws BoundsError findblockindex(b,-2)
-        @test_throws BoundsError findblockindex(b,5)
-
-        o = OffsetArray([2,2,3],-1:1)
-        b = BlockArrays._BlockedUnitRange(-3, cumsum(o) .- 4)
-        @test @inferred(findblock(b,-3)) == Block(-1)
-        @test @inferred(findblockindex(b,-3)) == Block(-1)[1]
-        @test findblock.(Ref(b),-3:3) == Block.([-1,-1,0,0,1,1,1])
-        @test findblockindex.(Ref(b),-3:3) == BlockIndex.([-1,-1,0,0,1,1,1], [1,2,1,2,1,2,3])
-        @test_throws BoundsError findblock(b,-4)
-        @test_throws BoundsError findblock(b,5)
-        @test_throws BoundsError findblockindex(b,-4)
-        @test_throws BoundsError findblockindex(b,5)
+        @test_throws ArgumentError blockedrange(o)
 
         b = blockedrange(Fill(3,1_000_000))
         @test @inferred(findblock(b, 1)) == Block(1)
@@ -624,6 +581,13 @@ end
         @test_throws BoundsError findblock(b,3_000_001)
         @test_throws BoundsError findblockindex(b,0)
         @test_throws BoundsError findblockindex(b,3_000_001)
+    end
+
+    @testset "BlockedOneTo indexing" begin
+        b1 = blockedrange(1:3)
+        b2 = blockedrange(1:2)
+        @test b1[b2] == b2
+        @test_throws BoundsError b1[blockedrange(1:4)]
     end
 
     @testset "BlockIndex indexing" begin
@@ -644,6 +608,20 @@ end
             @test b[Block.(2:4)] == 2:10
             @test length(b[Block.(2:4)]) == 9
         end
+
+        b = blockedrange(1:3)
+        @test bpart isa BlockedUnitRange
+        bpart = @inferred(b[Block.(1:2)])
+        @test bpart == blockedrange(1:2)
+        bpart = @inferred(b[Block.(1:0)])
+        @test bpart isa BlockedUnitRange
+        @test bpart == blockedrange(1:0)
+        bpart = @inferred(b[Block.(Base.OneTo(2))])
+        @test bpart isa BlockedOneTo
+        @test bpart == blockedrange(1:2)
+        bpart = @inferred(b[Block.(Base.OneTo(0))])
+        @test bpart isa BlockedOneTo
+        @test bpart == blockedrange(1:0)
     end
 
     @testset "misc" begin

--- a/test/test_blockindices.jl
+++ b/test/test_blockindices.jl
@@ -226,26 +226,30 @@ end
 
     @testset "firsts/lasts/lengths" begin
         b = blockedrange(1, [1,2,3])
-        @test blockfirsts(b) == [1,2,4]
-        @test blocklasts(b) == [1,3,6]
-        @test blocklengths(b) == [1,2,3]
+        @test @inferred(blockfirsts(b)) == [1,2,4]
+        @test @inferred(blocklasts(b)) == [1,3,6]
+        @test @inferred(blocklengths(b)) == [1,2,3]
 
         o = blockedrange(1, Ones{Int}(10))
-        @test blocklasts(o) == blockfirsts(o) == Base.OneTo(10)
-        @test blocklengths(o) == Ones{Int}(10)
+        @test @inferred(blocklasts(o)) == @inferred(blockfirsts(o)) == Base.OneTo(10)
+        @test @inferred(blocklengths(o)) == Ones{Int}(10)
 
         f = blockedrange(1, Fill(2,5))
-        @test blockfirsts(f) ≡ 1:2:9
-        @test blocklasts(f) ≡ StepRangeLen(2,2,5)
-        @test blocklengths(f) ≡ Fill(2,5)
+        @test @inferred(blockfirsts(f)) ≡ 1:2:9
+        @test @inferred(blocklasts(f)) ≡ StepRangeLen(2,2,5)
+        @test @inferred(blocklengths(f)) ≡ Fill(2,5)
 
         f = blockedrange(1, Zeros{Int}(2))
-        @test blockfirsts(f) == [1,1]
-        @test blocklasts(f) == [0,0]
+        @test @inferred(blockfirsts(f)) == [1,1]
+        @test @inferred(blocklasts(f)) == [0,0]
 
         r = blockedrange(1, Base.OneTo(5))
-        @test (@inferred blocklengths(r)) == 1:5
-        @test blocklasts(r) == ArrayLayouts.RangeCumsum(Base.OneTo(5))
+        @test @inferred(blocklengths(r)) == 1:5
+        @test @inferred(blocklasts(r)) == ArrayLayouts.RangeCumsum(Base.OneTo(5))
+
+        r = blockedrange(2, 2:3:11)
+        @test @inferred(blockfirsts(r)) == [2,4,9,17]
+        @test @inferred(blocklengths(r)) == 2:3:11
     end
 
     @testset "convert" begin
@@ -498,26 +502,30 @@ end
 
     @testset "firsts/lasts/lengths" begin
         b = blockedrange([1,2,3])
-        @test blockfirsts(b) == [1,2,4]
-        @test blocklasts(b) == [1,3,6]
-        @test blocklengths(b) == [1,2,3]
+        @test @inferred(blockfirsts(b)) == [1,2,4]
+        @test @inferred(blocklasts(b)) == [1,3,6]
+        @test @inferred(blocklengths(b)) == [1,2,3]
 
         o = blockedrange(Ones{Int}(10))
-        @test blocklasts(o) == blockfirsts(o) == Base.OneTo(10)
-        @test blocklengths(o) == Ones{Int}(10)
+        @test @inferred(blocklasts(o)) == @inferred(blockfirsts(o)) == Base.OneTo(10)
+        @test @inferred(blocklengths(o)) == Ones{Int}(10)
 
         f = blockedrange(Fill(2,5))
-        @test blockfirsts(f) ≡ 1:2:9
-        @test blocklasts(f) ≡ StepRangeLen(2,2,5)
-        @test blocklengths(f) ≡ Fill(2,5)
+        @test @inferred(blockfirsts(f)) ≡ 1:2:9
+        @test @inferred(blocklasts(f)) ≡ StepRangeLen(2,2,5)
+        @test @inferred(blocklengths(f)) ≡ Fill(2,5)
 
         f = blockedrange(Zeros{Int}(2))
-        @test blockfirsts(f) == [1,1]
-        @test blocklasts(f) == [0,0]
+        @test @inferred(blockfirsts(f)) == [1,1]
+        @test @inferred(blocklasts(f)) == [0,0]
 
         r = blockedrange(Base.OneTo(5))
-        @test (@inferred blocklengths(r)) == 1:5
-        @test blocklasts(r) == ArrayLayouts.RangeCumsum(Base.OneTo(5))
+        @test @inferred(blocklengths(r)) == 1:5
+        @test @inferred(blocklasts(r)) == ArrayLayouts.RangeCumsum(Base.OneTo(5))
+
+        r = blockedrange(2:3:11)
+        @test @inferred(blockfirsts(r)) == [1,3,8,16]
+        @test @inferred(blocklengths(r)) == 2:3:11
     end
 
     @testset "convert" begin

--- a/test/test_blockindices.jl
+++ b/test/test_blockindices.jl
@@ -473,7 +473,7 @@ end
         @test_throws BlockBoundsError b[Block(-2)]
         @test_throws BlockBoundsError b[Block(2)]
 
-        b = BlockArrays._BlockedUnitRange(1, cumsum(Fill(3,1_000_000)))
+        b = blockedrange(1,Fill(3,1_000_000))
         @test b isa BlockedUnitRange{<:AbstractRange}
         @test b[Block(100_000)] == 299_998:300_000
         @test_throws BlockBoundsError b[Block(0)]

--- a/test/test_blockindices.jl
+++ b/test/test_blockindices.jl
@@ -187,13 +187,7 @@ end
         @test bpart == blockedrange(2, 1:0)
 
         o = OffsetArray([2,2,3],-1:1)
-        b = blockedrange(1, o)
-        @test axes(b) == (b,)
-        @test @inferred(b[Block(-1)]) == 1:2
-        @test b[Block(0)] == 3:4
-        @test b[Block(1)] == 5:7
-        @test_throws BlockBoundsError b[Block(-2)]
-        @test_throws BlockBoundsError b[Block(2)]
+        @test_throws ArgumentError blockedrange(1, o)
 
         b = BlockArrays._BlockedUnitRange(-1,[-1,1,4])
         @test axes(b,1) == blockedrange(1, [1,2,3])
@@ -202,15 +196,6 @@ end
         @test b[Block(3)] == 2:4
         @test_throws BlockBoundsError b[Block(0)]
         @test_throws BlockBoundsError b[Block(4)]
-
-        o = OffsetArray([2,2,3],-1:1)
-        b = BlockArrays._BlockedUnitRange(-3, cumsum(o) .- 4)
-        @test axes(b,1) == blockedrange(1, [2,2,3])
-        @test b[Block(-1)] == -3:-2
-        @test b[Block(0)] == -1:0
-        @test b[Block(1)] == 1:3
-        @test_throws BlockBoundsError b[Block(-2)]
-        @test_throws BlockBoundsError b[Block(2)]
 
         b = BlockArrays._BlockedUnitRange(1, cumsum(Fill(3,1_000_000)))
         @test b isa BlockedUnitRange{<:AbstractRange}
@@ -286,17 +271,6 @@ end
         @test_throws BoundsError findblockindex(b,0)
         @test_throws BoundsError findblockindex(b,7)
 
-        o = OffsetArray([2,2,3],-1:1)
-        b = blockedrange(1, o)
-        @test @inferred(findblock(b,1)) == Block(-1)
-        @test @inferred(findblockindex(b,1)) == Block(-1)[1]
-        @test findblock.(Ref(b),1:7) == Block.([-1,-1,0,0,1,1,1])
-        @test findblockindex.(Ref(b),1:7) == BlockIndex.([-1,-1,0,0,1,1,1], [1,2,1,2,1,2,3])
-        @test_throws BoundsError findblock(b,0)
-        @test_throws BoundsError findblock(b,8)
-        @test_throws BoundsError findblockindex(b,0)
-        @test_throws BoundsError findblockindex(b,8)
-
         b = BlockArrays._BlockedUnitRange(-1,[-1,1,4])
         @test @inferred(findblock(b,-1)) == Block(1)
         @test @inferred(findblockindex(b,-1)) == Block(1)[1]
@@ -305,17 +279,6 @@ end
         @test_throws BoundsError findblock(b,-2)
         @test_throws BoundsError findblock(b,5)
         @test_throws BoundsError findblockindex(b,-2)
-        @test_throws BoundsError findblockindex(b,5)
-
-        o = OffsetArray([2,2,3],-1:1)
-        b = BlockArrays._BlockedUnitRange(-3, cumsum(o) .- 4)
-        @test @inferred(findblock(b,-3)) == Block(-1)
-        @test @inferred(findblockindex(b,-3)) == Block(-1)[1]
-        @test findblock.(Ref(b),-3:3) == Block.([-1,-1,0,0,1,1,1])
-        @test findblockindex.(Ref(b),-3:3) == BlockIndex.([-1,-1,0,0,1,1,1], [1,2,1,2,1,2,3])
-        @test_throws BoundsError findblock(b,-4)
-        @test_throws BoundsError findblock(b,5)
-        @test_throws BoundsError findblockindex(b,-4)
         @test_throws BoundsError findblockindex(b,5)
 
         b = blockedrange(1, Fill(3,1_000_000))
@@ -462,31 +425,13 @@ end
         @test_throws BlockBoundsError b[Block(4)]
         @test_throws BlockBoundsError view(b, Block(4))
 
-        o = OffsetArray([2,2,3],-1:1)
-        b = blockedrange(o)
-        @test axes(b) == (b,)
-        @test @inferred(b[Block(-1)]) == 1:2
-        @test b[Block(0)] == 3:4
-        @test b[Block(1)] == 5:7
-        @test_throws BlockBoundsError b[Block(-2)]
-        @test_throws BlockBoundsError b[Block(2)]
-
-        b = BlockArrays._BlockedUnitRange(-1,[-1,1,4])
-        @test axes(b,1) == blockedrange([1,2,3])
-        @test b[Block(1)] == -1:-1
-        @test b[Block(2)] == 0:1
+        b = BlockedOneTo([0,1,4])
+        @test axes(b,1) == blockedrange([0,1,3])
+        @test b[Block(1)] == 1:0
+        @test b[Block(2)] == 1:1
         @test b[Block(3)] == 2:4
         @test_throws BlockBoundsError b[Block(0)]
         @test_throws BlockBoundsError b[Block(4)]
-
-        o = OffsetArray([2,2,3],-1:1)
-        b = BlockArrays._BlockedUnitRange(-3, cumsum(o) .- 4)
-        @test axes(b,1) == blockedrange([2,2,3])
-        @test b[Block(-1)] == -3:-2
-        @test b[Block(0)] == -1:0
-        @test b[Block(1)] == 1:3
-        @test_throws BlockBoundsError b[Block(-2)]
-        @test_throws BlockBoundsError b[Block(2)]
 
         b = blockedrange(1,Fill(3,1_000_000))
         @test b isa BlockedUnitRange{<:AbstractRange}
@@ -610,8 +555,8 @@ end
         end
 
         b = blockedrange(1:3)
-        @test bpart isa BlockedUnitRange
         bpart = @inferred(b[Block.(1:2)])
+        @test bpart isa BlockedUnitRange
         @test bpart == blockedrange(1:2)
         bpart = @inferred(b[Block.(1:0)])
         @test bpart isa BlockedUnitRange

--- a/test/test_blockindices.jl
+++ b/test/test_blockindices.jl
@@ -175,6 +175,17 @@ end
         @test_throws BlockBoundsError b[Block(4)]
         @test_throws BlockBoundsError view(b, Block(4))
 
+        b = blockedrange(2, 1:3)
+        bpart = @inferred(b[Block.(1:2)])
+        @test bpart isa BlockedUnitRange
+        @test bpart == blockedrange(2, 1:2)
+        bpart = @inferred(b[Block.(Base.OneTo(2))])
+        @test bpart isa BlockedUnitRange
+        @test bpart == blockedrange(2, 1:2)
+        bpart = @inferred(b[Block.(Base.OneTo(0))])
+        @test bpart isa BlockedUnitRange
+        @test bpart == blockedrange(2, 1:0)
+
         o = OffsetArray([2,2,3],-1:1)
         b = blockedrange(1, o)
         @test axes(b) == (b,)
@@ -450,6 +461,20 @@ end
         @test_throws BlockBoundsError b[Block(0)]
         @test_throws BlockBoundsError b[Block(4)]
         @test_throws BlockBoundsError view(b, Block(4))
+
+        b = blockedrange(1:3)
+        bpart = @inferred(b[Block.(1:2)])
+        @test bpart isa BlockedUnitRange
+        @test bpart == blockedrange(1:2)
+        bpart = @inferred(b[Block.(1:0)])
+        @test bpart isa BlockedUnitRange
+        @test bpart == blockedrange(1:0)
+        bpart = @inferred(b[Block.(Base.OneTo(2))])
+        @test bpart isa BlockedOneTo
+        @test bpart == blockedrange(1:2)
+        bpart = @inferred(b[Block.(Base.OneTo(0))])
+        @test bpart isa BlockedOneTo
+        @test bpart == blockedrange(1:0)
 
         o = OffsetArray([2,2,3],-1:1)
         b = blockedrange(o)

--- a/test/test_blockindices.jl
+++ b/test/test_blockindices.jl
@@ -258,6 +258,7 @@ end
         @test convert(BlockedUnitRange{Vector{Int}}, c) === c
         @test blockisequal(convert(BlockedUnitRange{Vector{Int}}, b),b)
         @test blockisequal(convert(BlockedUnitRange{Vector{Int}}, Base.OneTo(5)), blockedrange(1, [5]))
+        @test blockisequal(convert(BlockedUnitRange, BlockedOneTo(1:3)), blockedrange(1, [1,1,1]))
     end
 
     @testset "findblock" begin

--- a/test/test_blockviews.jl
+++ b/test/test_blockviews.jl
@@ -140,7 +140,7 @@ bview(a, b) = Base.invoke(view, Tuple{AbstractArray,Any}, a, b)
         A = PseudoBlockArray(collect(1:6), 1:3)
         V = view(A, Block.(1:2))
         @test V == 1:3
-        @test axes(V,1) isa BlockArrays.BlockedUnitRange
+        @test axes(V,1) isa BlockArrays.BlockedOneTo
         @test blockaxes(V,1) == Block.(1:2)
         @test view(V, Block(2)[1:2]) == [2,3]
         V = view(A, Block.(2:3))


### PR DESCRIPTION
This builds on top of https://github.com/JuliaArrays/BlockArrays.jl/pull/348, and should be rebased once that is merged. This adds tests for broadcasting involving infinite blocked ranges
```julia
julia> b = blockedrange(InfiniteArrays.OneToInf())
ℵ₀-blocked ℵ₀-element BlockedOneTo{ArrayLayouts.RangeCumsum{Int64, InfiniteArrays.OneToInf{Int64}}}:
 1
 ─
 2
 3
 ─
 4
 5
 6
 ─
 7
 8
 9
 ⋮

julia> b .+ b
(ℵ₀-blocked ℵ₀-element BlockedOneTo{ArrayLayouts.RangeCumsum{Int64, InfiniteArrays.OneToInf{Int64}}}) .+ (ℵ₀-blocked ℵ₀-element BlockedOneTo{ArrayLayouts.RangeCumsum{Int64, InfiniteArrays.OneToInf{Int64}}}) with indices BlockedOneTo(ArrayLayouts.RangeCumsum(OneToInf())):
  2
 ──
  4
  6
 ──
  8
 10
 12
 ──
 14
 16
 18
  ⋮
```