### PR TITLE
Generalize BlockArray/BlockedArray to non-integer block lengths

### DIFF
--- a/src/blockarray.jl
+++ b/src/blockarray.jl
@@ -242,7 +242,7 @@ julia> B
     initialized_blocks_BlockArray(R, block_sizes...)
 
 
-@inline BlockArray{T,N,R,BS}(::UndefInitializer, sizes::NTuple{N,Int}) where {T, N, R<:AbstractArray{<:AbstractArray{T,N},N}, BS<:Tuple{Vararg{AbstractUnitRange{<:Integer},N}}} =
+@inline BlockArray{T,N,R,BS}(::UndefInitializer, sizes::Tuple{Vararg{Integer, N}}) where {T, N, R<:AbstractArray{<:AbstractArray{T,N},N}, BS<:Tuple{Vararg{AbstractUnitRange{<:Integer},N}}} =
     BlockArray{T,N,R,BS}(undef, convert(BS, map(Base.OneTo, sizes)))
 
 function BlockArray{T}(arr::AbstractArray{V, N}, block_sizes::Vararg{AbstractVector{<:Integer}, N}) where {T,V,N}

--- a/src/blockarray.jl
+++ b/src/blockarray.jl
@@ -553,6 +553,8 @@ Base.reshape(block_array::BlockArray, axes::Tuple{Union{Integer,Base.OneTo}, Var
     reshape(BlockedArray(block_array), axes)
 Base.reshape(block_array::BlockArray, dims::Tuple{Vararg{Union{Integer,Colon}}}) =
     reshape(BlockedArray(block_array), dims)
+Base.reshape(block_array::BlockArray, dims::Tuple{Vararg{Union{Int,Colon}}}) =
+    reshape(BlockedArray(block_array), dims)
 
 """
     resize!(a::BlockVector, N::Block) -> BlockedVector

--- a/src/blockarray.jl
+++ b/src/blockarray.jl
@@ -51,18 +51,18 @@ const undef_blocks = UndefBlocksInitializer()
 function _BlockArray end
 
 """
-    BlockArray{T, N, R<:AbstractArray{<:AbstractArray{T,N},N}, BS<:NTuple{N,AbstractUnitRange{Int}}} <: AbstractBlockArray{T, N}
+    BlockArray{T, N, R<:AbstractArray{<:AbstractArray{T,N},N}, BS<:Tuple{Vararg{AbstractUnitRange{<:Integer},N}}} <: AbstractBlockArray{T, N}
 
 A `BlockArray` is an array where each block is stored contiguously. This means that insertions and retrieval of blocks
 can be very fast and non allocating since no copying of data is needed.
 
 In the type definition, `R` defines the array type that holds the blocks, for example `Matrix{Matrix{Float64}}`.
 """
-struct BlockArray{T, N, R <: AbstractArray{<:AbstractArray{T,N},N}, BS<:NTuple{N,AbstractUnitRange{Int}}} <: AbstractBlockArray{T, N}
+struct BlockArray{T, N, R <: AbstractArray{<:AbstractArray{T,N},N}, BS <: Tuple{Vararg{AbstractUnitRange{<:Integer},N}}} <: AbstractBlockArray{T, N}
     blocks::R
     axes::BS
 
-    global @inline function _BlockArray(blocks::R, block_axes::BS) where {T, N, R<:AbstractArray{<:AbstractArray{T,N},N}, BS<:NTuple{N,AbstractUnitRange{Int}}}
+    global @inline function _BlockArray(blocks::R, block_axes::BS) where {T, N, R<:AbstractArray{<:AbstractArray{T,N},N}, BS<:Tuple{Vararg{AbstractUnitRange{<:Integer},N}}}
         Base.require_one_based_indexing(block_axes...)
         Base.require_one_based_indexing(blocks)
         new{T, N, R, BS}(blocks, block_axes)
@@ -74,7 +74,7 @@ end
     _BlockArray(blocks, map(blockedrange, block_axes))
 
 # support non-concrete eltypes in blocks
-_BlockArray(blocks::R, block_axes::BS) where {N, R<:AbstractArray{<:AbstractArray{V,N} where V,N}, BS<:NTuple{N,AbstractUnitRange{Int}}} =
+_BlockArray(blocks::R, block_axes::BS) where {N, R<:AbstractArray{<:AbstractArray{V,N} where V,N}, BS<:Tuple{Vararg{AbstractUnitRange{<:Integer},N}}} =
     _BlockArray(convert(AbstractArray{AbstractArray{mapreduce(eltype,promote_type,blocks),N},N}, blocks), block_axes)
 _BlockArray(blocks::R, block_sizes::Vararg{AbstractVector{<:Integer}, N}) where {N, R<:AbstractArray{<:AbstractArray{<:Any,N},N}} =
     _BlockArray(convert(AbstractArray{AbstractArray{mapreduce(eltype,promote_type,blocks),N},N}, blocks), block_sizes...)
@@ -90,7 +90,7 @@ const BlockVecOrMat{T, R} = Union{BlockMatrix{T, R}, BlockVector{T, R}}
 @inline _BlockArray(::Type{R}, block_sizes::Vararg{AbstractVector{<:Integer}, N}) where {T, N, R<:AbstractArray{<:AbstractArray{T,N},N}} =
     _BlockArray(R, map(blockedrange,block_sizes))
 
-function _BlockArray(::Type{R}, baxes::NTuple{N,AbstractUnitRange{Int}}) where {T, N, R<:AbstractArray{<:AbstractArray{T,N},N}}
+function _BlockArray(::Type{R}, baxes::Tuple{Vararg{AbstractUnitRange{<:Integer},N}}) where {T, N, R<:AbstractArray{<:AbstractArray{T,N},N}}
     n_blocks = map(blocklength,baxes)
     blocks = R(undef, n_blocks)
     _BlockArray(blocks, baxes)
@@ -186,7 +186,7 @@ See also [`undef_blocks`](@ref), [`UndefBlocksInitializer`](@ref)
 @inline BlockArray{T,N,R}(::UndefBlocksInitializer, block_sizes::Vararg{AbstractVector{<:Integer}, N}) where {T, N, R<:AbstractArray{<:AbstractArray{T,N},N}} =
     undef_blocks_BlockArray(R, block_sizes...)
 
-function initialized_blocks_BlockArray(::Type{R}, baxes::NTuple{N,AbstractUnitRange{Int}}) where R<:AbstractArray{V,N} where {T,N,V<:AbstractArray{T,N}}
+function initialized_blocks_BlockArray(::Type{R}, baxes::Tuple{Vararg{AbstractUnitRange{<:Integer},N}}) where R<:AbstractArray{V,N} where {T,N,V<:AbstractArray{T,N}}
     blocks = map(Iterators.product(map(x -> blockaxes(x,1), baxes)...)) do block_index
         indices = map((x,y) -> x[y], baxes, block_index)
         similar(V, map(length, indices))
@@ -198,16 +198,16 @@ end
 initialized_blocks_BlockArray(::Type{R}, block_sizes::Vararg{AbstractVector{<:Integer}, N}) where {T, N, R<:AbstractArray{<:AbstractArray{T,N},N}} =
     initialized_blocks_BlockArray(R, map(blockedrange,block_sizes))
 
-@inline BlockArray{T}(::UndefInitializer, baxes::NTuple{N,AbstractUnitRange{Int}}) where {T, N} =
+@inline BlockArray{T}(::UndefInitializer, baxes::Tuple{Vararg{AbstractUnitRange{<:Integer},N}}) where {T, N} =
     initialized_blocks_BlockArray(Array{Array{T,N},N}, baxes)
 
-@inline BlockArray{T, N}(::UndefInitializer, baxes::NTuple{N,AbstractUnitRange{Int}}) where {T, N} =
+@inline BlockArray{T, N}(::UndefInitializer, baxes::Tuple{Vararg{AbstractUnitRange{<:Integer},N}}) where {T, N} =
     initialized_blocks_BlockArray(Array{Array{T,N},N}, baxes)
 
-@inline BlockArray{T, N, R}(::UndefInitializer, baxes::NTuple{N,AbstractUnitRange{Int}}) where {T, N, R<:AbstractArray{<:AbstractArray{T,N},N}} =
+@inline BlockArray{T, N, R}(::UndefInitializer, baxes::Tuple{Vararg{AbstractUnitRange{<:Integer},N}}) where {T, N, R<:AbstractArray{<:AbstractArray{T,N},N}} =
     initialized_blocks_BlockArray(R, baxes)
 
-@inline BlockArray{T,N,R,BS}(::UndefInitializer, baxes::BS) where {T, N, R<:AbstractArray{<:AbstractArray{T,N},N}, BS<:NTuple{N,AbstractUnitRange{Int}}} =
+@inline BlockArray{T,N,R,BS}(::UndefInitializer, baxes::BS) where {T, N, R<:AbstractArray{<:AbstractArray{T,N},N}, BS<:Tuple{Vararg{AbstractUnitRange{<:Integer},N}}} =
     initialized_blocks_BlockArray(R, baxes)
 
 """
@@ -242,7 +242,7 @@ julia> B
     initialized_blocks_BlockArray(R, block_sizes...)
 
 
-@inline BlockArray{T,N,R,BS}(::UndefInitializer, sizes::NTuple{N,Int}) where {T, N, R<:AbstractArray{<:AbstractArray{T,N},N}, BS<:NTuple{N,AbstractUnitRange{Int}}} =
+@inline BlockArray{T,N,R,BS}(::UndefInitializer, sizes::NTuple{N,Int}) where {T, N, R<:AbstractArray{<:AbstractArray{T,N},N}, BS<:Tuple{Vararg{AbstractUnitRange{<:Integer},N}}} =
     BlockArray{T,N,R,BS}(undef, convert(BS, map(Base.OneTo, sizes)))
 
 function BlockArray{T}(arr::AbstractArray{V, N}, block_sizes::Vararg{AbstractVector{<:Integer}, N}) where {T,V,N}
@@ -257,7 +257,7 @@ end
 BlockArray(arr::AbstractArray{T, N}, block_sizes::Vararg{AbstractVector{<:Integer}, N}) where {T,N} =
     BlockArray{T}(arr, block_sizes...)
 
-function BlockArray{T}(arr::AbstractArray{T, N}, baxes::NTuple{N,AbstractUnitRange{Int}}) where {T,N}
+function BlockArray{T}(arr::AbstractArray{T, N}, baxes::Tuple{Vararg{AbstractUnitRange{<:Integer},N}}) where {T,N}
     blocks = map(Iterators.product(map(x -> blockaxes(x,1), baxes)...)) do block_index
         indices = map((x,y) -> x[y], baxes, block_index)
         arr[indices...]
@@ -265,30 +265,30 @@ function BlockArray{T}(arr::AbstractArray{T, N}, baxes::NTuple{N,AbstractUnitRan
     return _BlockArray(blocks, baxes)
 end
 
-BlockArray{T}(arr::AbstractArray{<:Any, N}, baxes::NTuple{N,AbstractUnitRange{Int}}) where {T,N} =
+BlockArray{T}(arr::AbstractArray{<:Any, N}, baxes::Tuple{Vararg{AbstractUnitRange{<:Integer},N}}) where {T,N} =
     BlockArray{T}(convert(AbstractArray{T, N}, arr), baxes)
 
-BlockArray(arr::AbstractArray{T, N}, baxes::NTuple{N,AbstractUnitRange{Int}}) where {T,N} =
+BlockArray(arr::AbstractArray{T, N}, baxes::Tuple{Vararg{AbstractUnitRange{<:Integer},N}}) where {T,N} =
     BlockArray{T}(arr, baxes)
 
-BlockVector(blocks::AbstractVector, baxes::Tuple{AbstractUnitRange{Int}}) = BlockArray(blocks, baxes)
+BlockVector(blocks::AbstractVector, baxes::Tuple{AbstractUnitRange{<:Integer}}) = BlockArray(blocks, baxes)
 BlockVector(blocks::AbstractVector, block_sizes::AbstractVector{<:Integer}) = BlockArray(blocks, block_sizes)
-BlockMatrix(blocks::AbstractMatrix, baxes::NTuple{2,AbstractUnitRange{Int}}) = BlockArray(blocks, baxes)
+BlockMatrix(blocks::AbstractMatrix, baxes::NTuple{2,AbstractUnitRange{<:Integer}}) = BlockArray(blocks, baxes)
 BlockMatrix(blocks::AbstractMatrix, block_sizes::Vararg{AbstractVector{<:Integer},2}) = BlockArray(blocks, block_sizes...)
 
-BlockArray{T}(λ::UniformScaling, baxes::NTuple{2,AbstractUnitRange{Int}}) where T = BlockArray{T}(Matrix(λ, map(length,baxes)...), baxes)
+BlockArray{T}(λ::UniformScaling, baxes::Tuple{Vararg{AbstractUnitRange{<:Integer},2}}) where T = BlockArray{T}(Matrix(λ, map(length,baxes)...), baxes)
 BlockArray{T}(λ::UniformScaling, block_sizes::Vararg{AbstractVector{<:Integer}, 2}) where T = BlockArray{T}(λ, map(blockedrange,block_sizes))
 BlockArray(λ::UniformScaling{T}, block_sizes::Vararg{AbstractVector{<:Integer}, 2}) where T = BlockArray{T}(λ, block_sizes...)
-BlockArray(λ::UniformScaling{T}, baxes::NTuple{2,AbstractUnitRange{Int}}) where T = BlockArray{T}(λ, baxes)
-BlockMatrix(λ::UniformScaling, baxes::NTuple{2,AbstractUnitRange{Int}}) = BlockArray(λ, baxes)
+BlockArray(λ::UniformScaling{T}, baxes::Tuple{Vararg{AbstractUnitRange{<:Integer},2}}) where T = BlockArray{T}(λ, baxes)
+BlockMatrix(λ::UniformScaling, baxes::Tuple{Vararg{AbstractUnitRange{<:Integer},2}}) = BlockArray(λ, baxes)
 BlockMatrix(λ::UniformScaling, block_sizes::Vararg{AbstractVector{<:Integer},2}) = BlockArray(λ, block_sizes...)
-BlockMatrix{T}(λ::UniformScaling, baxes::NTuple{2,AbstractUnitRange{Int}}) where T = BlockArray{T}(λ, baxes)
+BlockMatrix{T}(λ::UniformScaling, baxes::Tuple{Vararg{AbstractUnitRange{<:Integer},2}}) where T = BlockArray{T}(λ, baxes)
 BlockMatrix{T}(λ::UniformScaling, block_sizes::Vararg{AbstractVector{<:Integer},2}) where T = BlockArray{T}(λ, block_sizes...)
 
 """
     mortar(blocks::AbstractArray)
     mortar(blocks::AbstractArray{R, N}, sizes_1, sizes_2, ..., sizes_N)
-    mortar(blocks::AbstractArray{R, N}, block_sizes::NTuple{N,AbstractUnitRange{Int}})
+    mortar(blocks::AbstractArray{R, N}, block_sizes::Tuple{Vararg{AbstractUnitRange{<:Integer},N}})
 
 Construct a `BlockArray` from `blocks`.  `block_sizes` is computed from
 `blocks` if it is not given.
@@ -319,7 +319,7 @@ julia> M == mortar(
 true
 ```
 """
-mortar(blocks::AbstractArray{R, N}, baxes::NTuple{N,AbstractUnitRange{Int}}) where {R, N} =
+mortar(blocks::AbstractArray{R, N}, baxes::Tuple{Vararg{AbstractUnitRange{<:Integer},N}}) where {R, N} =
     _BlockArray(blocks, baxes)
 
 mortar(blocks::AbstractArray{R, N}, block_sizes::Vararg{AbstractVector{<:Integer}, N}) where {R, N} =
@@ -355,7 +355,7 @@ end
 
 getsizes(block_sizes, block_index) = getindex.(block_sizes, block_index)
 
-function checksizes(fullsizes::Array{NTuple{N,Int}, N}, block_sizes::NTuple{N,Vector{Int}}) where N
+function checksizes(fullsizes::Array{<:Tuple{Vararg{Integer,N}}, N}, block_sizes::Tuple{Vararg{Vector{<:Integer},N}}) where N
     for I in CartesianIndices(fullsizes)
         block_index = Tuple(I)
         if fullsizes[block_index...] != getsizes(block_sizes, block_index)
@@ -431,18 +431,18 @@ end
 ###########################
 
 
-@inline Base.similar(block_array::AbstractArray, ::Type{T}, axes::Tuple{AbstractBlockedUnitRange,Vararg{Union{AbstractUnitRange{Int},Integer}}}) where T =
+@inline Base.similar(block_array::AbstractArray, ::Type{T}, axes::Tuple{AbstractBlockedUnitRange,Vararg{Union{AbstractUnitRange{<:Integer},Integer}}}) where T =
     BlockArray{T}(undef, map(to_axes,axes))
-@inline Base.similar(block_array::AbstractArray, ::Type{T}, axes::Tuple{AbstractBlockedUnitRange,AbstractBlockedUnitRange,Vararg{Union{AbstractUnitRange{Int},Integer}}}) where T =
+@inline Base.similar(block_array::AbstractArray, ::Type{T}, axes::Tuple{AbstractBlockedUnitRange,AbstractBlockedUnitRange,Vararg{Union{AbstractUnitRange{<:Integer},Integer}}}) where T =
     BlockArray{T}(undef, map(to_axes,axes))
-@inline Base.similar(block_array::AbstractArray, ::Type{T}, axes::Tuple{Union{AbstractUnitRange{Int},Integer},AbstractBlockedUnitRange,Vararg{Union{AbstractUnitRange{Int},Integer}}}) where T =
+@inline Base.similar(block_array::AbstractArray, ::Type{T}, axes::Tuple{Union{AbstractUnitRange{<:Integer},Integer},AbstractBlockedUnitRange,Vararg{Union{AbstractUnitRange{<:Integer},Integer}}}) where T =
     BlockArray{T}(undef, map(to_axes,axes))
 
-@inline Base.similar(block_array::Type{<:AbstractArray{T}}, axes::Tuple{AbstractBlockedUnitRange,Vararg{Union{AbstractUnitRange{Int},Integer}}}) where T =
+@inline Base.similar(block_array::Type{<:AbstractArray{T}}, axes::Tuple{AbstractBlockedUnitRange,Vararg{Union{AbstractUnitRange{<:Integer},Integer}}}) where T =
     BlockArray{T}(undef, map(to_axes,axes))
-@inline Base.similar(block_array::Type{<:AbstractArray{T}}, axes::Tuple{AbstractBlockedUnitRange,AbstractBlockedUnitRange,Vararg{Union{AbstractUnitRange{Int},Integer}}}) where T =
+@inline Base.similar(block_array::Type{<:AbstractArray{T}}, axes::Tuple{AbstractBlockedUnitRange,AbstractBlockedUnitRange,Vararg{Union{AbstractUnitRange{<:Integer},Integer}}}) where T =
     BlockArray{T}(undef, map(to_axes,axes))
-@inline Base.similar(block_array::Type{<:AbstractArray{T}}, axes::Tuple{Union{AbstractUnitRange{Int},Integer},AbstractBlockedUnitRange,Vararg{Union{AbstractUnitRange{Int},Integer}}}) where T =
+@inline Base.similar(block_array::Type{<:AbstractArray{T}}, axes::Tuple{Union{AbstractUnitRange{<:Integer},Integer},AbstractBlockedUnitRange,Vararg{Union{AbstractUnitRange{<:Integer},Integer}}}) where T =
     BlockArray{T}(undef, map(to_axes,axes))
 
 @inline Base.similar(B::BlockArray, ::Type{T}) where {T} = mortar(similar.(blocks(B), T))
@@ -454,7 +454,7 @@ const OffsetAxis = Union{Integer, UnitRange, Base.OneTo, Base.IdentityUnitRange}
     Array{T}(undef, dims)
 @inline Base.similar(block_array::BlockArray, ::Type{T}, axes::Tuple{OffsetAxis,Vararg{OffsetAxis}}) where T =
     BlockArray{T}(undef, map(to_axes,axes))
-@inline Base.similar(block_array::BlockArray, ::Type{T}, axes::Tuple{Base.OneTo{Int},Vararg{Base.OneTo{Int}}}) where T =
+@inline Base.similar(block_array::BlockArray, ::Type{T}, axes::Tuple{Base.OneTo{<:Integer},Vararg{Base.OneTo{<:Integer}}}) where T =
     BlockArray{T}(undef, map(to_axes,axes))
 
 @inline function getindex(block_arr::BlockArray{T, N}, i::Vararg{Integer, N}) where {T,N}
@@ -545,13 +545,13 @@ function Base.fill!(block_array::BlockArray, v)
 end
 
 # Temporary work around
-Base.reshape(block_array::BlockArray, axes::NTuple{N,AbstractUnitRange{Int}}) where N =
+Base.reshape(block_array::BlockArray, axes::Tuple{Vararg{AbstractUnitRange{<:Integer},N}}) where N =
     reshape(BlockedArray(block_array), axes)
 Base.reshape(block_array::BlockArray, dims::Tuple{Int,Vararg{Int}}) =
     reshape(BlockedArray(block_array), dims)
 Base.reshape(block_array::BlockArray, axes::Tuple{Union{Integer,Base.OneTo}, Vararg{Union{Integer,Base.OneTo}}}) =
     reshape(BlockedArray(block_array), axes)
-Base.reshape(block_array::BlockArray, dims::Tuple{Vararg{Union{Int,Colon}}}) =
+Base.reshape(block_array::BlockArray, dims::Tuple{Vararg{Union{Integer,Colon}}}) =
     reshape(BlockedArray(block_array), dims)
 
 """

--- a/src/blockarray.jl
+++ b/src/blockarray.jl
@@ -273,17 +273,17 @@ BlockArray(arr::AbstractArray{T, N}, baxes::Tuple{Vararg{AbstractUnitRange{<:Int
 
 BlockVector(blocks::AbstractVector, baxes::Tuple{AbstractUnitRange{<:Integer}}) = BlockArray(blocks, baxes)
 BlockVector(blocks::AbstractVector, block_sizes::AbstractVector{<:Integer}) = BlockArray(blocks, block_sizes)
-BlockMatrix(blocks::AbstractMatrix, baxes::NTuple{2,AbstractUnitRange{<:Integer}}) = BlockArray(blocks, baxes)
-BlockMatrix(blocks::AbstractMatrix, block_sizes::Vararg{AbstractVector{<:Integer},2}) = BlockArray(blocks, block_sizes...)
+BlockMatrix(blocks::AbstractMatrix, baxes::Tuple{Vararg{AbstractUnitRange{<:Integer}, 2}}) = BlockArray(blocks, baxes)
+BlockMatrix(blocks::AbstractMatrix, block_sizes::Vararg{AbstractVector{<:Integer}, 2}) = BlockArray(blocks, block_sizes...)
 
-BlockArray{T}(λ::UniformScaling, baxes::Tuple{Vararg{AbstractUnitRange{<:Integer},2}}) where T = BlockArray{T}(Matrix(λ, map(length,baxes)...), baxes)
+BlockArray{T}(λ::UniformScaling, baxes::Tuple{Vararg{AbstractUnitRange{<:Integer}, 2}}) where T = BlockArray{T}(Matrix(λ, map(length,baxes)...), baxes)
 BlockArray{T}(λ::UniformScaling, block_sizes::Vararg{AbstractVector{<:Integer}, 2}) where T = BlockArray{T}(λ, map(blockedrange,block_sizes))
 BlockArray(λ::UniformScaling{T}, block_sizes::Vararg{AbstractVector{<:Integer}, 2}) where T = BlockArray{T}(λ, block_sizes...)
-BlockArray(λ::UniformScaling{T}, baxes::Tuple{Vararg{AbstractUnitRange{<:Integer},2}}) where T = BlockArray{T}(λ, baxes)
-BlockMatrix(λ::UniformScaling, baxes::Tuple{Vararg{AbstractUnitRange{<:Integer},2}}) = BlockArray(λ, baxes)
-BlockMatrix(λ::UniformScaling, block_sizes::Vararg{AbstractVector{<:Integer},2}) = BlockArray(λ, block_sizes...)
-BlockMatrix{T}(λ::UniformScaling, baxes::Tuple{Vararg{AbstractUnitRange{<:Integer},2}}) where T = BlockArray{T}(λ, baxes)
-BlockMatrix{T}(λ::UniformScaling, block_sizes::Vararg{AbstractVector{<:Integer},2}) where T = BlockArray{T}(λ, block_sizes...)
+BlockArray(λ::UniformScaling{T}, baxes::Tuple{Vararg{AbstractUnitRange{<:Integer}, 2}}) where T = BlockArray{T}(λ, baxes)
+BlockMatrix(λ::UniformScaling, baxes::Tuple{Vararg{AbstractUnitRange{<:Integer}, 2}}) = BlockArray(λ, baxes)
+BlockMatrix(λ::UniformScaling, block_sizes::Vararg{AbstractVector{<:Integer}, 2}) = BlockArray(λ, block_sizes...)
+BlockMatrix{T}(λ::UniformScaling, baxes::Tuple{Vararg{AbstractUnitRange{<:Integer}, 2}}) where T = BlockArray{T}(λ, baxes)
+BlockMatrix{T}(λ::UniformScaling, block_sizes::Vararg{AbstractVector{<:Integer}, 2}) where T = BlockArray{T}(λ, block_sizes...)
 
 """
     mortar(blocks::AbstractArray)

--- a/src/blockaxis.jl
+++ b/src/blockaxis.jl
@@ -147,7 +147,7 @@ end
 _throw_if_bool(_) = nothing
 _throw_if_bool(::Type{Bool}) = throw(ArgumentError("a Bool collection is not allowed as blocklasts"))
 
-const DefaultBlockAxis{T<:Integer} = BlockedOneTo{T, Vector{T}}
+const DefaultBlockAxis = BlockedOneTo{Int, Vector{Int}}
 
 first(b::BlockedOneTo) = oneunit(eltype(b))
 @inline blocklasts(a::BlockedOneTo) = a.lasts

--- a/src/blockaxis.jl
+++ b/src/blockaxis.jl
@@ -553,11 +553,11 @@ function sortedunion(a::RangeCumsum{<:Any,<:AbstractRange}, b::RangeCumsum{<:Any
 end
 
 _blocklengths2blocklasts(blocks::AbstractRange) = RangeCumsum(blocks)
-function blockfirsts(a::AbstractBlockedUnitRange{<:Any,Base.OneTo{<:Integer}})
+function blockfirsts(a::AbstractBlockedUnitRange{<:Any,<:Base.OneTo{<:Integer}})
     first(a) == 1 || error("Offset axes not supported")
     Base.OneTo{eltype(a)}(length(blocklasts(a)))
 end
-function blocklengths(a::AbstractBlockedUnitRange{<:Any,Base.OneTo{<:Integer}})
+function blocklengths(a::AbstractBlockedUnitRange{<:Any,<:Base.OneTo{<:Integer}})
     first(a) == 1 || error("Offset axes not supported")
     Ones{eltype(a)}(length(blocklasts(a)))
 end

--- a/src/blockbroadcast.jl
+++ b/src/blockbroadcast.jl
@@ -249,7 +249,7 @@ BroadcastStyle(::Type{<:SubArray{<:Any,N,<:Any,I}}) where {N,I<:Tuple{BlockSlice
 BroadcastStyle(::Type{<:SubArray{<:Any,N,<:Any,I}}) where {N,I<:Tuple{Any,BlockSlice{<:Any,<:Any,<:AbstractBlockedUnitRange},Vararg{Any}}} = BlockStyle{N}()
 
 BroadcastStyle(::Type{<:SubArray{<:Any,N,<:BlockedArray,I}}) where {N,I<:Tuple{BlockSlice{<:Any,<:Any,<:AbstractBlockedUnitRange},Vararg{Any}}} = BlockedStyle{N}()
-BroadcastStyle(::Type{<:SubArray{<:Any,N,<:BlockedArray,I}}) where {N,I<:Tuple{BlockSlice{<:Any,<:Any,<:AbstractBlockedUnitRange},BlockSlice{<:Any,<:AbstractBlockedUnitRange},Vararg{Any}}} = BlockedStyle{N}()
+BroadcastStyle(::Type{<:SubArray{<:Any,N,<:BlockedArray,I}}) where {N,I<:Tuple{BlockSlice{<:Any,<:Any,<:AbstractBlockedUnitRange},BlockSlice{<:Any,<:Any,<:AbstractBlockedUnitRange},Vararg{Any}}} = BlockedStyle{N}()
 BroadcastStyle(::Type{<:SubArray{<:Any,N,<:BlockedArray,I}}) where {N,I<:Tuple{Any,BlockSlice{<:Any,<:Any,<:AbstractBlockedUnitRange},Vararg{Any}}} = BlockedStyle{N}()
 
 

--- a/src/blockbroadcast.jl
+++ b/src/blockbroadcast.jl
@@ -82,7 +82,7 @@ julia> itr = SubBlockIterator(subblock_lasts, block_lasts)
 SubBlockIterator([1, 3, 6], [1, 3, 4, 6])
 
 julia> collect(itr)
-4-element Vector{BlockArrays.BlockIndexRange{1, Tuple{UnitRange{Int64}}}}:
+4-element Vector{BlockArrays.BlockIndexRange{1, Tuple{UnitRange{Int64}}, Tuple{Int64}, Int64}}:
  Block(1)[1:1]
  Block(2)[1:2]
  Block(3)[1:1]
@@ -95,7 +95,7 @@ struct SubBlockIterator
 end
 
 Base.IteratorEltype(::Type{<:SubBlockIterator}) = Base.HasEltype()
-Base.eltype(::Type{<:SubBlockIterator}) = BlockIndexRange{1,Tuple{UnitRange{Int64}}}
+Base.eltype(::Type{<:SubBlockIterator}) = BlockIndexRange{1,Tuple{UnitRange{Int}},Tuple{Int},Int}
 
 Base.IteratorSize(::Type{<:SubBlockIterator}) = Base.HasLength()
 Base.length(it::SubBlockIterator) = length(it.block_lasts)

--- a/src/blockbroadcast.jl
+++ b/src/blockbroadcast.jl
@@ -245,7 +245,7 @@ BroadcastStyle(::Type{<:SubArray{T,N,Arr,<:NTuple{N,BlockSlice1},false}}) where 
 
 # special cases for SubArrays which we want to broadcast by Block
 BroadcastStyle(::Type{<:SubArray{<:Any,N,<:Any,I}}) where {N,I<:Tuple{BlockSlice{<:Any,<:Any,<:AbstractBlockedUnitRange},Vararg{Any}}} = BlockStyle{N}()
-BroadcastStyle(::Type{<:SubArray{<:Any,N,<:Any,I}}) where {N,I<:Tuple{BlockSlice{<:Any,<:Any,<:AbstractBlockedUnitRange},BlockSlice{<:Any,<:AbstractBlockedUnitRange},Vararg{Any}}} = BlockStyle{N}()
+BroadcastStyle(::Type{<:SubArray{<:Any,N,<:Any,I}}) where {N,I<:Tuple{BlockSlice{<:Any,<:Any,<:AbstractBlockedUnitRange},BlockSlice{<:Any,<:Any,<:AbstractBlockedUnitRange},Vararg{Any}}} = BlockStyle{N}()
 BroadcastStyle(::Type{<:SubArray{<:Any,N,<:Any,I}}) where {N,I<:Tuple{Any,BlockSlice{<:Any,<:Any,<:AbstractBlockedUnitRange},Vararg{Any}}} = BlockStyle{N}()
 
 BroadcastStyle(::Type{<:SubArray{<:Any,N,<:BlockedArray,I}}) where {N,I<:Tuple{BlockSlice{<:Any,<:Any,<:AbstractBlockedUnitRange},Vararg{Any}}} = BlockedStyle{N}()

--- a/src/blockbroadcast.jl
+++ b/src/blockbroadcast.jl
@@ -244,13 +244,13 @@ BroadcastStyle(::Type{<:SubArray{T,N,Arr,<:NTuple{N,BlockSlice1},false}}) where 
 
 
 # special cases for SubArrays which we want to broadcast by Block
-BroadcastStyle(::Type{<:SubArray{<:Any,N,<:Any,I}}) where {N,I<:Tuple{BlockSlice{<:Any,<:AbstractBlockedUnitRange},Vararg{Any}}} = BlockStyle{N}()
-BroadcastStyle(::Type{<:SubArray{<:Any,N,<:Any,I}}) where {N,I<:Tuple{BlockSlice{<:Any,<:AbstractBlockedUnitRange},BlockSlice{<:Any,<:AbstractBlockedUnitRange},Vararg{Any}}} = BlockStyle{N}()
-BroadcastStyle(::Type{<:SubArray{<:Any,N,<:Any,I}}) where {N,I<:Tuple{Any,BlockSlice{<:Any,<:AbstractBlockedUnitRange},Vararg{Any}}} = BlockStyle{N}()
+BroadcastStyle(::Type{<:SubArray{<:Any,N,<:Any,I}}) where {N,I<:Tuple{BlockSlice{<:Any,<:Any,<:AbstractBlockedUnitRange},Vararg{Any}}} = BlockStyle{N}()
+BroadcastStyle(::Type{<:SubArray{<:Any,N,<:Any,I}}) where {N,I<:Tuple{BlockSlice{<:Any,<:Any,<:AbstractBlockedUnitRange},BlockSlice{<:Any,<:AbstractBlockedUnitRange},Vararg{Any}}} = BlockStyle{N}()
+BroadcastStyle(::Type{<:SubArray{<:Any,N,<:Any,I}}) where {N,I<:Tuple{Any,BlockSlice{<:Any,<:Any,<:AbstractBlockedUnitRange},Vararg{Any}}} = BlockStyle{N}()
 
-BroadcastStyle(::Type{<:SubArray{<:Any,N,<:BlockedArray,I}}) where {N,I<:Tuple{BlockSlice{<:Any,<:AbstractBlockedUnitRange},Vararg{Any}}} = BlockedStyle{N}()
-BroadcastStyle(::Type{<:SubArray{<:Any,N,<:BlockedArray,I}}) where {N,I<:Tuple{BlockSlice{<:Any,<:AbstractBlockedUnitRange},BlockSlice{<:Any,<:AbstractBlockedUnitRange},Vararg{Any}}} = BlockedStyle{N}()
-BroadcastStyle(::Type{<:SubArray{<:Any,N,<:BlockedArray,I}}) where {N,I<:Tuple{Any,BlockSlice{<:Any,<:AbstractBlockedUnitRange},Vararg{Any}}} = BlockedStyle{N}()
+BroadcastStyle(::Type{<:SubArray{<:Any,N,<:BlockedArray,I}}) where {N,I<:Tuple{BlockSlice{<:Any,<:Any,<:AbstractBlockedUnitRange},Vararg{Any}}} = BlockedStyle{N}()
+BroadcastStyle(::Type{<:SubArray{<:Any,N,<:BlockedArray,I}}) where {N,I<:Tuple{BlockSlice{<:Any,<:Any,<:AbstractBlockedUnitRange},BlockSlice{<:Any,<:AbstractBlockedUnitRange},Vararg{Any}}} = BlockedStyle{N}()
+BroadcastStyle(::Type{<:SubArray{<:Any,N,<:BlockedArray,I}}) where {N,I<:Tuple{Any,BlockSlice{<:Any,<:Any,<:AbstractBlockedUnitRange},Vararg{Any}}} = BlockedStyle{N}()
 
 
 

--- a/src/blockedarray.jl
+++ b/src/blockedarray.jl
@@ -296,9 +296,9 @@ end
 _blocked_reshape(block_array, axes) = BlockedArray(reshape(block_array.blocks,map(length,axes)),axes)
 Base.reshape(block_array::BlockedArray, axes::Tuple{Vararg{AbstractUnitRange{<:Integer},N}}) where N =
     _blocked_reshape(block_array, axes)
-Base.reshape(parent::BlockedArray, shp::Tuple{Union{Integer,Base.OneTo}, Vararg{Union{Integer,Base.OneTo}}}) =
+Base.reshape(parent::BlockedArray, shp::Tuple{Union{Int,Base.OneTo}, Vararg{Union{Int,Base.OneTo}}}) =
     reshape(parent, Base.to_shape(shp))
-Base.reshape(parent::BlockedArray, dims::Tuple{Integer,Vararg{Integer}}) =
+Base.reshape(parent::BlockedArray, dims::Tuple{Int,Vararg{Int}}) =
     Base._reshape(parent, dims)
 
 """

--- a/src/blockedarray.jl
+++ b/src/blockedarray.jl
@@ -40,10 +40,10 @@ julia> A
  0  0  0
 ```
 """
-struct BlockedArray{T, N, R<:AbstractArray{T,N}, BS<:NTuple{N,AbstractUnitRange{Int}}} <: AbstractBlockArray{T, N}
+struct BlockedArray{T, N, R<:AbstractArray{T,N}, BS<:Tuple{Vararg{AbstractUnitRange{<:Integer},N}}} <: AbstractBlockArray{T, N}
     blocks::R
     axes::BS
-    function BlockedArray{T,N,R,BS}(blocks::R, axes::BS) where {T,N,R,BS<:NTuple{N,AbstractUnitRange{Int}}}
+    function BlockedArray{T,N,R,BS}(blocks::R, axes::BS) where {T,N,R,BS<:Tuple{Vararg{AbstractUnitRange{<:Integer},N}}}
         checkbounds(blocks,axes...)
         return new{T,N,R,BS}(blocks, axes)
     end
@@ -99,62 +99,62 @@ const BlockedVector{T} = BlockedArray{T, 1}
 const BlockedVecOrMat{T} = Union{BlockedMatrix{T}, BlockedVector{T}}
 
 # Auxiliary outer constructors
-@inline BlockedArray(blocks::R, baxes::BS) where {T,N,R<:AbstractArray{T,N},BS<:NTuple{N,AbstractUnitRange{Int}}} =
+@inline BlockedArray(blocks::R, baxes::BS) where {T,N,R<:AbstractArray{T,N},BS<:Tuple{Vararg{AbstractUnitRange{<:Integer},N}}} =
     BlockedArray{T, N, R,BS}(blocks, baxes)
 
-@inline BlockedArray{T}(blocks::R, baxes::BS) where {T,N,R<:AbstractArray{T,N},BS<:NTuple{N,AbstractUnitRange{Int}}} =
+@inline BlockedArray{T}(blocks::R, baxes::BS) where {T,N,R<:AbstractArray{T,N},BS<:Tuple{Vararg{AbstractUnitRange{<:Integer},N}}} =
     BlockedArray{T, N, R,BS}(blocks, baxes)
 
-@inline BlockedArray{T}(blocks::AbstractArray{<:Any,N}, baxes::NTuple{N,AbstractUnitRange{Int}}) where {T,N} =
+@inline BlockedArray{T}(blocks::AbstractArray{<:Any,N}, baxes::Tuple{Vararg{AbstractUnitRange{<:Integer},N}}) where {T,N} =
     BlockedArray{T}(convert(AbstractArray{T,N}, blocks), baxes)
 
-@inline BlockedArray(blocks::BlockedArray, baxes::BS) where {N,BS<:NTuple{N,AbstractUnitRange{Int}}} =
+@inline BlockedArray(blocks::BlockedArray, baxes::BS) where {N,BS<:Tuple{Vararg{AbstractUnitRange{<:Integer},N}}} =
     BlockedArray(blocks.blocks, baxes)
 
-@inline BlockedArray{T}(blocks::BlockedArray, baxes::BS) where {T,N,BS<:NTuple{N,AbstractUnitRange{Int}}} =
+@inline BlockedArray{T}(blocks::BlockedArray, baxes::BS) where {T,N,BS<:Tuple{Vararg{AbstractUnitRange{<:Integer},N}}} =
     BlockedArray{T}(blocks.blocks, baxes)
 
-BlockedArray(blocks::AbstractArray{T, N}, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N} =
+BlockedArray(blocks::AbstractArray{T, N}, block_sizes::Vararg{AbstractVector{<:Integer}, N}) where {T, N} =
     BlockedArray(blocks, map(blockedrange,block_sizes))
 
-BlockedArray{T}(blocks::AbstractArray{<:Any, N}, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N} =
+BlockedArray{T}(blocks::AbstractArray{<:Any, N}, block_sizes::Vararg{AbstractVector{<:Integer}, N}) where {T, N} =
     BlockedArray{T}(blocks, map(blockedrange,block_sizes))
 
-@inline BlockedArray{T,N,R,BS}(::UndefInitializer, baxes::NTuple{N,AbstractUnitRange{Int}}) where {T,N,R,BS<:NTuple{N,AbstractUnitRange{Int}}} =
+@inline BlockedArray{T,N,R,BS}(::UndefInitializer, baxes::Tuple{Vararg{AbstractUnitRange{<:Integer},N}}) where {T,N,R,BS<:Tuple{Vararg{AbstractUnitRange{<:Integer},N}}} =
     BlockedArray{T,N,R,BS}(R(undef, length.(baxes)), convert(BS, baxes))
 
-@inline BlockedArray{T}(::UndefInitializer, baxes::NTuple{N,AbstractUnitRange{Int}}) where {T, N} =
+@inline BlockedArray{T}(::UndefInitializer, baxes::Tuple{Vararg{AbstractUnitRange{<:Integer},N}}) where {T, N} =
     BlockedArray(similar(Array{T, N}, length.(baxes)), baxes)
 
-@inline BlockedArray{T, N}(::UndefInitializer, baxes::NTuple{N,AbstractUnitRange{Int}}) where {T, N} =
+@inline BlockedArray{T, N}(::UndefInitializer, baxes::Tuple{Vararg{AbstractUnitRange{<:Integer},N}}) where {T, N} =
     BlockedArray{T}(undef, baxes)
 
-@inline BlockedArray{T, N, R}(::UndefInitializer, baxes::NTuple{N,AbstractUnitRange{Int}}) where {T, N, R <: AbstractArray{T, N}} =
+@inline BlockedArray{T, N, R}(::UndefInitializer, baxes::Tuple{Vararg{AbstractUnitRange{<:Integer},N}}) where {T, N, R <: AbstractArray{T, N}} =
     BlockedArray(similar(R, length.(baxes)), baxes)
 
-@inline BlockedArray{T}(::UndefInitializer, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N} =
+@inline BlockedArray{T}(::UndefInitializer, block_sizes::Vararg{AbstractVector{<:Integer}, N}) where {T, N} =
     BlockedArray{T}(undef, map(blockedrange,block_sizes))
 
-@inline BlockedArray{T, N}(::UndefInitializer, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N} =
+@inline BlockedArray{T, N}(::UndefInitializer, block_sizes::Vararg{AbstractVector{<:Integer}, N}) where {T, N} =
     BlockedArray{T, N}(undef, map(blockedrange,block_sizes))
 
-@inline BlockedArray{T, N, R}(::UndefInitializer, block_sizes::Vararg{AbstractVector{Int}, N}) where {T, N, R <: AbstractArray{T, N}} =
+@inline BlockedArray{T, N, R}(::UndefInitializer, block_sizes::Vararg{AbstractVector{<:Integer}, N}) where {T, N, R <: AbstractArray{T, N}} =
     BlockedArray{T, N, R}(undef, map(blockedrange,block_sizes))
 
 
-BlockedVector(blocks::AbstractVector, baxes::Tuple{AbstractUnitRange{Int}}) = BlockedArray(blocks, baxes)
-BlockedVector(blocks::AbstractVector, block_sizes::AbstractVector{Int}) = BlockedArray(blocks, block_sizes)
-BlockedMatrix(blocks::AbstractMatrix, baxes::NTuple{2,AbstractUnitRange{Int}}) = BlockedArray(blocks, baxes)
-BlockedMatrix(blocks::AbstractMatrix, block_sizes::Vararg{AbstractVector{Int},2}) = BlockedArray(blocks, block_sizes...)
+BlockedVector(blocks::AbstractVector, baxes::Tuple{AbstractUnitRange{<:Integer}}) = BlockedArray(blocks, baxes)
+BlockedVector(blocks::AbstractVector, block_sizes::AbstractVector{<:Integer}) = BlockedArray(blocks, block_sizes)
+BlockedMatrix(blocks::AbstractMatrix, baxes::Vararg{AbstractUnitRange{<:Integer}, 2}) = BlockedArray(blocks, baxes)
+BlockedMatrix(blocks::AbstractMatrix, block_sizes::Vararg{AbstractVector{<:Integer}, 2}) = BlockedArray(blocks, block_sizes...)
 
-BlockedArray{T}(λ::UniformScaling, baxes::NTuple{2,AbstractUnitRange{Int}}) where T = BlockedArray{T}(Matrix(λ, map(length,baxes)...), baxes)
-BlockedArray{T}(λ::UniformScaling, block_sizes::Vararg{AbstractVector{Int}, 2}) where T = BlockedArray{T}(λ, map(blockedrange,block_sizes))
-BlockedArray(λ::UniformScaling{T}, block_sizes::Vararg{AbstractVector{Int}, 2}) where T = BlockedArray{T}(λ, block_sizes...)
-BlockedArray(λ::UniformScaling{T}, baxes::NTuple{2,AbstractUnitRange{Int}}) where T = BlockedArray{T}(λ, baxes)
-BlockedMatrix(λ::UniformScaling, baxes::NTuple{2,AbstractUnitRange{Int}}) = BlockedArray(λ, baxes)
-BlockedMatrix(λ::UniformScaling, block_sizes::Vararg{AbstractVector{Int},2}) = BlockedArray(λ, block_sizes...)
-BlockedMatrix{T}(λ::UniformScaling, baxes::NTuple{2,AbstractUnitRange{Int}}) where T = BlockedArray{T}(λ, baxes)
-BlockedMatrix{T}(λ::UniformScaling, block_sizes::Vararg{AbstractVector{Int},2}) where T = BlockedArray{T}(λ, block_sizes...)
+BlockedArray{T}(λ::UniformScaling, baxes::Vararg{AbstractUnitRange{<:Integer}, 2}) where T = BlockedArray{T}(Matrix(λ, map(length,baxes)...), baxes)
+BlockedArray{T}(λ::UniformScaling, block_sizes::Vararg{AbstractVector{<:Integer}, 2}) where T = BlockedArray{T}(λ, map(blockedrange,block_sizes))
+BlockedArray(λ::UniformScaling{T}, block_sizes::Vararg{AbstractVector{<:Integer}, 2}) where T = BlockedArray{T}(λ, block_sizes...)
+BlockedArray(λ::UniformScaling{T}, baxes::Vararg{AbstractUnitRange{<:Integer}, 2}) where T = BlockedArray{T}(λ, baxes)
+BlockedMatrix(λ::UniformScaling, baxes::Vararg{AbstractUnitRange{<:Integer}, 2}) = BlockedArray(λ, baxes)
+BlockedMatrix(λ::UniformScaling, block_sizes::Vararg{AbstractVector{<:Integer}, 2}) = BlockedArray(λ, block_sizes...)
+BlockedMatrix{T}(λ::UniformScaling, baxes::Vararg{AbstractUnitRange{<:Integer}, 2}) where T = BlockedArray{T}(λ, baxes)
+BlockedMatrix{T}(λ::UniformScaling, block_sizes::Vararg{AbstractVector{<:Integer}, 2}) where T = BlockedArray{T}(λ, block_sizes...)
 
 
 # Convert AbstractArrays that conform to block array interface
@@ -205,25 +205,25 @@ end
 to_axes(r::AbstractUnitRange) = r
 to_axes(n::Integer) = Base.oneto(n)
 
-@inline Base.similar(block_array::Type{<:StridedArray{T}}, axes::Tuple{AbstractBlockedUnitRange,Vararg{Union{Integer,AbstractUnitRange{Int}}}}) where T =
+@inline Base.similar(block_array::Type{<:StridedArray{T}}, axes::Tuple{AbstractBlockedUnitRange,Vararg{Union{Integer,AbstractUnitRange{<:Integer}}}}) where T =
     BlockedArray{T}(undef, map(to_axes,axes))
-@inline Base.similar(block_array::Type{<:StridedArray{T}}, axes::Tuple{AbstractBlockedUnitRange,AbstractBlockedUnitRange,Vararg{Union{Integer,AbstractUnitRange{Int}}}}) where T =
+@inline Base.similar(block_array::Type{<:StridedArray{T}}, axes::Tuple{AbstractBlockedUnitRange,AbstractBlockedUnitRange,Vararg{Union{Integer,AbstractUnitRange{<:Integer}}}}) where T =
     BlockedArray{T}(undef, map(to_axes,axes))
-@inline Base.similar(block_array::Type{<:StridedArray{T}}, axes::Tuple{Union{Integer,AbstractUnitRange{Int}},AbstractBlockedUnitRange,Vararg{Union{Integer,AbstractUnitRange{Int}}}}) where T =
-    BlockedArray{T}(undef, map(to_axes,axes))
-
-@inline Base.similar(block_array::StridedArray, ::Type{T}, axes::Tuple{AbstractBlockedUnitRange,Vararg{Union{Integer,AbstractUnitRange{Int}}}}) where T =
-    BlockedArray{T}(undef, map(to_axes,axes))
-@inline Base.similar(block_array::StridedArray, ::Type{T}, axes::Tuple{AbstractBlockedUnitRange,AbstractBlockedUnitRange,Vararg{Union{Integer,AbstractUnitRange{Int}}}}) where T =
-    BlockedArray{T}(undef, map(to_axes,axes))
-@inline Base.similar(block_array::StridedArray, ::Type{T}, axes::Tuple{Union{Integer,AbstractUnitRange{Int}},AbstractBlockedUnitRange,Vararg{Union{Integer,AbstractUnitRange{Int}}}}) where T =
+@inline Base.similar(block_array::Type{<:StridedArray{T}}, axes::Tuple{Union{Integer,AbstractUnitRange{<:Integer}},AbstractBlockedUnitRange,Vararg{Union{Integer,AbstractUnitRange{<:Integer}}}}) where T =
     BlockedArray{T}(undef, map(to_axes,axes))
 
-@inline Base.similar(block_array::BlockedArray, ::Type{T}, axes::Tuple{AbstractBlockedUnitRange,Vararg{Union{Integer,AbstractUnitRange{Int}}}}) where T =
+@inline Base.similar(block_array::StridedArray, ::Type{T}, axes::Tuple{AbstractBlockedUnitRange,Vararg{Union{Integer,AbstractUnitRange{<:Integer}}}}) where T =
     BlockedArray{T}(undef, map(to_axes,axes))
-@inline Base.similar(block_array::BlockedArray, ::Type{T}, axes::Tuple{AbstractBlockedUnitRange,AbstractBlockedUnitRange,Vararg{Union{Integer,AbstractUnitRange{Int}}}}) where T =
+@inline Base.similar(block_array::StridedArray, ::Type{T}, axes::Tuple{AbstractBlockedUnitRange,AbstractBlockedUnitRange,Vararg{Union{Integer,AbstractUnitRange{<:Integer}}}}) where T =
     BlockedArray{T}(undef, map(to_axes,axes))
-@inline Base.similar(block_array::BlockedArray, ::Type{T}, axes::Tuple{Union{Integer,AbstractUnitRange{Int}},AbstractBlockedUnitRange,Vararg{Union{Integer,AbstractUnitRange{Int}}}}) where T =
+@inline Base.similar(block_array::StridedArray, ::Type{T}, axes::Tuple{Union{Integer,AbstractUnitRange{<:Integer}},AbstractBlockedUnitRange,Vararg{Union{Integer,AbstractUnitRange{<:Integer}}}}) where T =
+    BlockedArray{T}(undef, map(to_axes,axes))
+
+@inline Base.similar(block_array::BlockedArray, ::Type{T}, axes::Tuple{AbstractBlockedUnitRange,Vararg{Union{Integer,AbstractUnitRange{<:Integer}}}}) where T =
+    BlockedArray{T}(undef, map(to_axes,axes))
+@inline Base.similar(block_array::BlockedArray, ::Type{T}, axes::Tuple{AbstractBlockedUnitRange,AbstractBlockedUnitRange,Vararg{Union{Integer,AbstractUnitRange{<:Integer}}}}) where T =
+    BlockedArray{T}(undef, map(to_axes,axes))
+@inline Base.similar(block_array::BlockedArray, ::Type{T}, axes::Tuple{Union{Integer,AbstractUnitRange{<:Integer}},AbstractBlockedUnitRange,Vararg{Union{Integer,AbstractUnitRange{<:Integer}}}}) where T =
     BlockedArray{T}(undef, map(to_axes,axes))
 
 @propagate_inbounds getindex(block_arr::BlockedArray{T, N}, i::Vararg{Integer, N}) where {T,N} = block_arr.blocks[i...]
@@ -294,11 +294,11 @@ function ArrayLayouts.rmul!(block_array::BlockedArray, α::Number)
 end
 
 _blocked_reshape(block_array, axes) = BlockedArray(reshape(block_array.blocks,map(length,axes)),axes)
-Base.reshape(block_array::BlockedArray, axes::NTuple{N,AbstractUnitRange{Int}}) where N =
+Base.reshape(block_array::BlockedArray, axes::Tuple{Vararg{AbstractUnitRange{<:Integer},N}}) where N =
     _blocked_reshape(block_array, axes)
 Base.reshape(parent::BlockedArray, shp::Tuple{Union{Integer,Base.OneTo}, Vararg{Union{Integer,Base.OneTo}}}) =
     reshape(parent, Base.to_shape(shp))
-Base.reshape(parent::BlockedArray, dims::Tuple{Int,Vararg{Int}}) =
+Base.reshape(parent::BlockedArray, dims::Tuple{Integer,Vararg{Integer}}) =
     Base._reshape(parent, dims)
 
 """

--- a/src/blockedarray.jl
+++ b/src/blockedarray.jl
@@ -144,7 +144,7 @@ BlockedArray{T}(blocks::AbstractArray{<:Any, N}, block_sizes::Vararg{AbstractVec
 
 BlockedVector(blocks::AbstractVector, baxes::Tuple{AbstractUnitRange{<:Integer}}) = BlockedArray(blocks, baxes)
 BlockedVector(blocks::AbstractVector, block_sizes::AbstractVector{<:Integer}) = BlockedArray(blocks, block_sizes)
-BlockedMatrix(blocks::AbstractMatrix, baxes::Vararg{AbstractUnitRange{<:Integer}, 2}) = BlockedArray(blocks, baxes)
+BlockedMatrix(blocks::AbstractMatrix, baxes::Tuple{Vararg{AbstractUnitRange{<:Integer}, 2}}) = BlockedArray(blocks, baxes)
 BlockedMatrix(blocks::AbstractMatrix, block_sizes::Vararg{AbstractVector{<:Integer}, 2}) = BlockedArray(blocks, block_sizes...)
 
 BlockedArray{T}(λ::UniformScaling, baxes::Vararg{AbstractUnitRange{<:Integer}, 2}) where T = BlockedArray{T}(Matrix(λ, map(length,baxes)...), baxes)

--- a/src/blockedarray.jl
+++ b/src/blockedarray.jl
@@ -147,13 +147,13 @@ BlockedVector(blocks::AbstractVector, block_sizes::AbstractVector{<:Integer}) = 
 BlockedMatrix(blocks::AbstractMatrix, baxes::Tuple{Vararg{AbstractUnitRange{<:Integer}, 2}}) = BlockedArray(blocks, baxes)
 BlockedMatrix(blocks::AbstractMatrix, block_sizes::Vararg{AbstractVector{<:Integer}, 2}) = BlockedArray(blocks, block_sizes...)
 
-BlockedArray{T}(λ::UniformScaling, baxes::Vararg{AbstractUnitRange{<:Integer}, 2}) where T = BlockedArray{T}(Matrix(λ, map(length,baxes)...), baxes)
+BlockedArray{T}(λ::UniformScaling, baxes::Tuple{Vararg{AbstractUnitRange{<:Integer}, 2}}) where T = BlockedArray{T}(Matrix(λ, map(length,baxes)...), baxes)
 BlockedArray{T}(λ::UniformScaling, block_sizes::Vararg{AbstractVector{<:Integer}, 2}) where T = BlockedArray{T}(λ, map(blockedrange,block_sizes))
 BlockedArray(λ::UniformScaling{T}, block_sizes::Vararg{AbstractVector{<:Integer}, 2}) where T = BlockedArray{T}(λ, block_sizes...)
-BlockedArray(λ::UniformScaling{T}, baxes::Vararg{AbstractUnitRange{<:Integer}, 2}) where T = BlockedArray{T}(λ, baxes)
-BlockedMatrix(λ::UniformScaling, baxes::Vararg{AbstractUnitRange{<:Integer}, 2}) = BlockedArray(λ, baxes)
+BlockedArray(λ::UniformScaling{T}, baxes::Tuple{Vararg{AbstractUnitRange{<:Integer}, 2}}) where T = BlockedArray{T}(λ, baxes)
+BlockedMatrix(λ::UniformScaling, baxes::Tuple{Vararg{AbstractUnitRange{<:Integer}, 2}}) = BlockedArray(λ, baxes)
 BlockedMatrix(λ::UniformScaling, block_sizes::Vararg{AbstractVector{<:Integer}, 2}) = BlockedArray(λ, block_sizes...)
-BlockedMatrix{T}(λ::UniformScaling, baxes::Vararg{AbstractUnitRange{<:Integer}, 2}) where T = BlockedArray{T}(λ, baxes)
+BlockedMatrix{T}(λ::UniformScaling, baxes::Tuple{Vararg{AbstractUnitRange{<:Integer}, 2}}) where T = BlockedArray{T}(λ, baxes)
 BlockedMatrix{T}(λ::UniformScaling, block_sizes::Vararg{AbstractVector{<:Integer}, 2}) where T = BlockedArray{T}(λ, block_sizes...)
 
 

--- a/src/blockindices.jl
+++ b/src/blockindices.jl
@@ -257,7 +257,7 @@ the indices over which the Block spans.
 
 This mimics the relationship between `Colon` and `Base.Slice`.
 """
-struct BlockSlice{BB,INDS<:AbstractUnitRange{T},T<:Integer} <: AbstractUnitRange{T}
+struct BlockSlice{BB,T<:Integer,INDS<:AbstractUnitRange{T}} <: AbstractUnitRange{T}
     block::BB
     indices::INDS
 end
@@ -409,9 +409,9 @@ intersect(a::BlockRange{1}, b::BlockRange{1}) = BlockRange(intersect(a.indices[1
 
 # needed for scalar-like broadcasting
 
-BlockSlice{Block{1,BT},RT}(a::Base.OneTo) where {BT,RT<:AbstractUnitRange} =
-    BlockSlice(Block(convert(BT, 1)), convert(RT, a))::BlockSlice{Block{1,BT},RT}
-BlockSlice{BlockRange{1,Tuple{BT}},RT}(a::Base.OneTo) where {BT<:AbstractUnitRange,RT<:AbstractUnitRange} =
-    BlockSlice(BlockRange(convert(BT, Base.OneTo(1))), convert(RT, a))::BlockSlice{BlockRange{1,Tuple{BT}},RT}
-BlockSlice{BlockIndexRange{1,Tuple{BT}},RT}(a::Base.OneTo) where {BT<:AbstractUnitRange,RT<:AbstractUnitRange} =
-    BlockSlice(BlockIndexRange(Block(1), convert(BT, Base.OneTo(1))), convert(RT, a))::BlockSlice{BlockIndexRange{1,Tuple{BT}},RT}
+BlockSlice{Block{1,BT},T,RT}(a::Base.OneTo) where {BT,T,RT<:AbstractUnitRange} =
+    BlockSlice(Block(convert(BT, 1)), convert(RT, a))::BlockSlice{Block{1,BT},T,RT}
+BlockSlice{BlockRange{1,Tuple{BT}},T,RT}(a::Base.OneTo) where {BT<:AbstractUnitRange,T,RT<:AbstractUnitRange} =
+    BlockSlice(BlockRange(convert(BT, Base.OneTo(1))), convert(RT, a))::BlockSlice{BlockRange{1,Tuple{BT}},T,RT}
+BlockSlice{BlockIndexRange{1,Tuple{BT}},T,RT}(a::Base.OneTo) where {BT<:AbstractUnitRange,T,RT<:AbstractUnitRange} =
+    BlockSlice(BlockIndexRange(Block(1), convert(BT, Base.OneTo(1))), convert(RT, a))::BlockSlice{BlockIndexRange{1,Tuple{BT}},T,RT}

--- a/src/show.jl
+++ b/src/show.jl
@@ -87,19 +87,19 @@ function _blockarray_print_matrix_row(io::IO,
     end
 end
 
-function _show_typeof(io::IO, a::BlockVector{T,Vector{Vector{T}},Tuple{DefaultBlockAxis}}) where T
+function _show_typeof(io::IO, a::BlockVector{T,Vector{Vector{T}},<:Tuple{DefaultBlockAxis}}) where T
     print(io, "BlockVector{")
     show(io, T)
     print(io, '}')
 end
 
-function _show_typeof(io::IO, a::BlockMatrix{T,Matrix{Matrix{T}},NTuple{2,DefaultBlockAxis}}) where T
+function _show_typeof(io::IO, a::BlockMatrix{T,Matrix{Matrix{T}},<:Tuple{Vararg{DefaultBlockAxis,2}}}) where T
     print(io, "BlockMatrix{")
     show(io, T)
     print(io, '}')
 end
 
-function _show_typeof(io::IO, a::BlockArray{T,N,Array{Array{T,N},N},NTuple{N,DefaultBlockAxis}}) where {T,N}
+function _show_typeof(io::IO, a::BlockArray{T,N,Array{Array{T,N},N},<:Tuple{Vararg{DefaultBlockAxis,N}}}) where {T,N}
     Base.show_type_name(io, typeof(a).name)
     print(io, '{')
     show(io, T)
@@ -122,19 +122,19 @@ axes_print_matrix_row(::Tuple{AbstractBlockedUnitRange,AbstractUnitRange}, io, X
 Base.print_matrix_row(io::IO, X::AbstractBlockedUnitRange, A::Vector, i::Integer, cols::AbstractVector, sep::AbstractString, idxlast::Integer=last(axes(X, 2))) =
         _blockarray_print_matrix_row(io, X, A, i, cols, sep)
 
-function _show_typeof(io::IO, a::BlockedVector{T,Vector{T},Tuple{DefaultBlockAxis}}) where T
+function _show_typeof(io::IO, a::BlockedVector{T,Vector{T},<:Tuple{DefaultBlockAxis}}) where T
     print(io, "BlockedVector{")
     show(io, T)
     print(io, '}')
 end
 
-function _show_typeof(io::IO, a::BlockedMatrix{T,Matrix{T},NTuple{2,DefaultBlockAxis}}) where T
+function _show_typeof(io::IO, a::BlockedMatrix{T,Matrix{T},<:Tuple{Vararg{DefaultBlockAxis,2}}}) where T
     print(io, "BlockedMatrix{")
     show(io, T)
     print(io, '}')
 end
 
-function _show_typeof(io::IO, a::BlockedArray{T,N,Array{T,N},NTuple{N,DefaultBlockAxis}}) where {T,N}
+function _show_typeof(io::IO, a::BlockedArray{T,N,Array{T,N},<:Tuple{Vararg{DefaultBlockAxis,N}}}) where {T,N}
     Base.show_type_name(io, typeof(a).name)
     print(io, '{')
     show(io, T)

--- a/src/show.jl
+++ b/src/show.jl
@@ -87,19 +87,19 @@ function _blockarray_print_matrix_row(io::IO,
     end
 end
 
-function _show_typeof(io::IO, a::BlockVector{T,Vector{Vector{T}},<:Tuple{DefaultBlockAxis}}) where T
+function _show_typeof(io::IO, a::BlockVector{T,Vector{Vector{T}},<:Tuple{BlockedOneTo{<:Integer}}}) where T
     print(io, "BlockVector{")
     show(io, T)
     print(io, '}')
 end
 
-function _show_typeof(io::IO, a::BlockMatrix{T,Matrix{Matrix{T}},<:Tuple{Vararg{DefaultBlockAxis,2}}}) where T
+function _show_typeof(io::IO, a::BlockMatrix{T,Matrix{Matrix{T}},<:Tuple{Vararg{BlockedOneTo{<:Integer},2}}}) where T
     print(io, "BlockMatrix{")
     show(io, T)
     print(io, '}')
 end
 
-function _show_typeof(io::IO, a::BlockArray{T,N,Array{Array{T,N},N},<:Tuple{Vararg{DefaultBlockAxis,N}}}) where {T,N}
+function _show_typeof(io::IO, a::BlockArray{T,N,Array{Array{T,N},N},<:Tuple{Vararg{BlockedOneTo{<:Integer},N}}}) where {T,N}
     Base.show_type_name(io, typeof(a).name)
     print(io, '{')
     show(io, T)
@@ -122,19 +122,19 @@ axes_print_matrix_row(::Tuple{AbstractBlockedUnitRange,AbstractUnitRange}, io, X
 Base.print_matrix_row(io::IO, X::AbstractBlockedUnitRange, A::Vector, i::Integer, cols::AbstractVector, sep::AbstractString, idxlast::Integer=last(axes(X, 2))) =
         _blockarray_print_matrix_row(io, X, A, i, cols, sep)
 
-function _show_typeof(io::IO, a::BlockedVector{T,Vector{T},<:Tuple{DefaultBlockAxis}}) where T
+function _show_typeof(io::IO, a::BlockedVector{T,Vector{T},<:Tuple{BlockedOneTo{<:Integer}}}) where T
     print(io, "BlockedVector{")
     show(io, T)
     print(io, '}')
 end
 
-function _show_typeof(io::IO, a::BlockedMatrix{T,Matrix{T},<:Tuple{Vararg{DefaultBlockAxis,2}}}) where T
+function _show_typeof(io::IO, a::BlockedMatrix{T,Matrix{T},<:Tuple{Vararg{BlockedOneTo{<:Integer},2}}}) where T
     print(io, "BlockedMatrix{")
     show(io, T)
     print(io, '}')
 end
 
-function _show_typeof(io::IO, a::BlockedArray{T,N,Array{T,N},<:Tuple{Vararg{DefaultBlockAxis,N}}}) where {T,N}
+function _show_typeof(io::IO, a::BlockedArray{T,N,Array{T,N},<:Tuple{Vararg{BlockedOneTo{<:Integer},N}}}) where {T,N}
     Base.show_type_name(io, typeof(a).name)
     print(io, '{')
     show(io, T)

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -186,12 +186,6 @@ end
             @test all(iszero, ret)
 
             ax = blockedrange(1:3)
-            ret = BlockedArray{Float64,1,Vector{Float64},Tuple{typeof(ax)}}(undef, 1:3)
-            fill!(ret, 0)
-            @test size(ret) == (6,)
-            @test all(iszero, ret)
-
-            ax = blockedrange(1:3)
             ret = BlockedArray{Float64,1,Vector{Float64},Tuple{typeof(ax)}}(undef, (ax,))
             fill!(ret, 0)
             @test size(ret) == (6,)

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -123,6 +123,20 @@ end
                 @test all(isone, o)
                 @test axes(o) == (br,)
             end
+
+            # non-Int block lengths
+            blocklen = big(10)^30
+            blks = [Fill(1.0, blocklen), Fill(2.0, blocklen)]
+            ret = BlockArray{eltype(eltype(blks)),ndims(blks),typeof(blks)}(undef_blocks, [blocklen, blocklen])
+            ret[Block(1)] = blks[1]
+            ret[Block(2)] = blks[2]
+            @test size(ret) == (2blocklen,)
+            @test blocksize(ret) == (2,)
+            @test blocklengths.(axes(ret)) == ([blocklen,blocklen],)
+            @test ret[Block(1)] == Fill(1.0, blocklen)
+            @test ret[Block(2)] == Fill(2.0, blocklen)
+            @test ret[1] == 1.0
+            @test ret[blocklen + 1] == 2.0
         end
 
         @testset "BlockedArray constructors" begin

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -165,6 +165,10 @@ end
             @test size(ret) == (6,)
             @test all(iszero, ret)
 
+            ret2 = BlockedArray{Float64}(ret, (blockedrange(1:3),))
+            @test size(ret2) == (6,)
+            @test all(iszero, ret2)
+
             ret = BlockedVector{Float64}(undef, 1:3)
             fill!(ret, 0)
             @test size(ret) == (6,)

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -62,11 +62,26 @@ end
             @test size(ret) == (6,)
             @test all(iszero, ret)
 
+            ax = blockedrange(1:3)
+            ret = BlockArray{Float64,1,Vector{Vector{Float64}},Tuple{typeof(ax)}}(undef, (ax,))
+            fill!(ret, 0)
+            @test size(ret) == (6,)
+            @test all(iszero, ret)
+
+            ret = BlockArray{Float64,1,Vector{Vector{Float64}},Tuple{Base.OneTo{Int}}}(undef, (3,))
+            fill!(ret, 0)
+            @test size(ret) == (3,)
+            @test all(iszero, ret)
+
             ret = BlockArrays._BlockArray([[0.0],[0.0,0.0],[0.0,0.0,0.0]], 1:3)
             @test size(ret) == (6,)
             @test all(iszero, ret)
 
             ret = BlockArrays._BlockArray([[0.0],[0.0,0.0],[0.0,0.0,0.0]], (blockedrange(1:3),))
+            @test size(ret) == (6,)
+            @test all(iszero, ret)
+
+            ret = BlockArrays._BlockArray(Vector[[0.0],[0.0,0.0],[0.0,0.0,0.0]], (blockedrange(1:3),))
             @test size(ret) == (6,)
             @test all(iszero, ret)
 
@@ -240,6 +255,11 @@ end
             @test all(iszero, a)
             @test eltype(ret.blocks) <: SparseMatrixCSC
             @test axes(ret) == blockedrange.(([1, 2, 5], [3, 4]))
+
+            ret = @inferred mortar([[1, 2], [3, 4, 5]], (blockedrange([2, 3]),))
+            @test eltype(ret) == Int
+            @test axes(ret) == (blockedrange([2, 3]),)
+            @test ret == 1:5
 
             test_error_message("must have ndims consistent with ndims = 1") do
                 mortar([ones(2,2)])

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -172,17 +172,14 @@ end
 
             # non-Int block lengths
             blocklen = big(10)^30
-            blks = [Fill(1.0, blocklen), Fill(2.0, blocklen)]
-            ret = BlockedArray{Float64,1,eltype(blks)}(undef_blocks, [blocklen,blocklen])
-            ret[Block(1)] = blks[1]
-            ret[Block(2)] = blks[2]
+            ret = BlockedArray(1:2blocklen, [blocklen,blocklen])
             @test size(ret) == (2blocklen,)
             @test blocksize(ret) == (2,)
             @test blocklengths.(axes(ret)) == ([blocklen,blocklen],)
-            @test ret[Block(1)] == Fill(1.0, blocklen)
-            @test ret[Block(2)] == Fill(2.0, blocklen)
-            @test ret[1] == 1.0
-            @test ret[blocklen + 1] == 2.0
+            @test ret[Block(1)] == 1:blocklen
+            @test ret[Block(2)] == (blocklen+1):2blocklen
+            @test ret[1] == 1
+            @test ret[2blocklen] == 2blocklen
         end
 
         @testset "similar" begin

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -127,7 +127,7 @@ end
             # non-Int block lengths
             blocklen = big(10)^30
             blks = [Fill(1.0, blocklen), Fill(2.0, blocklen)]
-            ret = BlockArray{eltype(eltype(blks)),ndims(blks),typeof(blks)}(undef_blocks, [blocklen, blocklen])
+            ret = BlockArray{Float64,1,typeof(blks)}(undef_blocks, [blocklen,blocklen])
             ret[Block(1)] = blks[1]
             ret[Block(2)] = blks[2]
             @test size(ret) == (2blocklen,)
@@ -169,6 +169,20 @@ end
                 @test BlockedMatrix(M) == M
                 @test BlockedArray(M) == M
             end
+
+            # non-Int block lengths
+            blocklen = big(10)^30
+            blks = [Fill(1.0, blocklen), Fill(2.0, blocklen)]
+            ret = BlockedArray{Float64,1,eltype(blks)}(undef_blocks, [blocklen,blocklen])
+            ret[Block(1)] = blks[1]
+            ret[Block(2)] = blks[2]
+            @test size(ret) == (2blocklen,)
+            @test blocksize(ret) == (2,)
+            @test blocklengths.(axes(ret)) == ([blocklen,blocklen],)
+            @test ret[Block(1)] == Fill(1.0, blocklen)
+            @test ret[Block(2)] == Fill(2.0, blocklen)
+            @test ret[1] == 1.0
+            @test ret[blocklen + 1] == 2.0
         end
 
         @testset "similar" begin

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -160,6 +160,11 @@ end
             @test size(ret) == (6,)
             @test all(iszero, ret)
 
+            ret = BlockedArray{Float64}(undef, (blockedrange(1:3),))
+            fill!(ret, 0)
+            @test size(ret) == (6,)
+            @test all(iszero, ret)
+
             ret = BlockedVector{Float64}(undef, 1:3)
             fill!(ret, 0)
             @test size(ret) == (6,)
@@ -168,6 +173,28 @@ end
             ret = BlockedArray{Float64}(undef, 1:3, 1:3)
             fill!(ret, 0)
             @test size(ret) == (6,6)
+            @test all(iszero, ret)
+
+            ret = BlockedArray{Float64,1,Vector{Float64}}(undef, 1:3)
+            fill!(ret, 0)
+            @test size(ret) == (6,)
+            @test all(iszero, ret)
+
+            ret = BlockedArray{Float64,1,Vector{Float64}}(undef, (blockedrange(1:3),))
+            fill!(ret, 0)
+            @test size(ret) == (6,)
+            @test all(iszero, ret)
+
+            ax = blockedrange(1:3)
+            ret = BlockedArray{Float64,1,Vector{Float64},Tuple{typeof(ax)}}(undef, 1:3)
+            fill!(ret, 0)
+            @test size(ret) == (6,)
+            @test all(iszero, ret)
+
+            ax = blockedrange(1:3)
+            ret = BlockedArray{Float64,1,Vector{Float64},Tuple{typeof(ax)}}(undef, (ax,))
+            fill!(ret, 0)
+            @test size(ret) == (6,)
             @test all(iszero, ret)
 
             A = [1,2,3,4,5,6]
@@ -731,6 +758,7 @@ end
         @test reshape(A, Val(2)) == BlockedArray(reshape(1:6,6,1), (blockedrange(1:3), Base.OneTo(1)))
         @test reshape(A, (blockedrange(Fill(2,3)),))[Block(1)] == 1:2
         @test reshape(A, 2, 3) == reshape(A, Base.OneTo(2), 3) == reshape(Vector(A), 2, 3)
+        @test reshape(A, 2, 3) == reshape(A, 2, :) == reshape(A, UInt(2), :)
 
         @test_throws DimensionMismatch reshape(A,3)
 
@@ -739,6 +767,7 @@ end
         @test reshape(A, Val(2)) == BlockedArray(reshape(1:6,6,1), (blockedrange(1:3), Base.OneTo(1)))
         @test reshape(A, (blockedrange(Fill(2,3)),))[Block(1)] == 1:2
         @test reshape(A, 2, 3) == reshape(A, Base.OneTo(2), 3) == reshape(Vector(A), 2, 3)
+        @test reshape(A, 2, 3) == reshape(A, 2, :) == reshape(A, UInt(2), :)
     end
 
     @testset "*" begin

--- a/test/test_blockindices.jl
+++ b/test/test_blockindices.jl
@@ -90,6 +90,10 @@ import BlockArrays: BlockIndex, BlockIndexRange, BlockSlice
         @test Block(1,1)[1:2,1:2] == BlockIndexRange(Block(1,1),(1:2,1:2))
         @test Block(1)[1:3][1:2] == BlockIndexRange(Block(1),1:2)
         @test BlockIndex((2,2,2),(2,)) == BlockIndex((2,2,2),(2,1,)) == BlockIndex((2,2,2),(2,1,1))
+        @test BlockIndex(2,(2,)) === BlockIndex((2,),(2,))
+        @test BlockIndex(UInt(2),(2,)) === BlockIndex((UInt(2),),(2,))
+        @test BlockIndex(Block(2),2) === BlockIndex(Block(2),(2,))
+        @test BlockIndex(Block(2),UInt(2)) === BlockIndex(Block(2),(UInt(2),))
     end
 
     @testset "BlockRange" begin

--- a/test/test_blockindices.jl
+++ b/test/test_blockindices.jl
@@ -255,16 +255,18 @@ end
     end
 
     @testset "convert" begin
-        b = blockedrange(1, Fill(2,3))
-        c = blockedrange(1, [2,2,2])
-        @test oftype(b, b) === b
-        @test blockisequal(convert(BlockedUnitRange, Base.OneTo(5)), blockedrange(1, [5]))
-        @test blockisequal(convert(BlockedUnitRange, Base.Slice(Base.OneTo(5))), blockedrange(1, [5]))
-        @test blockisequal(convert(BlockedUnitRange, Base.IdentityUnitRange(-2:2)), BlockArrays._BlockedUnitRange(-2,[2]))
-        @test convert(BlockedUnitRange{Int,Vector{Int}}, c) === c
-        @test blockisequal(convert(BlockedUnitRange{Int,Vector{Int}}, b),b)
-        @test blockisequal(convert(BlockedUnitRange{Int,Vector{Int}}, Base.OneTo(5)), blockedrange(1, [5]))
-        @test blockisequal(convert(BlockedUnitRange, BlockedOneTo(1:3)), blockedrange(1, [1,1,1]))
+        for elt in (Int, UInt)
+            b = blockedrange(elt(1), Fill(elt(2),3))
+            c = blockedrange(elt(1), elt[2,2,2])
+            @test oftype(b, b) === b
+            @test blockisequal(convert(BlockedUnitRange, Base.OneTo(5)), blockedrange(1, [5]))
+            @test blockisequal(convert(BlockedUnitRange, Base.Slice(Base.OneTo(5))), blockedrange(1, [5]))
+            @test blockisequal(convert(BlockedUnitRange, Base.IdentityUnitRange(-2:2)), BlockArrays._BlockedUnitRange(-2,[2]))
+            @test convert(BlockedUnitRange{elt,Vector{elt}}, c) === c
+            @test blockisequal(convert(BlockedUnitRange{Int,Vector{Int}}, b),b)
+            @test blockisequal(convert(BlockedUnitRange{Int,Vector{Int}}, Base.OneTo(5)), blockedrange(1, [5]))
+            @test blockisequal(convert(BlockedUnitRange, BlockedOneTo(1:3)), blockedrange(1, [1,1,1]))
+        end
     end
 
     @testset "findblock" begin


### PR DESCRIPTION
The element types of `BlockedUnitRange`/`BlockedOneTo` were generalized to any `Integer` type in BlockArrays v1 (#255, #337, #395). However, the axes of `BlockArray` and `BlockedArray` are still hardcoded to have element type `Int`. This PR lifts that restriction.

Note that currently there is an issue printing very large BlockArray/BlockedArray:
```julia
julia> BlockedArray(1:2big(10)^10, [big(10)^10,big(10)^10])
2-blocked 20000000000-element BlockedVector{BigInt, UnitRange{BigInt}, Tuple{BlockedOneTo{BigInt, Vector{BigInt}}}}:
           1
           2
           3
           4
           5
           6
           7
           8
           9
          10
          11
          12
          13
          14
          15
          16
           ⋮
 19999999986
 19999999987
 19999999988
 19999999989
 19999999990
 19999999991
 19999999992
 19999999993
 19999999994
 19999999995
 19999999996
 19999999997
 19999999998
 19999999999
 20000000000

julia> BlockedArray(1:2big(10)^20, [big(10)^20,big(10)^20])
2-blocked 200000000000000000000-element BlockedVector{BigInt, UnitRange{BigInt}, Tuple{BlockedOneTo{BigInt, Vector{BigInt}}}}:
Error showing value of type BlockedVector{BigInt, UnitRange{BigInt}, Tuple{BlockedOneTo{BigInt, Vector{BigInt}}}}:
ERROR: InexactError: Int64(199999999999999999986)
Stacktrace:
  [1] Type
    @ ./gmp.jl:384 [inlined]
  [2] convert
    @ ./number.jl:7 [inlined]
  [3] to_index
    @ ./indices.jl:292 [inlined]
  [4] to_index
    @ ./indices.jl:277 [inlined]
  [5] _to_indices1
    @ ./indices.jl:359 [inlined]
  [6] to_indices
    @ ./indices.jl:354 [inlined]
  [7] to_indices
    @ ./indices.jl:350 [inlined]
  [8] isassigned(::BlockedVector{BigInt, UnitRange{BigInt}, Tuple{BlockedOneTo{BigInt, Vector{BigInt}}}}, ::BigInt, ::Int64)
    @ Base ./multidimensional.jl:1568
  [9] alignment(io::IOContext{…}, X::AbstractVecOrMat, rows::Vector{…}, cols::Vector{…}, cols_if_complete::Int64, cols_otherwise::Int64, sep::Int64, ncols::Int64)
    @ Base ./arrayshow.jl:68
 [10] _print_matrix(io::IOContext{…}, X::AbstractVecOrMat, pre::String, sep::String, post::String, hdots::String, vdots::String, ddots::String, hmod::Int64, vmod::Int64, rowsA::UnitRange{…}, colsA::UnitRange{…})
    @ Base ./arrayshow.jl:207
 [11] print_matrix(io::IOContext{…}, X::BlockedVector{…}, pre::String, sep::String, post::String, hdots::String, vdots::String, ddots::String, hmod::Int64, vmod::Int64)
    @ Base ./arrayshow.jl:171
 [12] print_matrix
    @ ./arrayshow.jl:171 [inlined]
 [13] print_array
    @ ./arrayshow.jl:358 [inlined]
 [14] show(io::IOContext{Base.TTY}, ::MIME{Symbol("text/plain")}, X::BlockedVector{BigInt, UnitRange{BigInt}, Tuple{BlockedOneTo{…}}})
    @ Base ./arrayshow.jl:399
 [15] (::OhMyREPL.var"#15#16"{REPL.REPLDisplay{REPL.LineEditREPL}, MIME{Symbol("text/plain")}, Base.RefValue{Any}})(io::IOContext{Base.TTY})
    @ OhMyREPL ~/.julia/packages/OhMyREPL/6UG7a/src/output_prompt_overwrite.jl:23
 [16] with_repl_linfo(f::Any, repl::REPL.LineEditREPL)
    @ REPL ~/.julia/juliaup/julia-1.10.4+0.aarch64.apple.darwin14/share/julia/stdlib/v1.10/REPL/src/REPL.jl:569
 [17] display
    @ ~/.julia/packages/OhMyREPL/6UG7a/src/output_prompt_overwrite.jl:6 [inlined]
 [18] display
    @ ~/.julia/juliaup/julia-1.10.4+0.aarch64.apple.darwin14/share/julia/stdlib/v1.10/REPL/src/REPL.jl:278 [inlined]
 [19] display(x::Any)
    @ Base.Multimedia ./multimedia.jl:340
 [20] print_response(errio::IO, response::Any, show_value::Bool, have_color::Bool, specialdisplay::Union{Nothing, AbstractDisplay})
    @ REPL ~/.julia/juliaup/julia-1.10.4+0.aarch64.apple.darwin14/share/julia/stdlib/v1.10/REPL/src/REPL.jl:0
 [21] (::REPL.var"#57#58"{REPL.LineEditREPL, Pair{Any, Bool}, Bool, Bool})(io::Any)
    @ REPL ~/.julia/juliaup/julia-1.10.4+0.aarch64.apple.darwin14/share/julia/stdlib/v1.10/REPL/src/REPL.jl:284
 [22] with_repl_linfo(f::Any, repl::REPL.LineEditREPL)
    @ REPL ~/.julia/juliaup/julia-1.10.4+0.aarch64.apple.darwin14/share/julia/stdlib/v1.10/REPL/src/REPL.jl:569
 [23] print_response(repl::REPL.AbstractREPL, response::Any, show_value::Bool, have_color::Bool)
    @ REPL ~/.julia/juliaup/julia-1.10.4+0.aarch64.apple.darwin14/share/julia/stdlib/v1.10/REPL/src/REPL.jl:282
 [24] (::REPL.var"#do_respond#80"{…})(s::REPL.LineEdit.MIState, buf::Any, ok::Bool)
    @ REPL ~/.julia/juliaup/julia-1.10.4+0.aarch64.apple.darwin14/share/julia/stdlib/v1.10/REPL/src/REPL.jl:911
 [25] #invokelatest#2
    @ ./essentials.jl:892 [inlined]
 [26] invokelatest
    @ ./essentials.jl:889 [inlined]
 [27] run_interface(terminal::REPL.Terminals.TextTerminal, m::REPL.LineEdit.ModalInterface, s::REPL.LineEdit.MIState)
    @ REPL.LineEdit ~/.julia/juliaup/julia-1.10.4+0.aarch64.apple.darwin14/share/julia/stdlib/v1.10/REPL/src/LineEdit.jl:2656
 [28] run_frontend(repl::REPL.LineEditREPL, backend::REPL.REPLBackendRef)
    @ REPL ~/.julia/juliaup/julia-1.10.4+0.aarch64.apple.darwin14/share/julia/stdlib/v1.10/REPL/src/REPL.jl:1312
 [29] (::REPL.var"#62#68"{REPL.LineEditREPL, REPL.REPLBackendRef})()
    @ REPL ~/.julia/juliaup/julia-1.10.4+0.aarch64.apple.darwin14/share/julia/stdlib/v1.10/REPL/src/REPL.jl:386
Some type information was truncated. Use `show(err)` to see complete types.
```
This appears to be a Base Julia issue, see https://github.com/JuliaLang/julia/issues/54786.