### PR TITLE
Rename PseudoBlockArray to BlockedArray

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 A block array is a partition of an array into blocks or subarrays, see [wikipedia](https://en.wikipedia.org/wiki/Block_matrix) for a more extensive description. This package has two purposes. Firstly, it defines an interface for an `AbstractBlockArray` block arrays that can be shared among types representing different types of block arrays. The advantage to this is that it provides a consistent API for block arrays.
 
-Secondly, it also implements two different type of block arrays that follow the `AbstractBlockArray` interface. The type `BlockArray` stores each block contiguously while the type `PseudoBlockArray` stores the full matrix contiguously. This means that `BlockArray` supports fast non copying extraction and insertion of blocks while `PseudoBlockArray` supports fast access to the full matrix to use in in for example a linear solver.
+Secondly, it also implements two different type of block arrays that follow the `AbstractBlockArray` interface. The type `BlockArray` stores each block contiguously while the type `BlockedArray` stores the full matrix contiguously. This means that `BlockArray` supports fast non copying extraction and insertion of blocks while `BlockedArray` supports fast access to the full matrix to use in in for example a linear solver.
 
 A simple way to produce `BlockArray`s is via `mortar`, which combines an array of arrays into a `BlockArray`:
 ```julia

--- a/benchmark/runbenchmarks.jl
+++ b/benchmark/runbenchmarks.jl
@@ -12,7 +12,7 @@ g = addgroup!(SUITE, "indexing")
 g_size = addgroup!(SUITE, "size")
 
 for n = (5,)
-    for BT in (BlockArray, PseudoBlockArray)
+    for BT in (BlockArray, BlockedArray)
         block_vec = BT(rand(n),       [1,3,1])
         block_mat = BT(rand(n,n),     [1,3,1], [4,1])
         block_arr = BT(rand(n,n,n),   [1,3,1], [4,1], [3, 2])

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -6,7 +6,7 @@
 
 A block array is a partition of an array into multiple blocks or subarrays, see [wikipedia](https://en.wikipedia.org/wiki/Block_matrix) for a more extensive description. This package has two purposes. Firstly, it defines an interface for an `AbstractBlockArray` block arrays that can be shared among types representing different types of block arrays. The advantage to this is that it provides a consistent API for block arrays.
 
-Secondly, it also implements two concrete types of block arrays that follow the `AbstractBlockArray` interface.  The type `BlockArray` stores each single block contiguously, by wrapping an `AbstractArray{<:AbstractArray{T,N},N}` to concatenate all blocks – the complete array is thus not stored contiguously.  Conversely, a `PseudoBlockArray` stores the full matrix contiguously (by wrapping only one `AbstractArray{T, N}`) and only superimposes a block structure.  This means that `BlockArray` supports fast non copying extraction and insertion of blocks, while `PseudoBlockArray` supports fast access to the full matrix to use in, for example, a linear solver.
+Secondly, it also implements two concrete types of block arrays that follow the `AbstractBlockArray` interface.  The type `BlockArray` stores each single block contiguously, by wrapping an `AbstractArray{<:AbstractArray{T,N},N}` to concatenate all blocks – the complete array is thus not stored contiguously.  Conversely, a `BlockedArray` stores the full matrix contiguously (by wrapping only one `AbstractArray{T, N}`) and only superimposes a block structure.  This means that `BlockArray` supports fast non copying extraction and insertion of blocks, while `BlockedArray` supports fast access to the full matrix to use in, for example, a linear solver.
 
 
 ## Terminology

--- a/docs/src/lib/public.md
+++ b/docs/src/lib/public.md
@@ -65,12 +65,12 @@ Base.popfirst!
 ```
 
 
-## PseudoBlockArray
+## BlockedArray
 
 ```@docs
-PseudoBlockArray
-PseudoBlockVector
-PseudoBlockMatrix
+BlockedArray
+BlockedVector
+BlockedMatrix
 Base.resize!
 ```
 

--- a/docs/src/man/pseudoblockarrays.md
+++ b/docs/src/man/pseudoblockarrays.md
@@ -1,4 +1,4 @@
-# PseudoBlockArrays
+# BlockedArrays
 
 ```@meta
 DocTestSetup = quote
@@ -8,22 +8,22 @@ DocTestSetup = quote
 end
 ```
 
-A `PseudoBlockArray` is similar to a [`BlockArray`](@ref) except the full array is stored
+A `BlockedArray` is similar to a [`BlockArray`](@ref) except the full array is stored
 contiguously instead of block by block. This means that is not possible to insert and retrieve
-blocks without copying data. On the other hand, converting a `PseudoBlockArray` to the "full" underlying array is instead instant since
+blocks without copying data. On the other hand, converting a `BlockedArray` to the "full" underlying array is instead instant since
 it can just return the wrapped array.
 
 When iteratively solving a set of equations with a gradient method the Jacobian typically has a block structure. It can be convenient
-to use a `PseudoBlockArray` to build up the Jacobian block by block and then pass the resulting matrix to
+to use a `BlockedArray` to build up the Jacobian block by block and then pass the resulting matrix to
 a direct solver using `Matrix`.
 
-## Creating PseudoBlockArrays
+## Creating BlockedArrays
 
-Creating a `PseudoBlockArray` works in the same way as a `BlockArray`.
+Creating a `BlockedArray` works in the same way as a `BlockArray`.
 
 ```jldoctest A
-julia> pseudo = PseudoBlockArray(reshape([1:9;], 3, 3), [1,2], [2,1])
-2×2-blocked 3×3 PseudoBlockMatrix{Int64}:
+julia> pseudo = BlockedArray(reshape([1:9;], 3, 3), [1,2], [2,1])
+2×2-blocked 3×3 BlockedMatrix{Int64}:
  1  4  │  7
  ──────┼───
  2  5  │  8
@@ -38,8 +38,8 @@ This "takes ownership" of the passed in array so no copy of the array is made.
 A block array can be created with uninitialized entries using the `BlockArray{T}(undef, block_sizes...)`
 function. The block_sizes are each an `AbstractVector{Int}` which determines the size of the blocks in that dimension. We here create a `[1,2]×[3,2]` block matrix of `Float32`s:
 ```julia
-julia> PseudoBlockArray{Float32}(undef, [1,2], [3,2])
-2×2-blocked 3×5 PseudoBlockMatrix{Float32}:
+julia> BlockedArray{Float32}(undef, [1,2], [3,2])
+2×2-blocked 3×5 BlockedMatrix{Float32}:
  1.02295e-43  0.0          1.09301e-43  │  0.0          1.17709e-43
  ───────────────────────────────────────┼──────────────────────────
  0.0          1.06499e-43  0.0          │  1.14906e-43  0.0
@@ -79,9 +79,9 @@ The underlying array is accessed with `Array` just like for `BlockArray`.
 
 ## Views of blocks
 
-We can also view and modify views of blocks of `PseudoBlockArray` using the `view` syntax:
+We can also view and modify views of blocks of `BlockedArray` using the `view` syntax:
 ```jldoctest
-julia> A = PseudoBlockArray(ones(6), 1:3);
+julia> A = BlockedArray(ones(6), 1:3);
 
 julia> view(A, Block(2))
 2-element view(::Vector{Float64}, 2:3) with eltype Float64:

--- a/ext/BlockArraysBandedMatricesExt.jl
+++ b/ext/BlockArraysBandedMatricesExt.jl
@@ -7,8 +7,8 @@ import BlockArrays: blockcolsupport, blockrowsupport, AbstractBlockedUnitRange
 import ArrayLayouts: sub_materialize
 
 
-bandeddata(P::PseudoBlockMatrix) = bandeddata(P.blocks)
-bandwidths(P::PseudoBlockMatrix) = bandwidths(P.blocks)
+bandeddata(P::BlockedMatrix) = bandeddata(P.blocks)
+bandwidths(P::BlockedMatrix) = bandwidths(P.blocks)
 
 function blockcolsupport(::AbstractBandedLayout, B, j)
     m,n = axes(B)

--- a/src/BlockArrays.jl
+++ b/src/BlockArrays.jl
@@ -9,7 +9,7 @@ export blocksizes, blocklengths, blocklasts, blockfirsts, blockisequal
 export BlockRange, blockedrange, BlockedUnitRange, BlockedOneTo
 
 export BlockArray, BlockMatrix, BlockVector, BlockVecOrMat, mortar
-export PseudoBlockArray, PseudoBlockMatrix, PseudoBlockVector, PseudoBlockVecOrMat
+export BlockedArray, BlockedMatrix, BlockedVector, BlockedVecOrMat
 
 export undef_blocks, undef, findblock, findblockindex
 

--- a/src/blockarray.jl
+++ b/src/blockarray.jl
@@ -546,16 +546,16 @@ end
 
 # Temporary work around
 Base.reshape(block_array::BlockArray, axes::NTuple{N,AbstractUnitRange{Int}}) where N =
-    reshape(PseudoBlockArray(block_array), axes)
+    reshape(BlockedArray(block_array), axes)
 Base.reshape(block_array::BlockArray, dims::Tuple{Int,Vararg{Int}}) =
-    reshape(PseudoBlockArray(block_array), dims)
+    reshape(BlockedArray(block_array), dims)
 Base.reshape(block_array::BlockArray, axes::Tuple{Union{Integer,Base.OneTo}, Vararg{Union{Integer,Base.OneTo}}}) =
-    reshape(PseudoBlockArray(block_array), axes)
+    reshape(BlockedArray(block_array), axes)
 Base.reshape(block_array::BlockArray, dims::Tuple{Vararg{Union{Int,Colon}}}) =
-    reshape(PseudoBlockArray(block_array), dims)
+    reshape(BlockedArray(block_array), dims)
 
 """
-    resize!(a::BlockVector, N::Block) -> PseudoBlockVector
+    resize!(a::BlockVector, N::Block) -> BlockedVector
 
 Resize `a` to contain the first `N` blocks, returning a new `BlockVector` sharing
 memory with `a`. If `N` is smaller than the current

--- a/src/blockdeque.jl
+++ b/src/blockdeque.jl
@@ -39,7 +39,7 @@ end
 
 function blockappend!(
     dest::BlockVector{<:Any,<:AbstractArray{T}},
-    src::PseudoBlockVector{<:Any,T},
+    src::BlockedVector{<:Any,T},
 ) where {T}
     if blocklength(src) == 1
         return _blockpush!(dest, src.blocks)

--- a/src/blockindices.jl
+++ b/src/blockindices.jl
@@ -125,8 +125,8 @@ It can be used to index into `BlockArrays` in the following manner:
 ```jldoctest
 julia> arr = Array(reshape(1:25, (5,5)));
 
-julia> a = PseudoBlockArray(arr, [3,2], [1,4])
-2×2-blocked 5×5 PseudoBlockMatrix{Int64}:
+julia> a = BlockedArray(arr, [3,2], [1,4])
+2×2-blocked 5×5 BlockedMatrix{Int64}:
  1  │   6  11  16  21
  2  │   7  12  17  22
  3  │   8  13  18  23

--- a/src/blocklinalg.jl
+++ b/src/blocklinalg.jl
@@ -78,7 +78,7 @@ end
 similar(M::MulAdd{<:AbstractBlockLayout,<:AbstractBlockLayout}, ::Type{T}, axes) where {T} =
     similar(BlockArray{T}, axes)
 
-@inline MemoryLayout(::Type{<:PseudoBlockArray{T,N,R}}) where {T,N,R} = MemoryLayout(R)
+@inline MemoryLayout(::Type{<:BlockedArray{T,N,R}}) where {T,N,R} = MemoryLayout(R)
 @inline MemoryLayout(::Type{<:BlockArray{T,N,R}}) where {T,N,D,R<:AbstractArray{D,N}} =
     BlockLayout{typeof(MemoryLayout(R)),typeof(MemoryLayout(D))}()
 
@@ -102,11 +102,11 @@ sublayout(BL::BlockLayout{MLAY,BLAY}, ::Type{<:NTuple{N,<:AbstractBlockedUnitRan
 # materialize views, used for `getindex`
 sub_materialize(::AbstractBlockLayout, V, _) = BlockArray(V)
 
-# if it's not a block layout, best to use PseudoBlockArray to take advantage of strideness
-sub_materialize_axes(V, ::Tuple{AbstractBlockedUnitRange}) = PseudoBlockArray(V)
-sub_materialize_axes(V, ::Tuple{AbstractBlockedUnitRange,AbstractBlockedUnitRange}) = PseudoBlockArray(V)
-sub_materialize_axes(V, ::Tuple{AbstractUnitRange,AbstractBlockedUnitRange}) = PseudoBlockArray(V)
-sub_materialize_axes(V, ::Tuple{AbstractBlockedUnitRange,AbstractUnitRange}) = PseudoBlockArray(V)
+# if it's not a block layout, best to use BlockedArray to take advantage of strideness
+sub_materialize_axes(V, ::Tuple{AbstractBlockedUnitRange}) = BlockedArray(V)
+sub_materialize_axes(V, ::Tuple{AbstractBlockedUnitRange,AbstractBlockedUnitRange}) = BlockedArray(V)
+sub_materialize_axes(V, ::Tuple{AbstractUnitRange,AbstractBlockedUnitRange}) = BlockedArray(V)
+sub_materialize_axes(V, ::Tuple{AbstractBlockedUnitRange,AbstractUnitRange}) = BlockedArray(V)
 
 # Special for FillArrays.jl
 
@@ -130,7 +130,7 @@ transposelayout(::BlockLayout{MLAY,BLAY}) where {MLAY,BLAY} =
 function _copyto!(_, ::AbstractBlockLayout, dest::AbstractVector, src::AbstractVector)
     if !blockisequal(axes(dest), axes(src))
         # impose block structure
-        copyto!(PseudoBlockArray(dest, axes(src)), src)
+        copyto!(BlockedArray(dest, axes(src)), src)
         return dest
     end
 
@@ -143,7 +143,7 @@ end
 function _copyto!(_, ::AbstractBlockLayout, dest::AbstractMatrix, src::AbstractMatrix)
     if !blockisequal(axes(dest), axes(src))
         # impose block structure
-        copyto!(PseudoBlockArray(dest, axes(src)), src)
+        copyto!(BlockedArray(dest, axes(src)), src)
         return dest
     end
 
@@ -214,8 +214,8 @@ function materialize!(M::MatMulVecAdd{<:AbstractBlockLayout,<:AbstractStridedLay
     end
 
     # impose block structure
-    y = PseudoBlockArray(y_in, (axes(A,1),))
-    x = PseudoBlockArray(x_in, (axes(A,2),))
+    y = BlockedArray(y_in, (axes(A,1),))
+    x = BlockedArray(x_in, (axes(A,2),))
     _block_muladd!(α, A, x, β, y)
     y_in
 end
@@ -243,23 +243,23 @@ end
 
 function materialize!(M::MatMulMatAdd{<:AbstractBlockLayout,<:AbstractBlockLayout,<:AbstractColumnMajor})
     α, A, X, β, Y_in = M.α, M.A, M.B, M.β, M.C
-    Y = PseudoBlockArray(Y_in, (axes(A,1), axes(X,2)))
+    Y = BlockedArray(Y_in, (axes(A,1), axes(X,2)))
     _block_muladd!(α, A, X, β, Y)
     Y_in
 end
 
 function materialize!(M::MatMulMatAdd{<:AbstractBlockLayout,<:AbstractColumnMajor,<:AbstractColumnMajor})
     α, A, X_in, β, Y_in = M.α, M.A, M.B, M.β, M.C
-    X = PseudoBlockArray(X_in, (axes(A,2), axes(X_in,2)))
-    Y = PseudoBlockArray(Y_in, (axes(A,1), axes(X_in,2)))
+    X = BlockedArray(X_in, (axes(A,2), axes(X_in,2)))
+    Y = BlockedArray(Y_in, (axes(A,1), axes(X_in,2)))
     _block_muladd!(α, A, X, β, Y)
     Y_in
 end
 
 function materialize!(M::MatMulMatAdd{<:AbstractColumnMajor,<:AbstractBlockLayout,<:AbstractColumnMajor})
     α, A_in, X, β, Y_in = M.α, M.A, M.B, M.β, M.C
-    A = PseudoBlockArray(A_in, (axes(A_in,1),axes(X,1)))
-    Y = PseudoBlockArray(Y_in, (axes(A,1),axes(X,2)))
+    A = BlockedArray(A_in, (axes(A_in,1),axes(X,1)))
+    Y = BlockedArray(Y_in, (axes(A,1),axes(X,2)))
     _block_muladd!(α, A, X, β, Y)
     Y_in
 end
@@ -282,7 +282,7 @@ _triangular_matrix(::Val{'L'}, ::Val{'U'}, A) = UnitLowerTriangular(A)
 
 function _matchingblocks_triangular_mul!(::Val{'U'}, UNIT, A::AbstractMatrix{T}, dest) where T
     # impose block structure
-    b = PseudoBlockArray(dest, (axes(A,1),))
+    b = BlockedArray(dest, (axes(A,1),))
     for K = blockaxes(A,1)
         b_2 = view(b, K)
         Ũ = _triangular_matrix(Val('U'), UNIT, view(A, K,K))
@@ -297,7 +297,7 @@ end
 
 function _matchingblocks_triangular_mul!(::Val{'L'}, UNIT, A::AbstractMatrix{T}, dest) where T
     # impose block structure
-    b = PseudoBlockArray(dest, (axes(A,1),))
+    b = BlockedArray(dest, (axes(A,1),))
 
     N = blocksize(A,1)
 
@@ -322,8 +322,8 @@ end
     if hasmatchingblocks(U)
         _matchingblocks_triangular_mul!(Val(UPLO), Val(UNIT), triangulardata(U), x)
     else # use default
-        x_1 = PseudoBlockArray(copy(x), (axes(U,2),))
-        x_2 = PseudoBlockArray(x, (axes(U,1),))
+        x_1 = BlockedArray(copy(x), (axes(U,2),))
+        x_2 = BlockedArray(x, (axes(U,1),))
         _block_muladd!(one(T), U, x_1, zero(T), x_2)
     end
 end
@@ -345,7 +345,7 @@ for UNIT in ('U', 'N')
             @boundscheck size(A,1) == size(dest,1) || throw(BoundsError())
 
             # impose block structure
-            b = PseudoBlockArray(dest, (axes(A,1),))
+            b = BlockedArray(dest, (axes(A,1),))
 
             N = blocksize(A,1)
 
@@ -379,7 +379,7 @@ for UNIT in ('U', 'N')
             @boundscheck size(A,1) == size(dest,1) || throw(BoundsError())
 
             # impose block structure
-            b = PseudoBlockArray(dest, (axes(A,1),))
+            b = BlockedArray(dest, (axes(A,1),))
 
             N = blocksize(A,1)
 
@@ -401,11 +401,11 @@ for UNIT in ('U', 'N')
     end
 end
 
-# For now, use PseudoBlockArray
-_inv(::AbstractBlockLayout, axes, A) = BlockArray(inv(PseudoBlockArray(A)))
+# For now, use BlockedArray
+_inv(::AbstractBlockLayout, axes, A) = BlockArray(inv(BlockedArray(A)))
 
 for op in (:exp, :log, :sqrt)
     @eval begin
-       $op(A::PseudoBlockMatrix) = PseudoBlockMatrix($op(A.blocks), axes(A))
+       $op(A::BlockedMatrix) = BlockedMatrix($op(A.blocks), axes(A))
     end
 end

--- a/src/blockproduct.jl
+++ b/src/blockproduct.jl
@@ -151,7 +151,7 @@ julia> A = reshape(1:9, 3, 3)
  3  6  9
 
 julia> BlockArrays.blockvec(A)
-3-blocked 9-element PseudoBlockVector{Int64, UnitRange{Int64}, Tuple{BlockedOneTo{Int64, StepRangeLen{Int64, Int64, Int64, Int64}}}}:
+3-blocked 9-element BlockedVector{Int64, UnitRange{Int64}, Tuple{BlockedOneTo{Int64, StepRangeLen{Int64, Int64, Int64, Int64}}}}:
  1
  2
  3
@@ -165,4 +165,4 @@ julia> BlockArrays.blockvec(A)
  9
 ```
 """
-blockvec(A::AbstractMatrix) = PseudoBlockVector(vec(A), Fill(size(A,1), size(A,2)))
+blockvec(A::AbstractMatrix) = BlockedVector(vec(A), Fill(size(A,1), size(A,2)))

--- a/src/blockreduce.jl
+++ b/src/blockreduce.jl
@@ -11,10 +11,10 @@ Base.mapreduce(f::F, op::OP, B::BlockVector; kw...) where {F, OP} =
         mapreduce(f, op, block; kw...)
     end
 
-Base.mapfoldl(f::F, op::OP, B::PseudoBlockArray; kw...) where {F, OP} =
+Base.mapfoldl(f::F, op::OP, B::BlockedArray; kw...) where {F, OP} =
     mapfoldl(f, op, B.blocks; kw...)
 
-Base.mapreduce(f::F, op::OP, B::PseudoBlockArray; kw...) where {F, OP} =
+Base.mapreduce(f::F, op::OP, B::BlockedArray; kw...) where {F, OP} =
     mapreduce(f, op, B.blocks; kw...)
 
 # support sum, need to return something analogous to Base.OneTo(1) but same type

--- a/src/pseudo_blockarray.jl
+++ b/src/pseudo_blockarray.jl
@@ -2,27 +2,27 @@
 # When Vararg is fast enough, they can simply be removed
 
 ####################
-# PseudoBlockArray #
+# BlockedArray #
 ####################
 
 """
-    PseudoBlockArray{T, N, R} <: AbstractBlockArray{T, N}
+    BlockedArray{T, N, R} <: AbstractBlockArray{T, N}
 
-A `PseudoBlockArray` is similar to a [`BlockArray`](@ref) except the full array is stored
+A `BlockedArray` is similar to a [`BlockArray`](@ref) except the full array is stored
 contiguously instead of block by block. This means that is not possible to insert and retrieve
-blocks without copying data. On the other hand `parent` on a `PseudoBlockArray` is instead instant since
+blocks without copying data. On the other hand `parent` on a `BlockedArray` is instead instant since
 it just returns the wrapped array.
 
 When iteratively solving a set of equations with a gradient method the Jacobian typically has a block structure. It can be convenient
-to use a `PseudoBlockArray` to build up the Jacobian block by block and then pass the resulting matrix to
+to use a `BlockedArray` to build up the Jacobian block by block and then pass the resulting matrix to
 a direct solver using `parent`.
 
 # Examples
 ```jldoctest
 julia> A = zeros(Int, 2, 3);
 
-julia> B = PseudoBlockArray(A, [1,1], [2,1])
-2×2-blocked 2×3 PseudoBlockMatrix{Int64}:
+julia> B = BlockedArray(A, [1,1], [2,1])
+2×2-blocked 2×3 BlockedMatrix{Int64}:
  0  0  │  0
  ──────┼───
  0  0  │  0
@@ -40,19 +40,19 @@ julia> A
  0  0  0
 ```
 """
-struct PseudoBlockArray{T, N, R<:AbstractArray{T,N}, BS<:NTuple{N,AbstractUnitRange{Int}}} <: AbstractBlockArray{T, N}
+struct BlockedArray{T, N, R<:AbstractArray{T,N}, BS<:NTuple{N,AbstractUnitRange{Int}}} <: AbstractBlockArray{T, N}
     blocks::R
     axes::BS
-    function PseudoBlockArray{T,N,R,BS}(blocks::R, axes::BS) where {T,N,R,BS<:NTuple{N,AbstractUnitRange{Int}}}
+    function BlockedArray{T,N,R,BS}(blocks::R, axes::BS) where {T,N,R,BS<:NTuple{N,AbstractUnitRange{Int}}}
         checkbounds(blocks,axes...)
         return new{T,N,R,BS}(blocks, axes)
     end
 end
 
 """
-    PseudoBlockMatrix{T}
+    BlockedMatrix{T}
 
-Alias for `PseudoBlockArray{T, 2}`
+Alias for `BlockedArray{T, 2}`
 
 ```jldoctest
 julia> A = reshape([1:6;], 2, 3)
@@ -60,18 +60,18 @@ julia> A = reshape([1:6;], 2, 3)
  1  3  5
  2  4  6
 
-julia> PseudoBlockMatrix(A, [1,1], [1,2])
-2×2-blocked 2×3 PseudoBlockMatrix{Int64}:
+julia> BlockedMatrix(A, [1,1], [1,2])
+2×2-blocked 2×3 BlockedMatrix{Int64}:
  1  │  3  5
  ───┼──────
  2  │  4  6
 ```
 """
-const PseudoBlockMatrix{T} = PseudoBlockArray{T, 2}
+const BlockedMatrix{T} = BlockedArray{T, 2}
 """
-    PseudoBlockVector{T}
+    BlockedVector{T}
 
-Alias for `PseudoBlockArray{T, 1}`
+Alias for `BlockedArray{T, 1}`
 
 ```jldoctest
 julia> A = [1:6;]
@@ -83,8 +83,8 @@ julia> A = [1:6;]
  5
  6
 
-julia> PseudoBlockVector(A, [3,2,1])
-3-blocked 6-element PseudoBlockVector{Int64}:
+julia> BlockedVector(A, [3,2,1])
+3-blocked 6-element BlockedVector{Int64}:
  1
  2
  3
@@ -95,139 +95,139 @@ julia> PseudoBlockVector(A, [3,2,1])
  6
 ```
 """
-const PseudoBlockVector{T} = PseudoBlockArray{T, 1}
-const PseudoBlockVecOrMat{T} = Union{PseudoBlockMatrix{T}, PseudoBlockVector{T}}
+const BlockedVector{T} = BlockedArray{T, 1}
+const BlockedVecOrMat{T} = Union{BlockedMatrix{T}, BlockedVector{T}}
 
 # Auxiliary outer constructors
-@inline PseudoBlockArray(blocks::R, baxes::BS) where {T,N,R<:AbstractArray{T,N},BS<:NTuple{N,AbstractUnitRange{Int}}} =
-    PseudoBlockArray{T, N, R,BS}(blocks, baxes)
+@inline BlockedArray(blocks::R, baxes::BS) where {T,N,R<:AbstractArray{T,N},BS<:NTuple{N,AbstractUnitRange{Int}}} =
+    BlockedArray{T, N, R,BS}(blocks, baxes)
 
-@inline PseudoBlockArray{T}(blocks::R, baxes::BS) where {T,N,R<:AbstractArray{T,N},BS<:NTuple{N,AbstractUnitRange{Int}}} =
-    PseudoBlockArray{T, N, R,BS}(blocks, baxes)
+@inline BlockedArray{T}(blocks::R, baxes::BS) where {T,N,R<:AbstractArray{T,N},BS<:NTuple{N,AbstractUnitRange{Int}}} =
+    BlockedArray{T, N, R,BS}(blocks, baxes)
 
-@inline PseudoBlockArray{T}(blocks::AbstractArray{<:Any,N}, baxes::NTuple{N,AbstractUnitRange{Int}}) where {T,N} =
-    PseudoBlockArray{T}(convert(AbstractArray{T,N}, blocks), baxes)
+@inline BlockedArray{T}(blocks::AbstractArray{<:Any,N}, baxes::NTuple{N,AbstractUnitRange{Int}}) where {T,N} =
+    BlockedArray{T}(convert(AbstractArray{T,N}, blocks), baxes)
 
-@inline PseudoBlockArray(blocks::PseudoBlockArray, baxes::BS) where {N,BS<:NTuple{N,AbstractUnitRange{Int}}} =
-    PseudoBlockArray(blocks.blocks, baxes)
+@inline BlockedArray(blocks::BlockedArray, baxes::BS) where {N,BS<:NTuple{N,AbstractUnitRange{Int}}} =
+    BlockedArray(blocks.blocks, baxes)
 
-@inline PseudoBlockArray{T}(blocks::PseudoBlockArray, baxes::BS) where {T,N,BS<:NTuple{N,AbstractUnitRange{Int}}} =
-    PseudoBlockArray{T}(blocks.blocks, baxes)
+@inline BlockedArray{T}(blocks::BlockedArray, baxes::BS) where {T,N,BS<:NTuple{N,AbstractUnitRange{Int}}} =
+    BlockedArray{T}(blocks.blocks, baxes)
 
-PseudoBlockArray(blocks::AbstractArray{T, N}, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N} =
-    PseudoBlockArray(blocks, map(blockedrange,block_sizes))
+BlockedArray(blocks::AbstractArray{T, N}, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N} =
+    BlockedArray(blocks, map(blockedrange,block_sizes))
 
-PseudoBlockArray{T}(blocks::AbstractArray{<:Any, N}, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N} =
-    PseudoBlockArray{T}(blocks, map(blockedrange,block_sizes))
+BlockedArray{T}(blocks::AbstractArray{<:Any, N}, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N} =
+    BlockedArray{T}(blocks, map(blockedrange,block_sizes))
 
-@inline PseudoBlockArray{T,N,R,BS}(::UndefInitializer, baxes::NTuple{N,AbstractUnitRange{Int}}) where {T,N,R,BS<:NTuple{N,AbstractUnitRange{Int}}} =
-    PseudoBlockArray{T,N,R,BS}(R(undef, length.(baxes)), convert(BS, baxes))
+@inline BlockedArray{T,N,R,BS}(::UndefInitializer, baxes::NTuple{N,AbstractUnitRange{Int}}) where {T,N,R,BS<:NTuple{N,AbstractUnitRange{Int}}} =
+    BlockedArray{T,N,R,BS}(R(undef, length.(baxes)), convert(BS, baxes))
 
-@inline PseudoBlockArray{T}(::UndefInitializer, baxes::NTuple{N,AbstractUnitRange{Int}}) where {T, N} =
-    PseudoBlockArray(similar(Array{T, N}, length.(baxes)), baxes)
+@inline BlockedArray{T}(::UndefInitializer, baxes::NTuple{N,AbstractUnitRange{Int}}) where {T, N} =
+    BlockedArray(similar(Array{T, N}, length.(baxes)), baxes)
 
-@inline PseudoBlockArray{T, N}(::UndefInitializer, baxes::NTuple{N,AbstractUnitRange{Int}}) where {T, N} =
-    PseudoBlockArray{T}(undef, baxes)
+@inline BlockedArray{T, N}(::UndefInitializer, baxes::NTuple{N,AbstractUnitRange{Int}}) where {T, N} =
+    BlockedArray{T}(undef, baxes)
 
-@inline PseudoBlockArray{T, N, R}(::UndefInitializer, baxes::NTuple{N,AbstractUnitRange{Int}}) where {T, N, R <: AbstractArray{T, N}} =
-    PseudoBlockArray(similar(R, length.(baxes)), baxes)
+@inline BlockedArray{T, N, R}(::UndefInitializer, baxes::NTuple{N,AbstractUnitRange{Int}}) where {T, N, R <: AbstractArray{T, N}} =
+    BlockedArray(similar(R, length.(baxes)), baxes)
 
-@inline PseudoBlockArray{T}(::UndefInitializer, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N} =
-    PseudoBlockArray{T}(undef, map(blockedrange,block_sizes))
+@inline BlockedArray{T}(::UndefInitializer, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N} =
+    BlockedArray{T}(undef, map(blockedrange,block_sizes))
 
-@inline PseudoBlockArray{T, N}(::UndefInitializer, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N} =
-    PseudoBlockArray{T, N}(undef, map(blockedrange,block_sizes))
+@inline BlockedArray{T, N}(::UndefInitializer, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N} =
+    BlockedArray{T, N}(undef, map(blockedrange,block_sizes))
 
-@inline PseudoBlockArray{T, N, R}(::UndefInitializer, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R <: AbstractArray{T, N}} =
-    PseudoBlockArray{T, N, R}(undef, map(blockedrange,block_sizes))
+@inline BlockedArray{T, N, R}(::UndefInitializer, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R <: AbstractArray{T, N}} =
+    BlockedArray{T, N, R}(undef, map(blockedrange,block_sizes))
 
 
-PseudoBlockVector(blocks::AbstractVector, baxes::Tuple{AbstractUnitRange{Int}}) = PseudoBlockArray(blocks, baxes)
-PseudoBlockVector(blocks::AbstractVector, block_sizes::AbstractVector{Int}) = PseudoBlockArray(blocks, block_sizes)
-PseudoBlockMatrix(blocks::AbstractMatrix, baxes::NTuple{2,AbstractUnitRange{Int}}) = PseudoBlockArray(blocks, baxes)
-PseudoBlockMatrix(blocks::AbstractMatrix, block_sizes::Vararg{AbstractVector{Int},2}) = PseudoBlockArray(blocks, block_sizes...)
+BlockedVector(blocks::AbstractVector, baxes::Tuple{AbstractUnitRange{Int}}) = BlockedArray(blocks, baxes)
+BlockedVector(blocks::AbstractVector, block_sizes::AbstractVector{Int}) = BlockedArray(blocks, block_sizes)
+BlockedMatrix(blocks::AbstractMatrix, baxes::NTuple{2,AbstractUnitRange{Int}}) = BlockedArray(blocks, baxes)
+BlockedMatrix(blocks::AbstractMatrix, block_sizes::Vararg{AbstractVector{Int},2}) = BlockedArray(blocks, block_sizes...)
 
-PseudoBlockArray{T}(λ::UniformScaling, baxes::NTuple{2,AbstractUnitRange{Int}}) where T = PseudoBlockArray{T}(Matrix(λ, map(length,baxes)...), baxes)
-PseudoBlockArray{T}(λ::UniformScaling, block_sizes::Vararg{AbstractVector{Int}, 2}) where T = PseudoBlockArray{T}(λ, map(blockedrange,block_sizes))
-PseudoBlockArray(λ::UniformScaling{T}, block_sizes::Vararg{AbstractVector{Int}, 2}) where T = PseudoBlockArray{T}(λ, block_sizes...)
-PseudoBlockArray(λ::UniformScaling{T}, baxes::NTuple{2,AbstractUnitRange{Int}}) where T = PseudoBlockArray{T}(λ, baxes)
-PseudoBlockMatrix(λ::UniformScaling, baxes::NTuple{2,AbstractUnitRange{Int}}) = PseudoBlockArray(λ, baxes)
-PseudoBlockMatrix(λ::UniformScaling, block_sizes::Vararg{AbstractVector{Int},2}) = PseudoBlockArray(λ, block_sizes...)
-PseudoBlockMatrix{T}(λ::UniformScaling, baxes::NTuple{2,AbstractUnitRange{Int}}) where T = PseudoBlockArray{T}(λ, baxes)
-PseudoBlockMatrix{T}(λ::UniformScaling, block_sizes::Vararg{AbstractVector{Int},2}) where T = PseudoBlockArray{T}(λ, block_sizes...)
+BlockedArray{T}(λ::UniformScaling, baxes::NTuple{2,AbstractUnitRange{Int}}) where T = BlockedArray{T}(Matrix(λ, map(length,baxes)...), baxes)
+BlockedArray{T}(λ::UniformScaling, block_sizes::Vararg{AbstractVector{Int}, 2}) where T = BlockedArray{T}(λ, map(blockedrange,block_sizes))
+BlockedArray(λ::UniformScaling{T}, block_sizes::Vararg{AbstractVector{Int}, 2}) where T = BlockedArray{T}(λ, block_sizes...)
+BlockedArray(λ::UniformScaling{T}, baxes::NTuple{2,AbstractUnitRange{Int}}) where T = BlockedArray{T}(λ, baxes)
+BlockedMatrix(λ::UniformScaling, baxes::NTuple{2,AbstractUnitRange{Int}}) = BlockedArray(λ, baxes)
+BlockedMatrix(λ::UniformScaling, block_sizes::Vararg{AbstractVector{Int},2}) = BlockedArray(λ, block_sizes...)
+BlockedMatrix{T}(λ::UniformScaling, baxes::NTuple{2,AbstractUnitRange{Int}}) where T = BlockedArray{T}(λ, baxes)
+BlockedMatrix{T}(λ::UniformScaling, block_sizes::Vararg{AbstractVector{Int},2}) where T = BlockedArray{T}(λ, block_sizes...)
 
 
 # Convert AbstractArrays that conform to block array interface
-convert(::Type{PseudoBlockArray{T,N,R,BS}}, A::PseudoBlockArray{T,N,R,BS}) where {T,N,R,BS} = A
-convert(::Type{PseudoBlockArray{T,N,R}}, A::PseudoBlockArray{T,N,R}) where {T,N,R} = A
-convert(::Type{PseudoBlockArray{T,N}}, A::PseudoBlockArray{T,N}) where {T,N} = A
-convert(::Type{PseudoBlockArray{T}}, A::PseudoBlockArray{T}) where {T} = A
-convert(::Type{PseudoBlockArray}, A::PseudoBlockArray) = A
+convert(::Type{BlockedArray{T,N,R,BS}}, A::BlockedArray{T,N,R,BS}) where {T,N,R,BS} = A
+convert(::Type{BlockedArray{T,N,R}}, A::BlockedArray{T,N,R}) where {T,N,R} = A
+convert(::Type{BlockedArray{T,N}}, A::BlockedArray{T,N}) where {T,N} = A
+convert(::Type{BlockedArray{T}}, A::BlockedArray{T}) where {T} = A
+convert(::Type{BlockedArray}, A::BlockedArray) = A
 
-convert(::Type{PseudoBlockArray{T,N,R,BS}}, A::PseudoBlockArray) where {T,N,R,BS} =
-    PseudoBlockArray{T,N,R,BS}(convert(R, A.blocks), convert(BS, A.axes))
+convert(::Type{BlockedArray{T,N,R,BS}}, A::BlockedArray) where {T,N,R,BS} =
+    BlockedArray{T,N,R,BS}(convert(R, A.blocks), convert(BS, A.axes))
 
-convert(::Type{AbstractArray{T,N}}, A::PseudoBlockArray{T,N}) where {T,N} = A
-convert(::Type{AbstractArray{V,N} where V}, A::PseudoBlockArray{T,N}) where {T,N} = A
-convert(::Type{AbstractArray{T}}, A::PseudoBlockArray{T}) where {T} = A
-convert(::Type{AbstractArray}, A::PseudoBlockArray) = A
+convert(::Type{AbstractArray{T,N}}, A::BlockedArray{T,N}) where {T,N} = A
+convert(::Type{AbstractArray{V,N} where V}, A::BlockedArray{T,N}) where {T,N} = A
+convert(::Type{AbstractArray{T}}, A::BlockedArray{T}) where {T} = A
+convert(::Type{AbstractArray}, A::BlockedArray) = A
 
 
 
-PseudoBlockArray{T, N}(A::AbstractArray{T2, N}) where {T,T2,N} =
-    PseudoBlockArray(Array{T, N}(A), axes(A))
-PseudoBlockArray{T1}(A::AbstractArray{T2, N}) where {T1,T2,N} = PseudoBlockArray{T1, N}(A)
-PseudoBlockArray{<:Any,N}(A::AbstractArray{T, N}) where {T,N} = PseudoBlockArray{T, N}(A)
-PseudoBlockArray(A::AbstractArray{T, N}) where {T,N} = PseudoBlockArray{T, N}(A)
+BlockedArray{T, N}(A::AbstractArray{T2, N}) where {T,T2,N} =
+    BlockedArray(Array{T, N}(A), axes(A))
+BlockedArray{T1}(A::AbstractArray{T2, N}) where {T1,T2,N} = BlockedArray{T1, N}(A)
+BlockedArray{<:Any,N}(A::AbstractArray{T, N}) where {T,N} = BlockedArray{T, N}(A)
+BlockedArray(A::AbstractArray{T, N}) where {T,N} = BlockedArray{T, N}(A)
 
-convert(::Type{PseudoBlockArray{T, N}}, A::AbstractArray{T2, N}) where {T,T2,N} =
-    PseudoBlockArray(convert(Array{T, N}, A), axes(A))
-convert(::Type{PseudoBlockArray{T1}}, A::AbstractArray{T2, N}) where {T1,T2,N} =
-    convert(PseudoBlockArray{T1, N}, A)
-convert(::Type{PseudoBlockArray}, A::AbstractArray{T, N}) where {T,N} =
-    convert(PseudoBlockArray{T, N}, A)
+convert(::Type{BlockedArray{T, N}}, A::AbstractArray{T2, N}) where {T,T2,N} =
+    BlockedArray(convert(Array{T, N}, A), axes(A))
+convert(::Type{BlockedArray{T1}}, A::AbstractArray{T2, N}) where {T1,T2,N} =
+    convert(BlockedArray{T1, N}, A)
+convert(::Type{BlockedArray}, A::AbstractArray{T, N}) where {T,N} =
+    convert(BlockedArray{T, N}, A)
 
-AbstractArray{T}(A::PseudoBlockArray) where T = PseudoBlockArray(AbstractArray{T}(A.blocks), A.axes)
-AbstractArray{T,N}(A::PseudoBlockArray) where {T,N} = PseudoBlockArray(AbstractArray{T,N}(A.blocks), A.axes)
+AbstractArray{T}(A::BlockedArray) where T = BlockedArray(AbstractArray{T}(A.blocks), A.axes)
+AbstractArray{T,N}(A::BlockedArray) where {T,N} = BlockedArray(AbstractArray{T,N}(A.blocks), A.axes)
 
-copy(A::PseudoBlockArray) = PseudoBlockArray(copy(A.blocks), A.axes)
+copy(A::BlockedArray) = BlockedArray(copy(A.blocks), A.axes)
 
-Base.dataids(A::PseudoBlockArray) = Base.dataids(A.blocks)
+Base.dataids(A::BlockedArray) = Base.dataids(A.blocks)
 
 ###########################
 # AbstractArray Interface #
 ###########################
 
-function Base.similar(block_array::PseudoBlockArray{T,N}, ::Type{T2}) where {T,N,T2}
-    PseudoBlockArray(similar(block_array.blocks, T2), axes(block_array))
+function Base.similar(block_array::BlockedArray{T,N}, ::Type{T2}) where {T,N,T2}
+    BlockedArray(similar(block_array.blocks, T2), axes(block_array))
 end
 
 to_axes(r::AbstractUnitRange) = r
 to_axes(n::Integer) = Base.oneto(n)
 
 @inline Base.similar(block_array::Type{<:StridedArray{T}}, axes::Tuple{AbstractBlockedUnitRange,Vararg{Union{Integer,AbstractUnitRange{Int}}}}) where T =
-    PseudoBlockArray{T}(undef, map(to_axes,axes))
+    BlockedArray{T}(undef, map(to_axes,axes))
 @inline Base.similar(block_array::Type{<:StridedArray{T}}, axes::Tuple{AbstractBlockedUnitRange,AbstractBlockedUnitRange,Vararg{Union{Integer,AbstractUnitRange{Int}}}}) where T =
-    PseudoBlockArray{T}(undef, map(to_axes,axes))
+    BlockedArray{T}(undef, map(to_axes,axes))
 @inline Base.similar(block_array::Type{<:StridedArray{T}}, axes::Tuple{Union{Integer,AbstractUnitRange{Int}},AbstractBlockedUnitRange,Vararg{Union{Integer,AbstractUnitRange{Int}}}}) where T =
-    PseudoBlockArray{T}(undef, map(to_axes,axes))
+    BlockedArray{T}(undef, map(to_axes,axes))
 
 @inline Base.similar(block_array::StridedArray, ::Type{T}, axes::Tuple{AbstractBlockedUnitRange,Vararg{Union{Integer,AbstractUnitRange{Int}}}}) where T =
-    PseudoBlockArray{T}(undef, map(to_axes,axes))
+    BlockedArray{T}(undef, map(to_axes,axes))
 @inline Base.similar(block_array::StridedArray, ::Type{T}, axes::Tuple{AbstractBlockedUnitRange,AbstractBlockedUnitRange,Vararg{Union{Integer,AbstractUnitRange{Int}}}}) where T =
-    PseudoBlockArray{T}(undef, map(to_axes,axes))
+    BlockedArray{T}(undef, map(to_axes,axes))
 @inline Base.similar(block_array::StridedArray, ::Type{T}, axes::Tuple{Union{Integer,AbstractUnitRange{Int}},AbstractBlockedUnitRange,Vararg{Union{Integer,AbstractUnitRange{Int}}}}) where T =
-    PseudoBlockArray{T}(undef, map(to_axes,axes))
+    BlockedArray{T}(undef, map(to_axes,axes))
 
-@inline Base.similar(block_array::PseudoBlockArray, ::Type{T}, axes::Tuple{AbstractBlockedUnitRange,Vararg{Union{Integer,AbstractUnitRange{Int}}}}) where T =
-    PseudoBlockArray{T}(undef, map(to_axes,axes))
-@inline Base.similar(block_array::PseudoBlockArray, ::Type{T}, axes::Tuple{AbstractBlockedUnitRange,AbstractBlockedUnitRange,Vararg{Union{Integer,AbstractUnitRange{Int}}}}) where T =
-    PseudoBlockArray{T}(undef, map(to_axes,axes))
-@inline Base.similar(block_array::PseudoBlockArray, ::Type{T}, axes::Tuple{Union{Integer,AbstractUnitRange{Int}},AbstractBlockedUnitRange,Vararg{Union{Integer,AbstractUnitRange{Int}}}}) where T =
-    PseudoBlockArray{T}(undef, map(to_axes,axes))
+@inline Base.similar(block_array::BlockedArray, ::Type{T}, axes::Tuple{AbstractBlockedUnitRange,Vararg{Union{Integer,AbstractUnitRange{Int}}}}) where T =
+    BlockedArray{T}(undef, map(to_axes,axes))
+@inline Base.similar(block_array::BlockedArray, ::Type{T}, axes::Tuple{AbstractBlockedUnitRange,AbstractBlockedUnitRange,Vararg{Union{Integer,AbstractUnitRange{Int}}}}) where T =
+    BlockedArray{T}(undef, map(to_axes,axes))
+@inline Base.similar(block_array::BlockedArray, ::Type{T}, axes::Tuple{Union{Integer,AbstractUnitRange{Int}},AbstractBlockedUnitRange,Vararg{Union{Integer,AbstractUnitRange{Int}}}}) where T =
+    BlockedArray{T}(undef, map(to_axes,axes))
 
-@propagate_inbounds getindex(block_arr::PseudoBlockArray{T, N}, i::Vararg{Integer, N}) where {T,N} = block_arr.blocks[i...]
-@propagate_inbounds function setindex!(block_arr::PseudoBlockArray{T, N}, v, i::Vararg{Integer, N}) where {T,N}
+@propagate_inbounds getindex(block_arr::BlockedArray{T, N}, i::Vararg{Integer, N}) where {T,N} = block_arr.blocks[i...]
+@propagate_inbounds function setindex!(block_arr::BlockedArray{T, N}, v, i::Vararg{Integer, N}) where {T,N}
     setindex!(block_arr.blocks, v, i...)
     block_arr
 end
@@ -235,13 +235,13 @@ end
 ################################
 # AbstractBlockArray Interface #
 ################################
-@inline axes(block_array::PseudoBlockArray) = block_array.axes
+@inline axes(block_array::BlockedArray) = block_array.axes
 
 ############
 # Indexing #
 ############
 
-@inline function viewblock(block_arr::PseudoBlockArray, block)
+@inline function viewblock(block_arr::BlockedArray, block)
     range = getindex.(axes(block_arr), Block.(block.n))
     return view(block_arr.blocks, range...)
 end
@@ -251,69 +251,69 @@ end
     block_arr.blocks[I...]
 end
 
-@propagate_inbounds getindex(block_arr::PseudoBlockArray{T,N}, blockindex::BlockIndex{N}) where {T,N} =
+@propagate_inbounds getindex(block_arr::BlockedArray{T,N}, blockindex::BlockIndex{N}) where {T,N} =
     _pseudoblockindex_getindex(block_arr, blockindex)
 
 
-@propagate_inbounds getindex(block_arr::PseudoBlockVector{T}, blockindex::BlockIndex{1}) where T =
+@propagate_inbounds getindex(block_arr::BlockedVector{T}, blockindex::BlockIndex{1}) where T =
     _pseudoblockindex_getindex(block_arr, blockindex)
 
 ########
 # Misc #
 ########
 
-Base.parent(block_array::PseudoBlockArray) = block_array.blocks
+Base.parent(block_array::BlockedArray) = block_array.blocks
 
-Base.Array(block_array::PseudoBlockArray) = Array(block_array.blocks)
+Base.Array(block_array::BlockedArray) = Array(block_array.blocks)
 
-function copyto!(block_array::PseudoBlockArray{T, N, R}, arr::R) where {T,N,R <: AbstractArray}
+function copyto!(block_array::BlockedArray{T, N, R}, arr::R) where {T,N,R <: AbstractArray}
     copyto!(block_array.blocks, arr)
 end
 
-function copyto!(block_array::PseudoBlockArray{T, N, R}, arr::R) where {T,N,R <: LayoutArray}
+function copyto!(block_array::BlockedArray{T, N, R}, arr::R) where {T,N,R <: LayoutArray}
     copyto!(block_array.blocks, arr)
 end
 
-function Base.copy(block_array::PseudoBlockArray{T, N, R}) where {T,N,R <: AbstractArray}
+function Base.copy(block_array::BlockedArray{T, N, R}) where {T,N,R <: AbstractArray}
     copy(block_array.blocks)
 end
 
-function Base.fill!(block_array::PseudoBlockArray, v)
+function Base.fill!(block_array::BlockedArray, v)
     fill!(block_array.blocks, v)
     block_array
 end
 
-function ArrayLayouts.lmul!(α::Number, block_array::PseudoBlockArray)
+function ArrayLayouts.lmul!(α::Number, block_array::BlockedArray)
     lmul!(α, block_array.blocks)
     block_array
 end
 
-function ArrayLayouts.rmul!(block_array::PseudoBlockArray, α::Number)
+function ArrayLayouts.rmul!(block_array::BlockedArray, α::Number)
     rmul!(block_array.blocks, α)
     block_array
 end
 
-_pseudo_reshape(block_array, axes) = PseudoBlockArray(reshape(block_array.blocks,map(length,axes)),axes)
-Base.reshape(block_array::PseudoBlockArray, axes::NTuple{N,AbstractUnitRange{Int}}) where N =
+_pseudo_reshape(block_array, axes) = BlockedArray(reshape(block_array.blocks,map(length,axes)),axes)
+Base.reshape(block_array::BlockedArray, axes::NTuple{N,AbstractUnitRange{Int}}) where N =
     _pseudo_reshape(block_array, axes)
-Base.reshape(parent::PseudoBlockArray, shp::Tuple{Union{Integer,Base.OneTo}, Vararg{Union{Integer,Base.OneTo}}}) =
+Base.reshape(parent::BlockedArray, shp::Tuple{Union{Integer,Base.OneTo}, Vararg{Union{Integer,Base.OneTo}}}) =
     reshape(parent, Base.to_shape(shp))
-Base.reshape(parent::PseudoBlockArray, dims::Tuple{Int,Vararg{Int}}) =
+Base.reshape(parent::BlockedArray, dims::Tuple{Int,Vararg{Int}}) =
     Base._reshape(parent, dims)
 
 """
-    resize!(a::PseudoBlockVector, N::Block) -> PseudoBlockVector
+    resize!(a::BlockedVector, N::Block) -> BlockedVector
 
-Resize `a` to contain the first `N` blocks, returning a new `PseudoBlockVector` sharing
+Resize `a` to contain the first `N` blocks, returning a new `BlockedVector` sharing
 memory with `a`. If `N` is smaller than the current
 collection block length, the first `N` blocks will be retained. `N` is not allowed to be larger.
 """
-function resize!(a::PseudoBlockVector, N::Block{1})
+function resize!(a::BlockedVector, N::Block{1})
     ax = axes(a,1)
     if iszero(Int(N))
-        PseudoBlockVector(resize!(a.blocks, 0), (ax[Block.(Base.OneTo(0))],))
+        BlockedVector(resize!(a.blocks, 0), (ax[Block.(Base.OneTo(0))],))
     else
-        PseudoBlockVector(resize!(a.blocks, last(ax[N])), (ax[Block.(Base.OneTo(Int(N)))],))
+        BlockedVector(resize!(a.blocks, last(ax[N])), (ax[Block.(Base.OneTo(Int(N)))],))
     end
 end
 
@@ -323,34 +323,34 @@ end
 # Strided Array interface #
 ###########################
 
-Base.strides(A::PseudoBlockArray) = strides(A.blocks)
-Base.stride(A::PseudoBlockArray, i::Integer) = stride(A.blocks, i)
-Base.unsafe_convert(::Type{Ptr{T}}, A::PseudoBlockArray) where T = Base.unsafe_convert(Ptr{T}, A.blocks)
-Base.elsize(::Type{<:PseudoBlockArray{T,N,R}}) where {T,N,R} = Base.elsize(R)
+Base.strides(A::BlockedArray) = strides(A.blocks)
+Base.stride(A::BlockedArray, i::Integer) = stride(A.blocks, i)
+Base.unsafe_convert(::Type{Ptr{T}}, A::BlockedArray) where T = Base.unsafe_convert(Ptr{T}, A.blocks)
+Base.elsize(::Type{<:BlockedArray{T,N,R}}) where {T,N,R} = Base.elsize(R)
 
 ###
 # col/rowsupport
 ###
 
-colsupport(A::PseudoBlockArray, j) = colsupport(A.blocks, j)
-rowsupport(A::PseudoBlockArray, j) = rowsupport(A.blocks, j)
+colsupport(A::BlockedArray, j) = colsupport(A.blocks, j)
+rowsupport(A::BlockedArray, j) = rowsupport(A.blocks, j)
 
 ###
 # zeros/ones
 ###
 
 for op in (:zeros, :ones)
-    @eval $op(::Type{T}, axs::Tuple{BlockedOneTo,Vararg{Union{Integer,AbstractUnitRange}}}) where T = PseudoBlockArray($op(T, map(length,axs)...), axs)
+    @eval $op(::Type{T}, axs::Tuple{BlockedOneTo,Vararg{Union{Integer,AbstractUnitRange}}}) where T = BlockedArray($op(T, map(length,axs)...), axs)
 end
 
-Base.replace_in_print_matrix(f::PseudoBlockVecOrMat, i::Integer, j::Integer, s::AbstractString) =
+Base.replace_in_print_matrix(f::BlockedVecOrMat, i::Integer, j::Integer, s::AbstractString) =
     Base.replace_in_print_matrix(f.blocks, i, j, s)
 
 
-LinearAlgebra.norm(A::PseudoBlockArray, p::Real=2) = norm(A.blocks, p)
+LinearAlgebra.norm(A::BlockedArray, p::Real=2) = norm(A.blocks, p)
 
 ###########################
 # FillArrays interface #
 ###########################
 
-FillArrays.getindex_value(P::PseudoBlockArray) = FillArrays.getindex_value(P.blocks)
+FillArrays.getindex_value(P::BlockedArray) = FillArrays.getindex_value(P.blocks)

--- a/src/show.jl
+++ b/src/show.jl
@@ -122,19 +122,19 @@ axes_print_matrix_row(::Tuple{AbstractBlockedUnitRange,AbstractUnitRange}, io, X
 Base.print_matrix_row(io::IO, X::AbstractBlockedUnitRange, A::Vector, i::Integer, cols::AbstractVector, sep::AbstractString, idxlast::Integer=last(axes(X, 2))) =
         _blockarray_print_matrix_row(io, X, A, i, cols, sep)
 
-function _show_typeof(io::IO, a::PseudoBlockVector{T,Vector{T},Tuple{DefaultBlockAxis}}) where T
-    print(io, "PseudoBlockVector{")
+function _show_typeof(io::IO, a::BlockedVector{T,Vector{T},Tuple{DefaultBlockAxis}}) where T
+    print(io, "BlockedVector{")
     show(io, T)
     print(io, '}')
 end
 
-function _show_typeof(io::IO, a::PseudoBlockMatrix{T,Matrix{T},NTuple{2,DefaultBlockAxis}}) where T
-    print(io, "PseudoBlockMatrix{")
+function _show_typeof(io::IO, a::BlockedMatrix{T,Matrix{T},NTuple{2,DefaultBlockAxis}}) where T
+    print(io, "BlockedMatrix{")
     show(io, T)
     print(io, '}')
 end
 
-function _show_typeof(io::IO, a::PseudoBlockArray{T,N,Array{T,N},NTuple{N,DefaultBlockAxis}}) where {T,N}
+function _show_typeof(io::IO, a::BlockedArray{T,N,Array{T,N},NTuple{N,DefaultBlockAxis}}) where {T,N}
     Base.show_type_name(io, typeof(a).name)
     print(io, '{')
     show(io, T)
@@ -143,12 +143,12 @@ function _show_typeof(io::IO, a::PseudoBlockArray{T,N,Array{T,N},NTuple{N,Defaul
     print(io, '}')
 end
 
-function Base.showarg(io::IO, A::PseudoBlockArray, toplevel::Bool)
+function Base.showarg(io::IO, A::BlockedArray, toplevel::Bool)
     if toplevel
-        print(io, "PseudoBlockArray of ")
+        print(io, "BlockedArray of ")
         Base.showarg(io, A.blocks, true)
     else
-        print(io, "::PseudoBlockArray{…,")
+        print(io, "::BlockedArray{…,")
         Base.showarg(io, A.blocks, false)
         print(io, '}')
     end

--- a/src/views.jl
+++ b/src/views.jl
@@ -76,7 +76,7 @@ _splatmap(f, t::Tuple) = (f(t[1])..., _splatmap(f, tail(t))...)
 end
 
 @propagate_inbounds function Base.unsafe_view(
-        A::PseudoBlockArray{<:Any, N},
+        A::BlockedArray{<:Any, N},
         I::Vararg{BlockSlice{<:BlockIndexRange{1}}, N}) where {N}
     return view(A.blocks, map(x -> x.indices, I)...)
 end
@@ -173,7 +173,7 @@ view(A::AdjOrTrans{<:Any,<:BlockArray}, K::Block{1}, J::Block{1}) = view(A, Bloc
 @propagate_inbounds getindex(v::LinearAlgebra.AdjOrTransAbsVec, ::Colon, is::AbstractArray{<:Block{1}}) = LinearAlgebra.wrapperop(v)(v.parent[is])
 
 
-unsafe_convert(::Type{Ptr{T}}, V::SubArray{T,N,PseudoBlockArray{T,N,AT},<:Tuple{Vararg{BlockOrRangeIndex}}}) where {T,N,AT} =
+unsafe_convert(::Type{Ptr{T}}, V::SubArray{T,N,BlockedArray{T,N,AT},<:Tuple{Vararg{BlockOrRangeIndex}}}) where {T,N,AT} =
     unsafe_convert(Ptr{T}, V.parent) + (Base.first_index(V)-1)*sizeof(T)
 
 # support for strided array interface for subblocks. Typically

--- a/test/test_blockarrayinterface.jl
+++ b/test/test_blockarrayinterface.jl
@@ -6,7 +6,7 @@ using BlockArrays, LinearAlgebra, FillArrays, Test, ArrayLayouts
 bview(a, b) = Base.invoke(view, Tuple{AbstractArray,Any}, a, b)
 
 @testset "missing fallback block axes" begin
-    @test_throws ArgumentError invoke(axes, Tuple{AbstractBlockArray}, PseudoBlockArray{ComplexF64}(undef, (1:4), (2:5)))
+    @test_throws ArgumentError invoke(axes, Tuple{AbstractBlockArray}, BlockedArray{ComplexF64}(undef, (1:4), (2:5)))
 end
 
 @testset "Array block interface" begin
@@ -35,7 +35,7 @@ end
 
 @testset "Triangular/Symmetric/Hermitian block arrays" begin
     @testset "square blocks" begin
-        A = PseudoBlockArray{ComplexF64}(undef, 1:4, 1:4)
+        A = BlockedArray{ComplexF64}(undef, 1:4, 1:4)
         A .= reshape(1:length(A), size(A))
         U = UpperTriangular(A)
         S = Symmetric(A)
@@ -60,14 +60,14 @@ end
         V = view(A, Block.(1:2), Block.(1:2))
         @test blockisequal(axes(Symmetric(V)), axes(view(A, Block.(1:2), Block.(1:2))))
 
-        A = PseudoBlockArray{Int}(reshape([1:9;],3,3), 1:2, 1:2)
+        A = BlockedArray{Int}(reshape([1:9;],3,3), 1:2, 1:2)
         B = UpperTriangular(A)
         str = sprint(show, "text/plain", B)
         @test str == "$(summary(B)):\n 1  │  4  7\n ───┼──────\n ⋅  │  5  8\n ⋅  │  ⋅  9"
     end
 
     @testset "rect blocks" begin
-        A = PseudoBlockArray{ComplexF64}(undef, 1:3, fill(3, 2))
+        A = BlockedArray{ComplexF64}(undef, 1:3, fill(3, 2))
         A .= randn(6, 6) .+ im * randn(6, 6)
         U = UpperTriangular(A)
         S = Symmetric(A)
@@ -96,7 +96,7 @@ end
     end
 
     @testset "getindex ambiguity" begin
-        A = PseudoBlockArray{ComplexF64}(undef, 1:4, 1:4)
+        A = BlockedArray{ComplexF64}(undef, 1:4, 1:4)
         A .= reshape(1:length(A), size(A)) .+ im
         S = Symmetric(A)
         H = Hermitian(A)
@@ -111,7 +111,7 @@ end
 end
 
 @testset "Adjoint/Transpose block arrays" begin
-    A = PseudoBlockArray{ComplexF64}(undef, (1:4), (2:5))
+    A = BlockedArray{ComplexF64}(undef, (1:4), (2:5))
     A .= randn.() .+ randn.() .* im
 
     @test blocksize(A') == (4, 4)

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -14,7 +14,7 @@ function test_error_message(f, needle, expected = Exception)
     return err
 end
 
-@testset "Block/PseudoArray" begin
+@testset "Block/BlockedArray" begin
     @testset "block constructors" begin
         @testset "BlockArray Constructors" begin
             ret = BlockArray{Float64}(undef, 1:3)
@@ -125,35 +125,35 @@ end
             end
         end
 
-        @testset "PseudoBlockArray constructors" begin
-            ret = PseudoBlockArray{Float64}(undef, 1:3)
+        @testset "BlockedArray constructors" begin
+            ret = BlockedArray{Float64}(undef, 1:3)
             fill!(ret, 0)
             @test size(ret) == (6,)
             @test all(iszero, ret)
 
-            ret = PseudoBlockVector{Float64}(undef, 1:3)
+            ret = BlockedVector{Float64}(undef, 1:3)
             fill!(ret, 0)
             @test size(ret) == (6,)
             @test all(iszero, ret)
 
-            ret = PseudoBlockArray{Float64}(undef, 1:3, 1:3)
+            ret = BlockedArray{Float64}(undef, 1:3, 1:3)
             fill!(ret, 0)
             @test size(ret) == (6,6)
             @test all(iszero, ret)
 
             A = [1,2,3,4,5,6]
-            @test_throws BoundsError PseudoBlockArray(A,10:20)
-            @test A == PseudoBlockArray(A, 1:3) == PseudoBlockArray{Int}(A, 1:3) ==
-                PseudoBlockArray(A, (blockedrange(1:3),)) == PseudoBlockArray{Int}(A, (blockedrange(1:3),)) ==
-                PseudoBlockArray{Float64}(A, 1:3)
+            @test_throws BoundsError BlockedArray(A,10:20)
+            @test A == BlockedArray(A, 1:3) == BlockedArray{Int}(A, 1:3) ==
+                BlockedArray(A, (blockedrange(1:3),)) == BlockedArray{Int}(A, (blockedrange(1:3),)) ==
+                BlockedArray{Float64}(A, 1:3)
 
             @testset "from arrays" begin
                 v = [1,2,3]
-                @test PseudoBlockVector(v) == v
-                @test PseudoBlockArray(v) == v
+                @test BlockedVector(v) == v
+                @test BlockedArray(v) == v
                 M = [1 2; 3 4]
-                @test PseudoBlockMatrix(M) == M
-                @test PseudoBlockArray(M) == M
+                @test BlockedMatrix(M) == M
+                @test BlockedArray(M) == M
             end
         end
 
@@ -162,27 +162,27 @@ end
             @test similar(ret, Float64, (3,)) isa Vector
             @test similar(typeof(ret), axes(ret)) isa BlockArray
             @test similar(typeof(ret), (Base.OneTo(6),)) isa Array
-            @test similar(Array{Float64}, axes(ret)) isa PseudoBlockArray
-            @test similar(Vector{Float64}, axes(ret)) isa PseudoBlockArray
-            @test similar(randn(5,5), Float64, axes(ret)) isa PseudoBlockArray
+            @test similar(Array{Float64}, axes(ret)) isa BlockedArray
+            @test similar(Vector{Float64}, axes(ret)) isa BlockedArray
+            @test similar(randn(5,5), Float64, axes(ret)) isa BlockedArray
             @test similar(ret, Float64, (Base.IdentityUnitRange(1:3),)) isa BlockArray
 
-            ret = PseudoBlockArray{Float64}(undef, 1:3)
-            @test similar(ret, Float64, (blockedrange(1:3),)) isa PseudoBlockArray
+            ret = BlockedArray{Float64}(undef, 1:3)
+            @test similar(ret, Float64, (blockedrange(1:3),)) isa BlockedArray
 
             ret = BlockArray{Float64}(undef, 1:3, 1:3)
             @test similar(typeof(ret), axes(ret)) isa BlockArray
             @test similar(typeof(ret), (Base.OneTo(6),axes(ret,2))) isa BlockArray
-            @test similar(Array{Float64}, axes(ret)) isa PseudoBlockArray
-            @test similar(Vector{Float64}, axes(ret)) isa PseudoBlockArray
-            @test similar(Array{Float64}, (Base.OneTo(5), axes(ret,2))) isa PseudoBlockArray
-            @test similar(randn(5,5), Float64, axes(ret)) isa PseudoBlockArray
-            @test similar(randn(5,5), Float64, (Base.OneTo(5), axes(ret,2))) isa PseudoBlockArray
+            @test similar(Array{Float64}, axes(ret)) isa BlockedArray
+            @test similar(Vector{Float64}, axes(ret)) isa BlockedArray
+            @test similar(Array{Float64}, (Base.OneTo(5), axes(ret,2))) isa BlockedArray
+            @test similar(randn(5,5), Float64, axes(ret)) isa BlockedArray
+            @test similar(randn(5,5), Float64, (Base.OneTo(5), axes(ret,2))) isa BlockedArray
 
-            @test similar(randn(6,5), Float64, (blockedrange(1:3),3)) isa PseudoBlockMatrix
-            @test similar(randn(6,5), Float64, (3,blockedrange(1:3))) isa PseudoBlockMatrix
-            @test similar(typeof(view(randn(5),1:3)), (blockedrange(1:3),)) isa PseudoBlockVector
-            @test similar(view(randn(5),1:3), Int, (blockedrange(1:3),)) isa PseudoBlockVector{Int}
+            @test similar(randn(6,5), Float64, (blockedrange(1:3),3)) isa BlockedMatrix
+            @test similar(randn(6,5), Float64, (3,blockedrange(1:3))) isa BlockedMatrix
+            @test similar(typeof(view(randn(5),1:3)), (blockedrange(1:3),)) isa BlockedVector
+            @test similar(view(randn(5),1:3), Int, (blockedrange(1:3),)) isa BlockedVector{Int}
         end
 
         @test_throws DimensionMismatch BlockArray([1,2,3],[1,1])
@@ -259,11 +259,11 @@ end
             a[1] = 2
             @test a == [2,2,3]
             @test a_data == [1,2,3]
-            a = PseudoBlockVector(a_data,[1,2])
+            a = BlockedVector(a_data,[1,2])
             a[1] = 2
             @test a == [2,2,3]
             @test a_data == [2,2,3]
-            a = PseudoBlockVector(a_data,(blockedrange([1,2]),))
+            a = BlockedVector(a_data,(blockedrange([1,2]),))
             a[1] = 3
             @test a == [3,2,3]
             @test a_data == [3,2,3]
@@ -279,11 +279,11 @@ end
             a[1] = 2
             @test a == [2 2; 3 4]
             @test a_data == [1 2; 3 4]
-            a = PseudoBlockMatrix(a_data,[1,1],[2])
+            a = BlockedMatrix(a_data,[1,1],[2])
             a[1] = 2
             @test a == [2 2; 3 4]
             @test a_data == [2 2; 3 4]
-            a = PseudoBlockMatrix(a_data, blockedrange.(([1,1],[2])))
+            a = BlockedMatrix(a_data, blockedrange.(([1,1],[2])))
             a[1] = 3
             @test a == [3 2; 3 4]
             @test a_data == [3 2; 3 4]
@@ -304,18 +304,18 @@ end
                         BlockMatrix{Float64}(I, blockedrange.((fill(2,4), fill(2,5)))) ==
                         Matrix(I, 8, 10)
 
-            B = PseudoBlockArray(I, fill(2,4), fill(2,5))
-            @test B isa PseudoBlockMatrix{Bool}
-            @test B == PseudoBlockMatrix(I, fill(2,4), fill(2,5)) ==
-                        PseudoBlockArray(I, blockedrange.((fill(2,4), fill(2,5)))) ==
-                        PseudoBlockMatrix(I, blockedrange.((fill(2,4), fill(2,5)))) ==
+            B = BlockedArray(I, fill(2,4), fill(2,5))
+            @test B isa BlockedMatrix{Bool}
+            @test B == BlockedMatrix(I, fill(2,4), fill(2,5)) ==
+                        BlockedArray(I, blockedrange.((fill(2,4), fill(2,5)))) ==
+                        BlockedMatrix(I, blockedrange.((fill(2,4), fill(2,5)))) ==
                         Matrix(I, 8, 10)
 
-            B = PseudoBlockArray{Float64}(I, fill(2,4), fill(2,5))
-            @test B isa PseudoBlockMatrix{Float64}
-            @test B == PseudoBlockMatrix{Float64}(I, fill(2,4), fill(2,5)) ==
-                        PseudoBlockArray{Float64}(I, blockedrange.((fill(2,4), fill(2,5)))) ==
-                        PseudoBlockMatrix{Float64}(I, blockedrange.((fill(2,4), fill(2,5)))) ==
+            B = BlockedArray{Float64}(I, fill(2,4), fill(2,5))
+            @test B isa BlockedMatrix{Float64}
+            @test B == BlockedMatrix{Float64}(I, fill(2,4), fill(2,5)) ==
+                        BlockedArray{Float64}(I, blockedrange.((fill(2,4), fill(2,5)))) ==
+                        BlockedMatrix{Float64}(I, blockedrange.((fill(2,4), fill(2,5)))) ==
                         Matrix(I, 8, 10)
         end
     end
@@ -372,7 +372,7 @@ end
         @test_throws BlockBoundsError blockcheckbounds(BA_3, 1, 2)
 
         @testset for (T,F) in ((Fill, Fill(3,4,4)), (Ones, Ones(4,4)), (Zeros, Zeros(4,4)))
-            P = PseudoBlockArray(F, [1,3], [1,3])
+            P = BlockedArray(F, [1,3], [1,3])
             V = P[axes(P)...]
             @test V isa T
             @test V == F
@@ -392,7 +392,7 @@ end
     end
 
     @testset "misc block tests" begin
-        for BlockType in (BlockArray, PseudoBlockArray)
+        for BlockType in (BlockArray, BlockedArray)
             a_1 = rand(6)
             BA_1 = BlockType(a_1, [1,2,3])
             @test Array(BA_1) == a_1
@@ -403,7 +403,7 @@ end
             BA_1[Block(1)] = q
             BA_1[BlockIndex(3, 2)] = a_1[5]
             @test BA_1[Block(1)] == q
-            if BlockType == PseudoBlockArray
+            if BlockType == BlockedArray
                 q2 = zero(q)
                 copyto!(q2, view(BA_1, Block(1)))
                 @test q2 == q
@@ -439,7 +439,7 @@ end
             BA_2[Block(1,2)] = q
             @test_throws DimensionMismatch BA_2[Block(1,2)] = rand(1,5)
             @test BA_2[Block(1,2)] == q
-            if BlockType == PseudoBlockArray
+            if BlockType == BlockedArray
                 q2 = zero(q)
                 copyto!(q2, view(BA_2, Block(1, 2)))
                 @test q2 == q
@@ -468,7 +468,7 @@ end
             q = rand(1,4,2)
             BA_3[Block(1,2,2)] = q
             @test BA_3[Block(1,2,2)] == q
-            if BlockType == PseudoBlockArray
+            if BlockType == BlockedArray
                 q3 = zero(q)
                 copyto!(q3, view(BA_3, Block(1, 2, 2)))
                 @test q3 == q
@@ -483,7 +483,7 @@ end
 
     @testset "convert" begin
         # Could probably be DRY'd.
-        A = PseudoBlockArray(rand(2,3), [1,1], [2,1])
+        A = BlockedArray(rand(2,3), [1,1], [2,1])
 
         @test convert(AbstractMatrix{Float64}, A) ≡ convert(AbstractMatrix, A) ≡ A
         @test convert(AbstractArray{Float64}, A) ≡ convert(AbstractArray, A) ≡ A
@@ -502,11 +502,11 @@ end
         @test C ≈ A ≈ BlockArray(A)
         @test eltype(C) == Float32
 
-        Ã = PseudoBlockArray(rand(2,3), Fill(1,2), [2,1])
+        Ã = BlockedArray(rand(2,3), Fill(1,2), [2,1])
         @test convert(typeof(A), Ã) == Ã
 
-        @test PseudoBlockArray(A, axes(Ã)) isa typeof(Ã)
-        @test PseudoBlockArray(A, axes(Ã)) == A
+        @test BlockedArray(A, axes(Ã)) isa typeof(Ã)
+        @test BlockedArray(A, axes(Ã)) == A
 
 
         A = BlockArray(rand(2,3), [1,1], [2,1])
@@ -516,16 +516,16 @@ end
         @test convert(AbstractMatrix{Float32}, A) == AbstractMatrix{Float32}(A)
         @test convert(AbstractArray{Float32}, A) == AbstractArray{Float32}(A)
 
-        C = convert(PseudoBlockArray, A)
-        @test C == A == PseudoBlockArray(A)
+        C = convert(BlockedArray, A)
+        @test C == A == BlockedArray(A)
         @test eltype(C) == eltype(A)
 
-        C = convert(PseudoBlockArray{Float32}, A)
-        @test C ≈ A ≈ PseudoBlockArray(A)
+        C = convert(BlockedArray{Float32}, A)
+        @test C ≈ A ≈ BlockedArray(A)
         @test eltype(C) == Float32
 
-        C = convert(PseudoBlockArray{Float32, 2}, A)
-        @test C ≈ A ≈ PseudoBlockArray(A)
+        C = convert(BlockedArray{Float32, 2}, A)
+        @test C ≈ A ≈ BlockedArray(A)
         @test eltype(C) == Float32
 
         @test convert(BlockArray, A) === A
@@ -545,7 +545,7 @@ end
         Base.showerror(buf, BlockBoundsError(A, (3,2)))
         @test String(take!(buf)) == "BlockBoundsError: attempt to access $(summary(A)) at block index [3,2]"
 
-        A = PseudoBlockArray(rand(4, 5), [1,3], [2,3]);
+        A = BlockedArray(rand(4, 5), [1,3], [2,3]);
         Base.showerror(buf, BlockBoundsError(A, (3,2)))
         @test String(take!(buf)) == "BlockBoundsError: attempt to access $(summary(A)) at block index [3,2]"
     end
@@ -553,22 +553,22 @@ end
     @testset "replstring" begin
         A = BlockArray(collect(1:4), [1,3])
         @test sprint(show, "text/plain", A) == "$(summary(A)):\n 1\n ─\n 2\n 3\n 4"
-        A = PseudoBlockArray(collect(1:4), [1,3])
+        A = BlockedArray(collect(1:4), [1,3])
         @test sprint(show, "text/plain", A) == "$(summary(A)):\n 1\n ─\n 2\n 3\n 4"
         A = BlockArray(collect(reshape(1:16, 4, 4)), [1,3], [2,2])
         @test sprint(show, "text/plain", A) == "$(summary(A)):\n 1  5  │   9  13\n ──────┼────────\n 2  6  │  10  14\n 3  7  │  11  15\n 4  8  │  12  16"
-        A = PseudoBlockArray(collect(reshape(1:16, 4, 4)), [1,3], [2,2])
+        A = BlockedArray(collect(reshape(1:16, 4, 4)), [1,3], [2,2])
         @test sprint(show, "text/plain", A) == "$(summary(A)):\n 1  5  │   9  13\n ──────┼────────\n 2  6  │  10  14\n 3  7  │  11  15\n 4  8  │  12  16"
         A = BlockArray(collect(reshape(1:8, 2, 2, 2)), [1,1], [1,1], [1,1])
         @test sprint(show, "text/plain", A) == "$(summary(A)):\n[:, :, 1] =\n 1  3\n 2  4\n\n[:, :, 2] =\n 5  7\n 6  8"
-        A = PseudoBlockArray(collect(reshape(1:8, 2, 2, 2)), [1,1], [1,1], [1,1])
+        A = BlockedArray(collect(reshape(1:8, 2, 2, 2)), [1,1], [1,1], [1,1])
         @test sprint(show, "text/plain", A) == "$(summary(A)):\n[:, :, 1] =\n 1  3\n 2  4\n\n[:, :, 2] =\n 5  7\n 6  8"
         design = zeros(Int16,6,9);
         A = BlockArray(design,[6],[4,5])
         @test sprint(show, "text/plain", A) == "$(summary(A)):\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0"
-        A = PseudoBlockArray(design,[6],[4,5])
+        A = BlockedArray(design,[6],[4,5])
         @test sprint(show, "text/plain", A) == "$(summary(A)):\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0\n 0  0  0  0  │  0  0  0  0  0"
-        D = PseudoBlockArray(Diagonal(1:3), [1,2], [2,1])
+        D = BlockedArray(Diagonal(1:3), [1,2], [2,1])
         @test sprint(show, "text/plain", D) == "$(summary(D)):\n 1  ⋅  │  ⋅\n ──────┼───\n ⋅  2  │  ⋅\n ⋅  ⋅  │  3"
 
         a = BlockArray{Int}(undef_blocks, [1,2])
@@ -588,7 +588,7 @@ end
     end
 
     @testset "Strided array interface" begin
-        A = PseudoBlockArray{Float64}(undef, 1:3, 1:3)
+        A = BlockedArray{Float64}(undef, 1:3, 1:3)
         fill!(A, 1)
         @test strides(A) == (1, size(A,1))
         x = randn(size(A,2))
@@ -597,14 +597,14 @@ end
     end
 
     @testset "FillArrays interface" begin
-        P = PseudoBlockArray(Fill(3,4,4), [1,3], [1,3])
+        P = BlockedArray(Fill(3,4,4), [1,3], [1,3])
         @test P[1:3, 2:3] === Fill(3,3,2)
         @test P[1:3, 1] == Fill(3,3)
         @test P[2, 1:3] == Fill(3,3)
     end
 
     @testset "lmul!/rmul!" begin
-        A = PseudoBlockArray{Float64}(undef, 1:3)
+        A = BlockedArray{Float64}(undef, 1:3)
         @test fill!(A, NaN) === A
         @test all(isnan, lmul!(0.0, copy(A))) == all(isnan, lmul!(0.0, Array(A)))
         @test lmul!(false, copy(A)) == lmul!(false, Array(A))
@@ -626,7 +626,7 @@ end
     end
 
     @testset "copy" begin
-        A = PseudoBlockArray(randn(6), 1:3)
+        A = BlockedArray(randn(6), 1:3)
         B = copy(A)
         @test typeof(A) == typeof(B)
         @test axes(A) === axes(B)
@@ -644,20 +644,20 @@ end
         @test B[1] == 2
         @test A[1] ≠ 2
         @testset "copyto!" begin
-            A = PseudoBlockArray(randn(6), 1:3)
+            A = BlockedArray(randn(6), 1:3)
             B = BlockArray(randn(6), 1:3)
             @test copyto!(BlockArray{Float64}(undef, 1:3), A) == A
-            @test copyto!(PseudoBlockArray{Float64}(undef, 1:3), A) == A
+            @test copyto!(BlockedArray{Float64}(undef, 1:3), A) == A
 
             @test copyto!(BlockArray{Float64}(undef, 1:3), B) == B
-            @test copyto!(PseudoBlockArray{Float64}(undef, 1:3), B) == B
+            @test copyto!(BlockedArray{Float64}(undef, 1:3), B) == B
         end
     end
 
     @testset "const block size" begin
         N = 10
         A = mortar(fill([1,2], N), Fill(2,N))
-        B = PseudoBlockArray(vcat(fill([1,2], N)...),  Fill(2,N))
+        B = BlockedArray(vcat(fill([1,2], N)...),  Fill(2,N))
         @test A == vcat(A.blocks...) == B
         @test A[Block(1)] == B[Block(1)] == [1,2]
     end
@@ -682,34 +682,34 @@ end
 
     @testset "reshape" begin
         A = BlockArray(1:6, 1:3)
-        @test reshape(A, Val(2)) isa PseudoBlockArray{Int,2,Matrix{Int},Tuple{typeof(axes(A,1)),Base.OneTo{Int}}}
-        @test reshape(A, Val(2)) == PseudoBlockArray(reshape(1:6,6,1), (blockedrange(1:3), Base.OneTo(1)))
+        @test reshape(A, Val(2)) isa BlockedArray{Int,2,Matrix{Int},Tuple{typeof(axes(A,1)),Base.OneTo{Int}}}
+        @test reshape(A, Val(2)) == BlockedArray(reshape(1:6,6,1), (blockedrange(1:3), Base.OneTo(1)))
         @test reshape(A, (blockedrange(Fill(2,3)),))[Block(1)] == 1:2
         @test reshape(A, 2, 3) == reshape(A, Base.OneTo(2), 3) == reshape(Vector(A), 2, 3)
 
         @test_throws DimensionMismatch reshape(A,3)
 
-        A = PseudoBlockArray(1:6, 1:3)
-        @test reshape(A, Val(2)) isa typeof(PseudoBlockArray(reshape(1:6,6,1), (blockedrange(1:3), Base.OneTo(1))))
-        @test reshape(A, Val(2)) == PseudoBlockArray(reshape(1:6,6,1), (blockedrange(1:3), Base.OneTo(1)))
+        A = BlockedArray(1:6, 1:3)
+        @test reshape(A, Val(2)) isa typeof(BlockedArray(reshape(1:6,6,1), (blockedrange(1:3), Base.OneTo(1))))
+        @test reshape(A, Val(2)) == BlockedArray(reshape(1:6,6,1), (blockedrange(1:3), Base.OneTo(1)))
         @test reshape(A, (blockedrange(Fill(2,3)),))[Block(1)] == 1:2
         @test reshape(A, 2, 3) == reshape(A, Base.OneTo(2), 3) == reshape(Vector(A), 2, 3)
     end
 
     @testset "*" begin
         A = BlockArray(randn(6,6), 1:3,1:3)
-        Ã = PseudoBlockArray(A)
+        Ã = BlockedArray(A)
         b = randn(6)
-        @test A*b isa PseudoBlockVector{Float64}
-        @test Ã*b isa PseudoBlockVector{Float64}
+        @test A*b isa BlockedVector{Float64}
+        @test Ã*b isa BlockedVector{Float64}
         @test A*b ≈ Ã*b ≈ Matrix(A)*b
     end
 
     @testset "Blockindex" begin
-        a = PseudoBlockArray(randn(3), [1,2])
+        a = BlockedArray(randn(3), [1,2])
         @test a[Block(1)[1]] == a[1]
         @test a[Block(1)[1:1]] == a[1:1]
-        A = PseudoBlockArray(randn(3,3), [1,2], [1,2])
+        A = BlockedArray(randn(3,3), [1,2], [1,2])
         @test A[Block(1)[1], Block(1)[1]] == A[Block(1,1)[1,1]] == A[1,1]
         @test A[Block(1)[1:1], Block(1)[1:1]] == A[Block(1,1)[1:1,1:1]] == A[1:1,1:1]
         @test A[Block(1)[1:1], Block(1)[1]] == BlockArray(A)[Block(1)[1:1], Block(1)[1]] == A[1:1,1]
@@ -717,12 +717,12 @@ end
     end
 
     @testset "permutedims" begin
-        for a in (BlockArray(randn(3), [1,2]), PseudoBlockArray(randn(3), [1,2]))
+        for a in (BlockArray(randn(3), [1,2]), BlockedArray(randn(3), [1,2]))
             @test permutedims(a) == permutedims(Vector(a))
             blockisequal(axes(permutedims(a),2), axes(a,1))
         end
 
-        for A in (BlockArray(randn(3,6), [1,2], 1:3), PseudoBlockArray(randn(3,6), [1,2], 1:3))
+        for A in (BlockArray(randn(3,6), [1,2], 1:3), BlockedArray(randn(3,6), [1,2], 1:3))
             @test permutedims(A) == permutedims(Matrix(A))
             blockisequal(axes(permutedims(A)), axes(A))
         end
@@ -763,14 +763,14 @@ end
     @testset "Array indexing" begin
         a = randn(6)
         A = randn(6,3)
-        @test a[blockedrange(1:3)] isa PseudoBlockVector
-        @test A[blockedrange(1:3),:] isa PseudoBlockMatrix
-        @test A[:,blockedrange(1:2)] isa PseudoBlockMatrix
-        @test A[blockedrange(1:3),blockedrange(1:2)] isa PseudoBlockMatrix
+        @test a[blockedrange(1:3)] isa BlockedVector
+        @test A[blockedrange(1:3),:] isa BlockedMatrix
+        @test A[:,blockedrange(1:2)] isa BlockedMatrix
+        @test A[blockedrange(1:3),blockedrange(1:2)] isa BlockedMatrix
     end
 
     @testset "resize!" begin
-        a = PseudoBlockVector(collect(1:6), 1:3)
+        a = BlockedVector(collect(1:6), 1:3)
         b = resize!(a,Block(2))
         @test b == 1:3
         @test_throws BoundsError a[4] # length of a.blocks has changed
@@ -787,8 +787,8 @@ end
 
     @testset "empty indexing of vectors" begin
         a = mortar([1:3, 2:6])
-        @test size(a[:,Block.(1:0)]) == size(PseudoBlockVector(a)[:,Block.(1:0)]) == (8,0)
-        @test size(a[:,Block.(1:1)]) == size(PseudoBlockVector(a)[:,Block.(1:1)]) == size(a[:,Block(1)]) == (8,1)
+        @test size(a[:,Block.(1:0)]) == size(BlockedVector(a)[:,Block.(1:0)]) == (8,0)
+        @test size(a[:,Block.(1:1)]) == size(BlockedVector(a)[:,Block.(1:1)]) == size(a[:,Block(1)]) == (8,1)
         @test_throws BoundsError a[:,Block.(1:2)]
         @test size(a[:,1]) == (8,)
     end

--- a/test/test_blockbanded.jl
+++ b/test/test_blockbanded.jl
@@ -45,7 +45,7 @@ using BandedMatrices: _BandedMatrix
 
     @testset "Block-BandedMatrix" begin
         a = blockedrange(1:5)
-        B = _BandedMatrix(PseudoBlockArray(randn(5,length(a)),(Base.OneTo(5),a)), a, 3, 1)
+        B = _BandedMatrix(BlockedArray(randn(5,length(a)),(Base.OneTo(5),a)), a, 3, 1)
         @test blockcolsupport(B,Block(1)) == Block.(1:3)
         @test blockcolsupport(B,Block(3)) == Block.(2:4)
         @test blockrowsupport(B,Block(1)) == Block.(1:2)
@@ -66,8 +66,8 @@ using BandedMatrices: _BandedMatrix
         end
     end
 
-    @testset "Banded PseudoMatrix" begin
-        A = PseudoBlockArray(brand(5,4,1,2), [3,2], [2,2])
+    @testset "Banded BlockedMatrix" begin
+        A = BlockedArray(brand(5,4,1,2), [3,2], [2,2])
         @test bandwidths(A) == (1,2)
         @test BandedMatrix(A) == A
     end

--- a/test/test_blockbroadcast.jl
+++ b/test/test_blockbroadcast.jl
@@ -41,22 +41,22 @@ using StaticArrays
         end
     end
 
-    @testset "PseudoBlockArray" begin
-        A = PseudoBlockArray(randn(6), 1:3)
+    @testset "BlockedArray" begin
+        A = BlockedArray(randn(6), 1:3)
 
-        @test BlockArrays.BroadcastStyle(typeof(A)) == BlockArrays.PseudoBlockStyle{1}()
+        @test BlockArrays.BroadcastStyle(typeof(A)) == BlockArrays.BlockedStyle{1}()
 
 
         @test exp.(A) == exp.(Vector(A))
         @test axes(A,1).lasts == axes(exp.(A),1).lasts
 
-        @test A+A isa PseudoBlockArray
+        @test A+A isa BlockedArray
         @test axes(A + A,1).lasts == axes(A .+ A,1).lasts == axes(A,1).lasts
         @test axes(A .+ 1,1).lasts == axes(A,1).lasts
 
-        B = PseudoBlockArray(randn(6,6), 1:3,1:3)
+        B = BlockedArray(randn(6,6), 1:3,1:3)
 
-        @test BlockArrays.BroadcastStyle(typeof(B)) == BlockArrays.PseudoBlockStyle{2}()
+        @test BlockArrays.BroadcastStyle(typeof(B)) == BlockArrays.BlockedStyle{2}()
 
         @test exp.(B) == exp.(Matrix(B))
         @test axes(B) == axes(exp.(B))
@@ -67,16 +67,16 @@ using StaticArrays
         @test A .+ 1 .+ B == Vector(A) .+ 1 .+ B == Vector(A) .+ 1 .+ Matrix(B)
 
         @testset "preserve structure" begin
-             x = PseudoBlockArray(1:6, Fill(3,2))
-             @test x + x isa PseudoBlockVector{Int,<:AbstractRange}
-             @test 2x + x isa PseudoBlockVector{Int,<:AbstractRange}
-             @test 2 .* (x .+ 1) isa PseudoBlockVector{Int,<:AbstractRange}
+             x = BlockedArray(1:6, Fill(3,2))
+             @test x + x isa BlockedVector{Int,<:AbstractRange}
+             @test 2x + x isa BlockedVector{Int,<:AbstractRange}
+             @test 2 .* (x .+ 1) isa BlockedVector{Int,<:AbstractRange}
         end
     end
 
     @testset "Mixed" begin
         A = BlockArray(randn(6), 1:3)
-        B = PseudoBlockArray(randn(6), 1:3)
+        B = BlockedArray(randn(6), 1:3)
 
         @test A + B isa BlockArray
         @test B + A isa BlockArray
@@ -87,8 +87,8 @@ using StaticArrays
 
         @test A + C isa BlockVector{Float64}
         @test C + A isa BlockVector{Float64}
-        @test B + C isa PseudoBlockVector{Float64}
-        @test C + B isa PseudoBlockVector{Float64}
+        @test B + C isa BlockedVector{Float64}
+        @test C + B isa BlockedVector{Float64}
 
         @test blocksize(A+C) == blocksize(C+A) == blocksize(A)
         @test blocksize(B+C) == blocksize(C+B) == blocksize(B)
@@ -184,7 +184,7 @@ using StaticArrays
         @test axes(b) ≡ axes(b .+ b)
         @test axes(a .+ b,1) ≡ BlockArrays._BlockedUnitRange(1, 1:6)
 
-        @test a .+ PseudoBlockArray(b) == PseudoBlockArray(a) .+ b
+        @test a .+ BlockedArray(b) == BlockedArray(a) .+ b
 
         A = BlockArray(randn(6), 1:3)
         @test blockisequal(axes(A .* Zeros(6)), axes(A .* zeros(6)))
@@ -201,50 +201,50 @@ using StaticArrays
     end
 
     @testset "adjtrans" begin
-        a = PseudoBlockArray(randn(6), [2,3])
+        a = BlockedArray(randn(6), [2,3])
         b = BlockArray(a)
 
-        @test Base.BroadcastStyle(typeof(a')) isa BlockArrays.PseudoBlockStyle{2}
+        @test Base.BroadcastStyle(typeof(a')) isa BlockArrays.BlockedStyle{2}
         @test Base.BroadcastStyle(typeof(b')) isa BlockArrays.BlockStyle{2}
 
         @test exp.(a') == exp.(b') == exp.(transpose(a)) == exp.(transpose(b)) == exp.(Vector(a)')
-        @test exp.(a') isa PseudoBlockArray
-        @test exp.(transpose(a)) isa PseudoBlockArray
+        @test exp.(a') isa BlockedArray
+        @test exp.(transpose(a)) isa BlockedArray
         @test exp.(b') isa BlockArray
         @test exp.(transpose(b)) isa BlockArray
     end
 
     @testset "subarray" begin
         @testset "vector" begin
-            a = PseudoBlockArray(randn(6), [2,3])
+            a = BlockedArray(randn(6), [2,3])
             b = BlockArray(a)
 
             v = view(a,Block.(1:2))
             w = view(b,Block.(1:2))
 
-            @test Base.BroadcastStyle(typeof(v)) isa BlockArrays.PseudoBlockStyle{1}
+            @test Base.BroadcastStyle(typeof(v)) isa BlockArrays.BlockedStyle{1}
             @test Base.BroadcastStyle(typeof(w)) isa BlockArrays.BlockStyle{1}
 
             @test exp.(v) == exp.(w) == exp.(Vector(v))
-            @test exp.(v) isa PseudoBlockArray
+            @test exp.(v) isa BlockedArray
             @test exp.(w) isa BlockArray
         end
 
         @testset "matrix" begin
-            A = PseudoBlockArray(randn(6,3), [2,3],[1,2])
+            A = BlockedArray(randn(6,3), [2,3],[1,2])
             B = BlockArray(A)
 
             v = view(A,1:3,Block.(1:2))
             w = view(B,1:3,Block.(1:2))
 
-            @test Base.BroadcastStyle(typeof(v)) isa BlockArrays.PseudoBlockStyle{2}
+            @test Base.BroadcastStyle(typeof(v)) isa BlockArrays.BlockedStyle{2}
             @test Base.BroadcastStyle(typeof(w)) isa BlockArrays.BlockStyle{2}
 
             @test exp.(v) == exp.(w) == exp.(Matrix(v))
-            @test exp.(v) isa PseudoBlockArray
+            @test exp.(v) isa BlockedArray
             @test exp.(w) isa BlockArray
 
-            @test Base.BroadcastStyle(typeof(view(A,Block.(1:2),Block.(1:2)))) isa BlockArrays.PseudoBlockStyle{2}
+            @test Base.BroadcastStyle(typeof(view(A,Block.(1:2),Block.(1:2)))) isa BlockArrays.BlockedStyle{2}
             @test Base.BroadcastStyle(typeof(view(B,Block.(1:2),Block.(1:2)))) isa BlockArrays.BlockStyle{2}
         end
     end

--- a/test/test_blockdeque.jl
+++ b/test/test_blockdeque.jl
@@ -5,7 +5,7 @@ using BlockArrays, Test
 @testset "block dequeue" begin
     @testset "blockappend!(::BlockVector, _)" begin
         @testset for compatible in [false, true],
-            srctype in [:BlockVector, :PseudoBlockVector, :PseudoBlockVector2, :Vector]
+            srctype in [:BlockVector, :BlockedVector, :BlockedVector2, :Vector]
 
             dest = mortar([[1, 2, 3], [4, 5]])
 
@@ -17,10 +17,10 @@ using BlockArrays, Test
             end
             if srctype === :BlockVector
                 src = mortar([T[6, 7], T[8, 9]])
-            elseif srctype === :PseudoBlockVector
-                src = PseudoBlockVector(T[6:9;], [4])
-            elseif srctype === :PseudoBlockVector2
-                src = PseudoBlockVector(T[6:9;], [2, 2])
+            elseif srctype === :BlockedVector
+                src = BlockedVector(T[6:9;], [4])
+            elseif srctype === :BlockedVector2
+                src = BlockedVector(T[6:9;], [2, 2])
             elseif srctype === :Vector
                 src = T[6:9;]
             else
@@ -42,7 +42,7 @@ using BlockArrays, Test
             end
 
             src[1] = 666
-            if compatible && srctype !== :PseudoBlockVector2
+            if compatible && srctype !== :BlockedVector2
                 @test dest[6] == 666
             else
                 @test dest[6] == 6

--- a/test/test_blockindices.jl
+++ b/test/test_blockindices.jl
@@ -858,7 +858,7 @@ end
 @testset "eachblock" begin
     v = Array(reshape(1:6, (2, 3)))
     A = BlockArray(v, [1,1], [2,1])
-    B = PseudoBlockArray(v, [1,1], [2,1])
+    B = BlockedArray(v, [1,1], [2,1])
 
     # test that contents match
     @test collect(eachblock(A)) == collect(eachblock(B)) == A.blocks

--- a/test/test_blocklinalg.jl
+++ b/test/test_blocklinalg.jl
@@ -24,11 +24,11 @@ bview(a, b) = Base.invoke(view, Tuple{AbstractArray,Any}, a, b)
         @test V*view(b,4:6) ≈ V*b[4:6] ≈ Matrix(V) * b[4:6]
         @test all(muladd!(1.0,V,view(b,4:6),0.0,similar(b,2)) .=== BLAS.gemv!('N', 1.0, Matrix(V), b[4:6], 0.0, similar(b,2)))
 
-        @test A*b isa PseudoBlockVector
+        @test A*b isa BlockedVector
         @test A*BlockVector(b,1:3) isa BlockVector
         @test blockisequal(axes(A*b,1), axes(A,1))
         @test A*b ≈ Matrix(A)*b ≈ A*BlockVector(b,1:3)
-        @test all(A*b .=== A*PseudoBlockVector(b,1:3))
+        @test all(A*b .=== A*BlockedVector(b,1:3))
 
         V = view(A, Block.(1:2), Block(3))
         @test MemoryLayout(V) isa BlockLayout{DenseColumnMajor,DenseColumnMajor}
@@ -49,8 +49,8 @@ bview(a, b) = Base.invoke(view, Tuple{AbstractArray,Any}, a, b)
         @test A^2 ≈ A*A ≈ Matrix(A)^2
     end
 
-    @testset "PseudoBlockArray matrix * vector" begin
-        A = PseudoBlockArray{Float64}(randn(6,6), fill(2,3), 1:3)
+    @testset "BlockedArray matrix * vector" begin
+        A = BlockedArray{Float64}(randn(6,6), fill(2,3), 1:3)
         b = randn(6)
         @test MemoryLayout(A) isa DenseColumnMajor
         V = view(A,Block(2,3))
@@ -60,10 +60,10 @@ bview(a, b) = Base.invoke(view, Tuple{AbstractArray,Any}, a, b)
         @test V*view(b,4:6) ≈ V*b[4:6] ≈ Matrix(V) * b[4:6]
         @test all(muladd!(1.0,V,view(b,4:6),0.0,similar(b,2)) .=== BLAS.gemv!('N', 1.0, Matrix(V), b[4:6], 0.0, similar(b,2)))
 
-        @test A*b isa PseudoBlockVector
+        @test A*b isa BlockedVector
         @test blockisequal(axes(A*b,1), axes(A,1))
         @test A*b ≈ Matrix(A)*b ≈ A*BlockVector(b,1:3)
-        @test all(A*b .=== A*PseudoBlockVector(b,1:3))
+        @test all(A*b .=== A*BlockedVector(b,1:3))
 
         V = view(A, Block.(1:2), Block(3))
         @test MemoryLayout(V) isa ColumnMajor
@@ -90,10 +90,10 @@ bview(a, b) = Base.invoke(view, Tuple{AbstractArray,Any}, a, b)
 
         @test A*B isa BlockMatrix
         @test A*B ≈ Matrix(A)*B ≈ A*Matrix(B) ≈ Matrix(A)*Matrix(B) ≈
-                PseudoBlockArray(A)*B ≈ A*PseudoBlockArray(B)
+                BlockedArray(A)*B ≈ A*BlockedArray(B)
 
-        @test all(PseudoBlockArray(A)*PseudoBlockArray(B) .=== PseudoBlockArray(A)*Matrix(B) .===
-                    Matrix(A)*PseudoBlockArray(B) .=== Matrix(A)*Matrix(B))
+        @test all(BlockedArray(A)*BlockedArray(B) .=== BlockedArray(A)*Matrix(B) .===
+                    Matrix(A)*BlockedArray(B) .=== Matrix(A)*Matrix(B))
     end
 
     @testset "BlockMatrix * BlockVector" begin
@@ -170,7 +170,7 @@ bview(a, b) = Base.invoke(view, Tuple{AbstractArray,Any}, a, b)
         @test mul(UpperTriangular(V),b[2:3]) ≈ UpperTriangular(V)*b[2:3] ≈ UpperTriangular(Matrix(V))*b[2:3]
 
         @testset "bug in view pointer" begin
-            b2 = PseudoBlockArray(b,(axes(A,1),))
+            b2 = BlockedArray(b,(axes(A,1),))
             @test Base.unsafe_convert(Ptr{Float64}, b) == Base.unsafe_convert(Ptr{Float64}, b2) ==
                     Base.unsafe_convert(Ptr{Float64}, view(b2,Block(1)))
         end
@@ -200,15 +200,15 @@ bview(a, b) = Base.invoke(view, Tuple{AbstractArray,Any}, a, b)
     end
 
     @testset "inv" begin
-        A = PseudoBlockArray{Float64}(randn(6,6), fill(2,3), 1:3)
+        A = BlockedArray{Float64}(randn(6,6), fill(2,3), 1:3)
         F = factorize(A)
 
         B = randn(6,6)
         @test ldiv!(F, copy(B)) ≈ Matrix(A) \ B
-        B̃ = PseudoBlockArray(copy(B),1:3,fill(2,3))
+        B̃ = BlockedArray(copy(B),1:3,fill(2,3))
         @test ldiv!(F, B̃) ≈ A\B ≈ Matrix(A) \ B
 
-        @test inv(A) isa PseudoBlockArray
+        @test inv(A) isa BlockedArray
         @test inv(A) ≈ inv(Matrix(A))
         @test inv(A)*A ≈ Matrix(I,6,6)
 
@@ -244,9 +244,9 @@ bview(a, b) = Base.invoke(view, Tuple{AbstractArray,Any}, a, b)
 
     @testset "5-arg mul! (#174)" begin
         A = BlockArray(rand(4, 5), [1,3], [2,3])
-        Ã = PseudoBlockArray(A)
+        Ã = BlockedArray(A)
         B = BlockArray(rand(5, 3), [2,3], [1,1,1])
-        B̃ = PseudoBlockArray(B)
+        B̃ = BlockedArray(B)
         C = randn(4,3)
         @test mul!(view(copy(C),:,1:3), A, B, 1, 2) ≈ A*B + 2C
         @test mul!(view(copy(C),:,1:3), A, B̃, 1, 2) ≈ A*B + 2C

--- a/test/test_blockrange.jl
+++ b/test/test_blockrange.jl
@@ -82,11 +82,11 @@ end
 	@test Block(Bi) == B
 	@test collect(Bi) == [BlockIndex((2,), 2), BlockIndex((2,), 3)]
 
-	A = PseudoBlockArray(rand(4), [1,3])
+	A = BlockedArray(rand(4), [1,3])
 
 	@test A[Bi] == A[3:4]
 
-    A = PseudoBlockArray(rand(4,4), [1,3],[2,2])
+    A = BlockedArray(rand(4,4), [1,3],[2,2])
 	@test A[Bi,Block(1)] == A[3:4,1:2]
     @test A[Bi,Block(1)[2:2]] == A[3:4,2:2]
 

--- a/test/test_blockreduce.jl
+++ b/test/test_blockreduce.jl
@@ -6,7 +6,7 @@ using BlockArrays, Test
     x = mortar([rand(3), rand(2)])
     @test foldl(push!, x; init = []) == collect(x)
 
-    x = PseudoBlockVector(rand(3), [1, 2])
+    x = BlockedVector(rand(3), [1, 2])
     @test foldl(push!, x; init = []) == collect(x)
 end
 
@@ -14,7 +14,7 @@ end
     x = mortar([rand(Int, 3), rand(Int, 2)])
     @test reduce(+, x) == sum(collect(x))
 
-    x = PseudoBlockVector(rand(Int, 3), [1, 2])
+    x = BlockedVector(rand(Int, 3), [1, 2])
     @test reduce(+, x) == sum(collect(x))
 end
 

--- a/test/test_blocks.jl
+++ b/test/test_blocks.jl
@@ -17,9 +17,9 @@ using Test, BlockArrays
         @test blocks(mortar(matrix_blocks)) === matrix_blocks
     end
 
-    @testset "blocks(::PseudoBlockVector)" begin
+    @testset "blocks(::BlockedVector)" begin
         v0 = rand(3)
-        vb = PseudoBlockArray(v0, [1, 2])
+        vb = BlockedArray(v0, [1, 2])
         @test size(blocks(vb)) == (2,)
         blocks(vb)[1] = [123]
         @test v0[1] == 123
@@ -27,16 +27,16 @@ using Test, BlockArrays
 
         # toplevel = true:
         str = sprint(show, "text/plain", blocks(vb))
-        @test occursin("blocks of PseudoBlockArray of", str)
+        @test occursin("blocks of BlockedArray of", str)
 
         # toplevel = false:
         str = sprint(show, "text/plain", view(blocks(vb), 1:1))
-        @test occursin("::BlocksView{…,::PseudoBlockArray{…,", str)
+        @test occursin("::BlocksView{…,::BlockedArray{…,", str)
     end
 
-    @testset "blocks(::PseudoBlockMatrix)" begin
+    @testset "blocks(::BlockedMatrix)" begin
         m0 = rand(2, 4)
-        mb = PseudoBlockArray(m0, [1, 1], [2, 1, 1])
+        mb = BlockedArray(m0, [1, 1], [2, 1, 1])
         @test size(blocks(mb)) == (2, 3)
         blocks(mb)[1, 1] = [123 456]
         @test m0[1, 1] == 123
@@ -50,11 +50,11 @@ using Test, BlockArrays
 
         # toplevel = true:
         str = sprint(show, "text/plain", blocks(mb))
-        @test occursin("blocks of PseudoBlockArray of", str)
+        @test occursin("blocks of BlockedArray of", str)
 
         # toplevel = false:
         str = sprint(show, "text/plain", view(blocks(mb), 1:1, 1:1))
-        @test occursin("::BlocksView{…,::PseudoBlockArray{…,", str)
+        @test occursin("::BlocksView{…,::BlockedArray{…,", str)
     end
 
     @testset "blocks(::Vector)" begin

--- a/test/test_blockviews.jl
+++ b/test/test_blockviews.jl
@@ -8,7 +8,7 @@ bview(a, b) = Base.invoke(view, Tuple{AbstractArray,Any}, a, b)
 
 @testset "Block Views" begin
     @testset "block slice" begin
-        A = PseudoBlockArray(1:6,1:3)
+        A = BlockedArray(1:6,1:3)
         b = parentindices(bview(A, Block(2)))[1] # A BlockSlice
 
         @test first(b) == 2
@@ -34,7 +34,7 @@ bview(a, b) = Base.invoke(view, Tuple{AbstractArray,Any}, a, b)
         # backend tests
         @test_throws ArgumentError Base.to_index(A, Block(1))
 
-        A = PseudoBlockArray(collect(1:6), 1:3)
+        A = BlockedArray(collect(1:6), 1:3)
         @test view(A, Block(2)) == [2,3]
         view(A, Block(2))[2] = -1
         @test A[3] == -1
@@ -43,7 +43,7 @@ bview(a, b) = Base.invoke(view, Tuple{AbstractArray,Any}, a, b)
         # backend tests
         @test_throws ArgumentError Base.to_index(A, Block(1))
 
-        A = PseudoBlockArray(reshape(collect(1:(6*12)),6,12), 1:3, 3:5)
+        A = BlockedArray(reshape(collect(1:(6*12)),6,12), 1:3, 3:5)
         V = view(A, Block(2), Block(3))
         @test size(V) == (2, 5)
         V[1,1] = -1
@@ -60,7 +60,7 @@ bview(a, b) = Base.invoke(view, Tuple{AbstractArray,Any}, a, b)
 
         # test mixed blocks and other indices
         @test view(A, Block(2), 2) == [8,9]
-        @test similar(A, (Base.OneTo(5), axes(A,2))) isa PseudoBlockArray{Int}
+        @test similar(A, (Base.OneTo(5), axes(A,2))) isa BlockedArray{Int}
         @test view(A, Block(2), :) == A[2:3,:]
 
         @test view(A, 2, Block(1)) == [2,8,14]
@@ -77,7 +77,7 @@ bview(a, b) = Base.invoke(view, Tuple{AbstractArray,Any}, a, b)
         @test_throws BlockBoundsError view(V, Block(2,1))
 
 
-        A = PseudoBlockArray(reshape(collect(1:(6^3)),6,6,6), 1:3, 1:3, 1:3)
+        A = BlockedArray(reshape(collect(1:(6^3)),6,6,6), 1:3, 1:3, 1:3)
         V = view(A, Block(2), Block(3), Block(1))
         @test size(V) == (2, 3, 1)
         V[1,1,1] = -3
@@ -124,7 +124,7 @@ bview(a, b) = Base.invoke(view, Tuple{AbstractArray,Any}, a, b)
         @test unsafe_load(pointer(V)) == V[1,1]
 
 
-        A = PseudoBlockArray(reshape(Vector{Float64}(1:(6^2)),6,6), 1:3, 1:3)
+        A = BlockedArray(reshape(Vector{Float64}(1:(6^2)),6,6), 1:3, 1:3)
 
         V = view(A, Block(1,2))
         @test Base.unsafe_convert(Ptr{Float64}, V) == Base.unsafe_convert(Ptr{Float64}, view(A.blocks, 1:1, 2:3))
@@ -140,7 +140,7 @@ bview(a, b) = Base.invoke(view, Tuple{AbstractArray,Any}, a, b)
     end
 
     @testset "block indx range of block range" begin
-        A = PseudoBlockArray(collect(1:6), 1:3)
+        A = BlockedArray(collect(1:6), 1:3)
         V = view(A, Block.(1:2))
         @test V == 1:3
         @test axes(V,1) isa BlockArrays.BlockedOneTo
@@ -163,29 +163,29 @@ bview(a, b) = Base.invoke(view, Tuple{AbstractArray,Any}, a, b)
     end
 
     @testset "subarray implements block interface" begin
-        A = PseudoBlockArray(reshape(Vector{Float64}(1:(6^2)),6,6), 1:3, 1:3)
+        A = BlockedArray(reshape(Vector{Float64}(1:(6^2)),6,6), 1:3, 1:3)
 
         V = view(A, Block(2,3))
-        @test PseudoBlockArray(V) isa PseudoBlockArray
+        @test BlockedArray(V) isa BlockedArray
         @test BlockArray(V) isa BlockArray
-        @test PseudoBlockArray(V) == BlockArray(V) == V
+        @test BlockedArray(V) == BlockArray(V) == V
 
         V = view(A, Block(2), Block.(2:3))
-        @test PseudoBlockArray(V) isa PseudoBlockArray
+        @test BlockedArray(V) isa BlockedArray
         @test BlockArray(V) isa BlockArray
-        @test PseudoBlockArray(V) == BlockArray(V) == V
+        @test BlockedArray(V) == BlockArray(V) == V
         @test blocksize(V) == (1,2)
 
         V = view(A, Block.(2:3), Block(3))
-        @test PseudoBlockArray(V) isa PseudoBlockArray
+        @test BlockedArray(V) isa BlockedArray
         @test BlockArray(V) isa BlockArray
-        @test PseudoBlockArray(V) == BlockArray(V) == V
+        @test BlockedArray(V) == BlockArray(V) == V
         @test blocksize(V) == (2,1)
 
         V = view(A, Block.(2:3), Block.(1:2))
-        @test PseudoBlockArray(V) isa PseudoBlockArray
+        @test BlockedArray(V) isa BlockedArray
         @test BlockArray(V) isa BlockArray
-        @test PseudoBlockArray(V) == BlockArray(V) == V
+        @test BlockedArray(V) == BlockArray(V) == V
         @test blocksize(V) == (2,2)
     end
 
@@ -209,8 +209,8 @@ bview(a, b) = Base.invoke(view, Tuple{AbstractArray,Any}, a, b)
         A = BlockArray(randn(6), 1:3)
         @test A[Block.(2:3)] isa BlockArray
         @test A[Block.(2:3)] == A[2:end]
-        A = PseudoBlockArray(randn(6), 1:3)
-        @test A[Block.(2:3)] isa PseudoBlockArray
+        A = BlockedArray(randn(6), 1:3)
+        @test A[Block.(2:3)] isa BlockedArray
         @test A[Block.(2:3)] == A[2:end]
     end
 
@@ -263,39 +263,39 @@ bview(a, b) = Base.invoke(view, Tuple{AbstractArray,Any}, a, b)
 
     @testset "sub_materialize cases" begin
         a = BlockArray(randn(6), 1:3)
-        b = PseudoBlockArray(randn(6), 1:3)
+        b = BlockedArray(randn(6), 1:3)
         @test a[Block.(1:2)] isa BlockArray
-        @test b[Block.(1:2)] isa PseudoBlockArray
+        @test b[Block.(1:2)] isa BlockedArray
         @test a[1:3] isa Array
         @test b[1:3] isa Array
         A = BlockArray(randn(6,6), 1:3, fill(3,2))
-        B = PseudoBlockArray(randn(6,6), 1:3, fill(3,2))
+        B = BlockedArray(randn(6,6), 1:3, fill(3,2))
         @test A[Block.(1:2),Block.(1:2)] isa BlockArray
-        @test B[Block.(1:2),Block.(1:2)] isa PseudoBlockArray
-        @test A[Block.(1:2),1:3] isa PseudoBlockArray
-        @test B[Block.(1:2),1:3] isa PseudoBlockArray
-        @test A[1:3,Block.(1:2)] isa PseudoBlockArray
-        @test B[1:3,Block.(1:2)] isa PseudoBlockArray
+        @test B[Block.(1:2),Block.(1:2)] isa BlockedArray
+        @test A[Block.(1:2),1:3] isa BlockedArray
+        @test B[Block.(1:2),1:3] isa BlockedArray
+        @test A[1:3,Block.(1:2)] isa BlockedArray
+        @test B[1:3,Block.(1:2)] isa BlockedArray
         @test A[Block.(1:2),:] isa BlockArray
-        @test B[Block.(1:2),:] isa PseudoBlockArray
+        @test B[Block.(1:2),:] isa BlockedArray
         @test blockisequal(axes(A,2),axes(A[Block.(1:2),:],2))
         @test blockisequal(axes(B,2),axes(B[Block.(1:2),:],2))
         @test A[:,Block.(1:2)] isa BlockArray
-        @test B[:,Block.(1:2)] isa PseudoBlockArray
+        @test B[:,Block.(1:2)] isa BlockedArray
         @test blockisequal(axes(A,1),axes(A[:,Block.(1:2)],1))
         @test blockisequal(axes(B,1),axes(B[:,Block.(1:2)],1))
         @test A[:,:] isa BlockArray
-        @test B[:,:] isa PseudoBlockArray
+        @test B[:,:] isa BlockedArray
         @test blockisequal(axes(A),axes(A[:,:]))
         @test blockisequal(axes(B),axes(B[:,:]))
         @test A[1:3,1:3] isa Array
         @test B[1:3,1:3] isa Array
         A = BlockArray(randn(6,6,6), 1:3, fill(3,2),1:3)
-        B = PseudoBlockArray(randn(6,6,6), 1:3, fill(3,2),1:3)
+        B = BlockedArray(randn(6,6,6), 1:3, fill(3,2),1:3)
         @test A[Block.(1:2),Block.(1:2),Block.(1:2)] isa BlockArray
-        @test B[Block.(1:2),Block.(1:2),Block.(1:2)] isa PseudoBlockArray
+        @test B[Block.(1:2),Block.(1:2),Block.(1:2)] isa BlockedArray
         @test A[1:3,Block.(1:2),1:3] isa BlockArray
-        @test B[1:3,Block.(1:2),1:3] isa PseudoBlockArray
+        @test B[1:3,Block.(1:2),1:3] isa BlockedArray
     end
 
     @testset "BlockArray BlockRange view" begin


### PR DESCRIPTION
Rename `PseudoBlockArray` to `BlockedArray`, as discussed in #255. Closes #400.