### PR TITLE
Allow non-Int eltypes in BlockedOneTo

### DIFF
--- a/docs/src/man/blockarrays.md
+++ b/docs/src/man/blockarrays.md
@@ -22,7 +22,7 @@ julia> BlockArray(Array(reshape(1:16, 4, 4)), [2,2], [1,1,2])
 julia> S = spzeros(4,5); S[1,2] = S[4,3] = 1;
 
 julia> block_array_sparse = BlockArray(S, [1,3], [2,3])
-2×2-blocked 4×5 BlockMatrix{Float64, Matrix{SparseMatrixCSC{Float64, Int64}}, Tuple{BlockedOneTo{Vector{Int64}}, BlockedOneTo{Vector{Int64}}}}:
+2×2-blocked 4×5 BlockMatrix{Float64, Matrix{SparseMatrixCSC{Float64, Int64}}, Tuple{BlockedOneTo{Int64, Vector{Int64}}, BlockedOneTo{Int64, Vector{Int64}}}}:
   ⋅   1.0  │   ⋅    ⋅    ⋅ 
  ──────────┼───────────────
   ⋅    ⋅   │   ⋅    ⋅    ⋅ 
@@ -67,7 +67,7 @@ The `block_type` should be an array type.  It specifies the internal block type,
 
 ```jldoctest
 julia> BlockArray(undef_blocks, SparseVector{Float64, Int}, [1,2])
-2-blocked 3-element BlockVector{Float64, Vector{SparseVector{Float64, Int64}}, Tuple{BlockedOneTo{Vector{Int64}}}}:
+2-blocked 3-element BlockVector{Float64, Vector{SparseVector{Float64, Int64}}, Tuple{BlockedOneTo{Int64, Vector{Int64}}}}:
  #undef
  ──────
  #undef
@@ -151,7 +151,7 @@ julia> view(A, Block(2)) .= [3,4]; A[Block(2)]
  4.0
 
 julia> view(A, Block.(1:2))
-3-element view(::BlockVector{Float64, Vector{Vector{Float64}}, Tuple{BlockedOneTo{ArrayLayouts.RangeCumsum{Int64, UnitRange{Int64}}}}}, BlockSlice(BlockRange(1:2),1:1:3)) with eltype Float64 with indices BlockedOneTo([1, 3]):
+3-element view(::BlockVector{Float64, Vector{Vector{Float64}}, Tuple{BlockedOneTo{Int64, ArrayLayouts.RangeCumsum{Int64, UnitRange{Int64}}}}}, BlockSlice(BlockRange(1:2),1:1:3)) with eltype Float64 with indices BlockedOneTo([1, 3]):
  1.0
  3.0
  4.0
@@ -167,7 +167,7 @@ An array can be repacked into a `BlockArray` with `BlockArray(array, block_sizes
 julia> S = spzeros(4,5); S[1,2] = S[4,3] = 1;
 
 julia> block_array_sparse = BlockArray(S, [1,3], [2,3])
-2×2-blocked 4×5 BlockMatrix{Float64, Matrix{SparseMatrixCSC{Float64, Int64}}, Tuple{BlockedOneTo{Vector{Int64}}, BlockedOneTo{Vector{Int64}}}}:
+2×2-blocked 4×5 BlockMatrix{Float64, Matrix{SparseMatrixCSC{Float64, Int64}}, Tuple{BlockedOneTo{Int64, Vector{Int64}}, BlockedOneTo{Int64, Vector{Int64}}}}:
   ⋅   1.0  │   ⋅    ⋅    ⋅ 
  ──────────┼───────────────
   ⋅    ⋅   │   ⋅    ⋅    ⋅ 

--- a/src/blockaxis.jl
+++ b/src/blockaxis.jl
@@ -135,14 +135,20 @@ See also [`BlockedUnitRange`](@ref).
 struct BlockedOneTo{T<:Integer,CS} <: AbstractBlockedUnitRange{T,CS}
     lasts::CS
     # assume that lasts is sorted, no checks carried out here
-    function BlockedOneTo(lasts::CS) where {CS}
-        T = eltype(CS)
-        T == Bool && throw(ArgumentError("a Bool collection is not allowed as blocklasts"))
+    function BlockedOneTo(lasts::CS) where {T, CS<:AbstractVector{T}}
+        _throw_if_bool(T)
         Base.require_one_based_indexing(lasts)
         isempty(lasts) || first(lasts) >= 0 || throw(ArgumentError("blocklasts must be >= 0"))
         new{T,CS}(lasts)
     end
+    function BlockedOneTo(lasts::CS) where {T, CS<:Tuple{T,Vararg{T}}}
+        _throw_if_bool(T)
+        first(lasts) >= 0 || throw(ArgumentError("blocklasts must be >= 0"))
+        new{T,CS}(lasts)
+    end
 end
+_throw_if_bool(_) = nothing
+_throw_if_bool(::Type{Bool}) = throw(ArgumentError("a Bool collection is not allowed as blocklasts"))
 
 const DefaultBlockAxis = BlockedOneTo{Int, Vector{Int}}
 

--- a/src/blockaxis.jl
+++ b/src/blockaxis.jl
@@ -135,13 +135,13 @@ See also [`BlockedUnitRange`](@ref).
 struct BlockedOneTo{T<:Integer,CS} <: AbstractBlockedUnitRange{T,CS}
     lasts::CS
     # assume that lasts is sorted, no checks carried out here
-    function BlockedOneTo(lasts::CS) where {T, CS<:AbstractVector{T}}
+    function BlockedOneTo(lasts::CS) where {T<:Integer, CS<:AbstractVector{T}}
         _throw_if_bool(T)
         Base.require_one_based_indexing(lasts)
         isempty(lasts) || first(lasts) >= 0 || throw(ArgumentError("blocklasts must be >= 0"))
         new{T,CS}(lasts)
     end
-    function BlockedOneTo(lasts::CS) where {T, CS<:Tuple{T,Vararg{T}}}
+    function BlockedOneTo(lasts::CS) where {T<:Integer, CS<:Tuple{T,Vararg{T}}}
         _throw_if_bool(T)
         first(lasts) >= 0 || throw(ArgumentError("blocklasts must be >= 0"))
         new{T,CS}(lasts)

--- a/src/blockaxis.jl
+++ b/src/blockaxis.jl
@@ -105,9 +105,9 @@ end
 end
 
 """
-    BlockedOneTo
+    BlockedOneTo{T, <:Union{AbstractVector{T}, NTuple{<:Any,T}}} where {T}
 
-Define an `AbstractUnitRange{Int}` that has been divided
+Define an `AbstractUnitRange{T}` that has been divided
 into blocks, which is used to represent `axes` of block arrays.
 This parallels `Base.OneTo` in that the first value is guaranteed
 to be `1`.
@@ -118,7 +118,7 @@ a vector of block lengths to a `BlockedUnitRange`.
 # Examples
 ```jldoctest
 julia> blockedrange([2,2,3]) # block lengths
-3-blocked 7-element BlockedOneTo{Vector{Int64}}:
+3-blocked 7-element BlockedOneTo{Int64, Vector{Int64}}:
  1
  2
  ─
@@ -132,18 +132,19 @@ julia> blockedrange([2,2,3]) # block lengths
 
 See also [`BlockedUnitRange`](@ref).
 """
-struct BlockedOneTo{CS} <: AbstractBlockedUnitRange{Int,CS}
+struct BlockedOneTo{T<:Integer,CS} <: AbstractBlockedUnitRange{T,CS}
     lasts::CS
     # assume that lasts is sorted, no checks carried out here
-    function BlockedOneTo{CS}(lasts) where {CS}
+    function BlockedOneTo(lasts::CS) where {CS}
+        T = eltype(CS)
+        T == Bool && throw(ArgumentError("a Bool collection is not allowed as blocklasts"))
         Base.require_one_based_indexing(lasts)
         isempty(lasts) || first(lasts) >= 0 || throw(ArgumentError("blocklasts must be >= 0"))
-        new{CS}(lasts)
+        new{T,CS}(lasts)
     end
 end
-BlockedOneTo(lasts) = BlockedOneTo{typeof(lasts)}(lasts)
 
-const DefaultBlockAxis = BlockedOneTo{Vector{Int}}
+const DefaultBlockAxis = BlockedOneTo{Int, Vector{Int}}
 
 first(b::BlockedOneTo) = oneunit(eltype(b))
 @inline blocklasts(a::BlockedOneTo) = a.lasts
@@ -163,7 +164,7 @@ Otherwise, if only the block lengths are provided, `first` is assumed to be `1`.
 # Examples
 ```jldoctest
 julia> blockedrange([1,2])
-2-blocked 3-element BlockedOneTo{Vector{Int64}}:
+2-blocked 3-element BlockedOneTo{Int64, Vector{Int64}}:
  1
  ─
  2
@@ -200,14 +201,14 @@ Check if `a` and `b` have the same block structure.
 # Examples
 ```jldoctest
 julia> b1 = blockedrange([1,2])
-2-blocked 3-element BlockedOneTo{Vector{Int64}}:
+2-blocked 3-element BlockedOneTo{Int64, Vector{Int64}}:
  1
  ─
  2
  3
 
 julia> b2 = blockedrange([1,1,1])
-3-blocked 3-element BlockedOneTo{Vector{Int64}}:
+3-blocked 3-element BlockedOneTo{Int64, Vector{Int64}}:
  1
  ─
  2
@@ -253,11 +254,11 @@ Base.unitrange(b::AbstractBlockedUnitRange) = first(b):last(b)
 
 Base.promote_rule(::Type{<:AbstractBlockedUnitRange{T}}, ::Type{Base.OneTo{Int}}) where {T} = UnitRange{promote_type(T, Int)}
 
-function Base.convert(::Type{BlockedOneTo}, axis::AbstractUnitRange{Int})
+function Base.convert(::Type{BlockedOneTo}, axis::AbstractUnitRange{<:Integer})
     first(axis) == 1 || throw(ArgumentError("first element of range is not 1"))
     BlockedOneTo(blocklasts(axis))
 end
-function Base.convert(::Type{BlockedOneTo{CS}}, axis::AbstractUnitRange{Int}) where CS
+function Base.convert(::Type{BlockedOneTo{T, CS}}, axis::AbstractUnitRange{<:Integer}) where {T, CS}
     first(axis) == 1 || throw(ArgumentError("first element of range is not 1"))
     BlockedOneTo(convert(CS, blocklasts(axis)))
 end
@@ -475,7 +476,7 @@ Return the first index of each block of `a`.
 # Examples
 ```jldoctest
 julia> b = blockedrange([1,2,3])
-3-blocked 6-element BlockedOneTo{Vector{Int64}}:
+3-blocked 6-element BlockedOneTo{Int64, Vector{Int64}}:
  1
  ─
  2
@@ -501,7 +502,7 @@ Return the last index of each block of `a`.
 # Examples
 ```jldoctest
 julia> b = blockedrange([1,2,3])
-3-blocked 6-element BlockedOneTo{Vector{Int64}}:
+3-blocked 6-element BlockedOneTo{Int64, Vector{Int64}}:
  1
  ─
  2
@@ -527,7 +528,7 @@ Return the length of each block of `a`.
 # Examples
 ```jldoctest
 julia> b = blockedrange([1,2,3])
-3-blocked 6-element BlockedOneTo{Vector{Int64}}:
+3-blocked 6-element BlockedOneTo{Int64, Vector{Int64}}:
  1
  ─
  2

--- a/src/blockproduct.jl
+++ b/src/blockproduct.jl
@@ -151,7 +151,7 @@ julia> A = reshape(1:9, 3, 3)
  3  6  9
 
 julia> BlockArrays.blockvec(A)
-3-blocked 9-element PseudoBlockVector{Int64, UnitRange{Int64}, Tuple{BlockedOneTo{StepRangeLen{Int64, Int64, Int64, Int64}}}}:
+3-blocked 9-element PseudoBlockVector{Int64, UnitRange{Int64}, Tuple{BlockedOneTo{Int64, StepRangeLen{Int64, Int64, Int64, Int64}}}}:
  1
  2
  3

--- a/test/test_blockarrayinterface.jl
+++ b/test/test_blockarrayinterface.jl
@@ -150,9 +150,9 @@ end
 
 @testset "non-standard block axes" begin
     A = BlockArray([1 2; 3 4], Fill(1, 2), Fill(1, 2))
-    @test A isa BlockMatrix{Int,Matrix{Matrix{Int}},<:NTuple{2,BlockedOneTo{<:AbstractRange}}}
+    @test A isa BlockMatrix{Int,Matrix{Matrix{Int}},<:NTuple{2,BlockedOneTo{Int,<:AbstractRange}}}
     A = BlockArray([1 2; 3 4], Fill(1, 2), [1, 1])
-    @test A isa BlockMatrix{Int,Matrix{Matrix{Int}},<:Tuple{BlockedOneTo{<:AbstractRange},BlockedOneTo{Vector{Int}}}}
+    @test A isa BlockMatrix{Int,Matrix{Matrix{Int}},<:Tuple{BlockedOneTo{Int,<:AbstractRange},BlockedOneTo{Int,Vector{Int}}}}
 end
 
 @testset "block Fill" begin

--- a/test/test_blockindices.jl
+++ b/test/test_blockindices.jl
@@ -411,6 +411,11 @@ end
 end
 
 @testset "BlockedOneTo" begin
+    @testset "constructor" begin
+        @test blockedrange((2,3)) isa BlockedOneTo{Int, NTuple{2,Int}}
+        @test blockedrange([2,3]) == blockedrange((2,3)) == 1:5
+    end
+
     @testset "promote" begin
         b = blockedrange([1,2,3])
         @test promote(b, 1:2) == (1:6, 1:2)

--- a/test/test_blockindices.jl
+++ b/test/test_blockindices.jl
@@ -339,7 +339,8 @@ end
         @test findblock(b,1) == Block(1)
         @test_throws BoundsError findblock(b,0)
         @test_throws BoundsError findblock(b,6)
-        @test sprint(show, "text/plain", blockedrange(1, [1,2,2])) == "3-blocked 5-element BlockedUnitRange{$Int, Vector{$Int}}:\n 1\n ─\n 2\n 3\n ─\n 4\n 5"
+        r = blockedrange(1, [1,2,2])
+        @test sprint(show, "text/plain", r) == "$(summary(r)):\n 1\n ─\n 2\n 3\n ─\n 4\n 5"
     end
 
     @testset "BlockIndex type piracy (#108)" begin
@@ -511,8 +512,8 @@ end
         end
         test_type_and_blockequal(BlockedOneTo, Base.OneTo(5), blockedrange([5]))
         test_type_and_blockequal(BlockedOneTo, Base.Slice(Base.OneTo(5)), blockedrange([5]))
-        test_type_and_blockequal(BlockedOneTo{Vector{Int}}, b, b)
-        test_type_and_blockequal(BlockedOneTo{Vector{Int}}, Base.OneTo(5), blockedrange([5]))
+        test_type_and_blockequal(BlockedOneTo{Int,Vector{Int}}, b, b)
+        test_type_and_blockequal(BlockedOneTo{Int,Vector{Int}}, Base.OneTo(5), blockedrange([5]))
         test_type_and_blockequal(BlockedOneTo, blockedrange(1, [1,1,1]), blockedrange([1,1,1]))
     end
 
@@ -588,7 +589,7 @@ end
         @test Base.dataids(b) == Base.dataids(blocklasts(b))
         @test_throws ArgumentError BlockedOneTo(b)
 
-        @test summary(b) == "3-blocked 6-element BlockedOneTo{Vector{$Int}}"
+        @test summary(b) == "3-blocked 6-element BlockedOneTo{$Int, Vector{$Int}}"
     end
 
     @testset "OneTo interface" begin
@@ -606,7 +607,8 @@ end
         @test findblock(b,1) == Block(1)
         @test_throws BoundsError findblock(b,0)
         @test_throws BoundsError findblock(b,6)
-        @test sprint(show, "text/plain", blockedrange([1,2,2])) == "3-blocked 5-element BlockedOneTo{Vector{$Int}}:\n 1\n ─\n 2\n 3\n ─\n 4\n 5"
+        r = blockedrange([1,2,2])
+        @test sprint(show, "text/plain", r) == "$(summary(r)):\n 1\n ─\n 2\n 3\n ─\n 4\n 5"
     end
 
     @testset "checkindex" begin
@@ -789,6 +791,12 @@ end
     @testset "show" begin
         b = blockedrange([1,2])
         @test repr(b) == "$BlockedOneTo($([1,3]))"
+    end
+
+    @testset "non-Int eltypes" begin
+        @test blockedrange(UInt32[1,2]) isa BlockedOneTo{UInt32, Vector{UInt32}}
+        @test blockedrange(UInt32[1,2]) == blockedrange([1,2])
+        @test_throws ArgumentError BlockedOneTo([true])
     end
 end
 


### PR DESCRIPTION
After this,
```julia
julia> blockedrange(UInt[1,2])
2-blocked 3-element BlockedOneTo{UInt64, Vector{UInt64}}:
 0x0000000000000001
 ──────────────────
 0x0000000000000002
 0x0000000000000003
```