### PR TITLE
Move LazyArrays extension to LazyArrays.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -20,7 +20,6 @@ ArrayLayouts = "1.0.8"
 BandedMatrices = "1.0"
 Documenter = "1"
 FillArrays = "1"
-InfiniteArrays = "0.13"
 LinearAlgebra = "1.6"
 OffsetArrays = "1"
 Random = "1.6"
@@ -33,7 +32,6 @@ julia = "1.6"
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 BandedMatrices = "aae01518-5342-5314-be14-df237901396f"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-InfiniteArrays = "4858937d-0d70-526a-a4dd-2d5cb5dd786c"
 OffsetArrays = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
@@ -41,4 +39,4 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "BandedMatrices", "Documenter", "InfiniteArrays", "OffsetArrays", "SparseArrays", "StaticArrays", "Test", "Random"]
+test = ["Aqua", "BandedMatrices", "Documenter", "OffsetArrays", "SparseArrays", "StaticArrays", "Test", "Random"]

--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,6 @@ version = "1.0.0-dev"
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
 BandedMatrices = "aae01518-5342-5314-be14-df237901396f"
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
-LazyArrays = "5078a376-72f3-5289-bfd5-ec5146d43c02"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [weakdeps]

--- a/Project.toml
+++ b/Project.toml
@@ -11,11 +11,9 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [weakdeps]
 BandedMatrices = "aae01518-5342-5314-be14-df237901396f"
-LazyArrays = "5078a376-72f3-5289-bfd5-ec5146d43c02"
 
 [extensions]
 BlockArraysBandedMatricesExt = "BandedMatrices"
-BlockArraysLazyArraysExt = "LazyArrays"
 
 [compat]
 Aqua = "0.8"
@@ -24,7 +22,6 @@ BandedMatrices = "1.0"
 Documenter = "1"
 FillArrays = "1"
 InfiniteArrays = "0.13"
-LazyArrays = "1"
 LinearAlgebra = "1.6"
 OffsetArrays = "1"
 Random = "1.6"

--- a/ext/BlockArraysLazyArraysExt.jl
+++ b/ext/BlockArraysLazyArraysExt.jl
@@ -1,8 +1,0 @@
-module BlockArraysLazyArraysExt
-
-import BlockArrays
-import LazyArrays
-
-BlockArrays._broadcaststyle(S::LazyArrays.LazyArrayStyle{1}) = S
-
-end

--- a/src/BlockArrays.jl
+++ b/src/BlockArrays.jl
@@ -76,7 +76,6 @@ include("blockbanded.jl")
 @deprecate setblock!(A::AbstractBlockArray{T,N}, v, I::Vararg{Integer, N}) where {T,N} (A[Block(I...)] = v)
 
 if !isdefined(Base, :get_extension)
-    include("../ext/BlockArraysLazyArraysExt.jl")
     include("../ext/BlockArraysBandedMatricesExt.jl")
 end
 

--- a/src/blockaxis.jl
+++ b/src/blockaxis.jl
@@ -545,7 +545,7 @@ Base.BroadcastStyle(::Type{<:AbstractBlockedUnitRange{<:Any,R}}) where R = _broa
 # We want to use lazy types when possible
 ###
 
-const OneToCumsum = RangeCumsum{Int,OneTo{Int}}
+const OneToCumsum = RangeCumsum{Int,Base.OneTo{Int}}
 sortedunion(a::OneToCumsum, ::OneToCumsum) = a
 function sortedunion(a::RangeCumsum{<:Any,<:AbstractRange}, b::RangeCumsum{<:Any,<:AbstractRange})
     @assert a == b

--- a/src/blockaxis.jl
+++ b/src/blockaxis.jl
@@ -545,6 +545,13 @@ Base.BroadcastStyle(::Type{<:AbstractBlockedUnitRange{<:Any,R}}) where R = _broa
 # We want to use lazy types when possible
 ###
 
+const OneToCumsum = RangeCumsum{Int,OneTo{Int}}
+sortedunion(a::OneToCumsum, ::OneToCumsum) = a
+function sortedunion(a::RangeCumsum{<:Any,<:AbstractRange}, b::RangeCumsum{<:Any,<:AbstractRange})
+    @assert a == b
+    a
+end
+
 _blocklengths2blocklasts(blocks::AbstractRange) = RangeCumsum(blocks)
 function blockfirsts(a::AbstractBlockedUnitRange{<:Any,Base.OneTo{Int}})
     first(a) == 1 || error("Offset axes not supported")

--- a/test/test_blockbroadcast.jl
+++ b/test/test_blockbroadcast.jl
@@ -2,7 +2,6 @@ module TestBlockBroadcast
 
 using BlockArrays, FillArrays, Test
 import BlockArrays: SubBlockIterator, BlockIndexRange, Diagonal
-import InfiniteArrays
 using StaticArrays
 
 @testset "broadcast" begin
@@ -124,17 +123,6 @@ using StaticArrays
         y2 = copy(y)
         z2 = copy(z)
         @test (@. z = x + y + z; z) == (@. z2 = x2 + y2 + z2; z2)
-    end
-
-    @testset "blockedrange" begin
-        b = blockedrange(InfiniteArrays.OneToInf())
-        b2 = b .+ b
-        for i in 1:10
-            @test b2[Block(i)] == b[Block(i)] + b[Block(i)]
-        end
-
-        b = blockedrange(SVector{2}([1,2]))
-        @test b .+ b == 2:2:6
     end
 
     @testset "Special broadcast" begin


### PR DESCRIPTION
The extension has been moved here:

https://github.com/JuliaArrays/LazyArrays.jl/pull/304

This is because a lot of code will be moved from LazyBandedMatrices.jl, which I don't want to pollute this repository.