### PR TITLE
Bump to v1.1.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BlockArrays"
 uuid = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
-version = "1.0.1"
+version = "1.1.0"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"


### PR DESCRIPTION
To register recent changes like #405, presumably that warrants a minor version bump.