### PR TITLE
Fix zero dimensional BlockArray and BlockedArray

### DIFF
--- a/src/abstractblockarray.jl
+++ b/src/abstractblockarray.jl
@@ -101,6 +101,7 @@ end
 
 blockcheckbounds(A::AbstractArray{T, N}, i::Block{N}) where {T,N} = blockcheckbounds(A, i.n...)
 blockcheckbounds(A::AbstractArray{T, N}, i::Vararg{Block{1},N}) where {T,N} = blockcheckbounds(A, Int.(i)...)
+blockcheckbounds(::AbstractArray{T, 0}) where {T} = true
 blockcheckbounds(A::AbstractVector{T}, i::Block{1}) where {T} = blockcheckbounds(A, Int(i))
 
 """

--- a/src/abstractblockarray.jl
+++ b/src/abstractblockarray.jl
@@ -187,7 +187,7 @@ viewblock(block_arr, block) = Base.invoke(view, Tuple{AbstractArray, Any}, block
     blkind = BlockRange(blocksize(block_arr))[Int(block)]
     view(block_arr, blkind)
 end
-@inline view(zerodim::AbstractBlockArray{<:Any,0}) = view(blocks(zerodim)[])
+@inline view(zerodim::AbstractBlockArray{<:Any,0}) = view(zerodim.blocks[])
 @inline view(block_arr::AbstractBlockVector, block::Block{1}) = viewblock(block_arr, block)
 @propagate_inbounds view(block_arr::AbstractBlockArray, block::Block{1}...) = view(block_arr, Block(block))
 

--- a/src/abstractblockarray.jl
+++ b/src/abstractblockarray.jl
@@ -187,6 +187,7 @@ viewblock(block_arr, block) = Base.invoke(view, Tuple{AbstractArray, Any}, block
     blkind = BlockRange(blocksize(block_arr))[Int(block)]
     view(block_arr, blkind)
 end
+@inline view(zerodim::AbstractBlockArray{<:Any,0}) = view(blocks(zerodim)[])
 @inline view(block_arr::AbstractBlockVector, block::Block{1}) = viewblock(block_arr, block)
 @propagate_inbounds view(block_arr::AbstractBlockArray, block::Block{1}...) = view(block_arr, Block(block))
 

--- a/src/blockarray.jl
+++ b/src/blockarray.jl
@@ -265,6 +265,12 @@ function BlockArray{T}(arr::AbstractArray{T, N}, baxes::Tuple{Vararg{AbstractUni
     return _BlockArray(blocks, baxes)
 end
 
+function BlockArray{T}(arr::AbstractArray{T, 0}, ::Tuple{}) where T
+    blocks = Array{Array{T, 0},0}(undef)
+    fill!(blocks, arr)
+    return _BlockArray(blocks)
+end
+
 BlockArray{T}(arr::AbstractArray{<:Any, N}, baxes::Tuple{Vararg{AbstractUnitRange{<:Integer},N}}) where {T,N} =
     BlockArray{T}(convert(AbstractArray{T, N}, arr), baxes)
 
@@ -461,6 +467,10 @@ const OffsetAxis = Union{Integer, UnitRange, Base.OneTo, Base.IdentityUnitRange}
     @boundscheck checkbounds(block_arr, i...)
     @inbounds v = block_arr[findblockindex.(axes(block_arr), i)...]
     return v
+end
+
+@inline function getindex(block_arr::BlockArray{T, 0}) where T
+    return blocks(block_arr)[][]
 end
 
 @inline function setindex!(block_arr::BlockArray{T, N}, v, i::Vararg{Integer, N}) where {T,N}

--- a/src/blockarray.jl
+++ b/src/blockarray.jl
@@ -542,6 +542,11 @@ end
 ########
 # Misc #
 ########
+function Base.Array(zerodim::BlockArray{T, 0}) where {T}
+    arr = Array{T}(undef)
+    arr[] = zerodim[]
+    return arr
+end
 
 function Base.Array(block_array::BlockArray{T, N, R}) where {T,N,R}
     arr = Array{eltype(T)}(undef, size(block_array))

--- a/src/blockarray.jl
+++ b/src/blockarray.jl
@@ -479,6 +479,11 @@ end
     return block_arr
 end
 
+@inline function setindex!(block_arr::BlockArray{<:Any, 0}, v)
+    blocks(block_arr)[][] = v
+end
+
+
 ############
 # Indexing #
 ############

--- a/src/blockarray.jl
+++ b/src/blockarray.jl
@@ -567,6 +567,8 @@ end
 # Temporary work around
 Base.reshape(block_array::BlockArray, axes::Tuple{Vararg{AbstractUnitRange{<:Integer},N}}) where N =
     reshape(BlockedArray(block_array), axes)
+Base.reshape(block_array::BlockArray, ::Tuple{}) =
+    reshape(BlockedArray(block_array), ())  # zerodim
 Base.reshape(block_array::BlockArray, dims::Tuple{Int,Vararg{Int}}) =
     reshape(BlockedArray(block_array), dims)
 Base.reshape(block_array::BlockArray, axes::Tuple{Union{Integer,Base.OneTo}, Vararg{Union{Integer,Base.OneTo}}}) =

--- a/src/blockedarray.jl
+++ b/src/blockedarray.jl
@@ -99,6 +99,7 @@ const BlockedVector{T} = BlockedArray{T, 1}
 const BlockedVecOrMat{T} = Union{BlockedMatrix{T}, BlockedVector{T}}
 
 # Auxiliary outer constructors
+BlockedArray(x::Number, ::Tuple{}) = x  # zero dimensional
 @inline BlockedArray(blocks::R, baxes::BS) where {T,N,R<:AbstractArray{T,N},BS<:Tuple{Vararg{AbstractUnitRange{<:Integer},N}}} =
     BlockedArray{T, N, R,BS}(blocks, baxes)
 

--- a/src/blockedarray.jl
+++ b/src/blockedarray.jl
@@ -302,6 +302,8 @@ Base.reshape(parent::BlockedArray, shp::Tuple{Union{Int,Base.OneTo}, Vararg{Unio
     reshape(parent, Base.to_shape(shp))
 Base.reshape(parent::BlockedArray, dims::Tuple{Int,Vararg{Int}}) =
     Base._reshape(parent, dims)
+Base.reshape(block_array::BlockedArray, ::Tuple{}) =
+    _blocked_reshape(block_array, ())  # zero dim
 
 """
     resize!(a::BlockedVector, N::Block) -> BlockedVector

--- a/src/blockedarray.jl
+++ b/src/blockedarray.jl
@@ -240,6 +240,7 @@ end
 ############
 # Indexing #
 ############
+@inline view(block_arr::BlockedArray{<:Any, 0}) = view(block_arr.blocks)
 
 @inline function viewblock(block_arr::BlockedArray, block)
     range = getindex.(axes(block_arr), Block.(block.n))

--- a/src/blockindices.jl
+++ b/src/blockindices.jl
@@ -202,6 +202,7 @@ BlockIndexRange(block::Block{N}, inds::Vararg{AbstractUnitRange{<:Integer},N}) w
 
 block(R::BlockIndexRange) = R.block
 
+getindex(::Block{0}) = Block()
 getindex(B::Block{N}, inds::Vararg{Integer,N}) where N = BlockIndex(B,inds)
 getindex(B::Block{N}, inds::Vararg{AbstractUnitRange{<:Integer},N}) where N = BlockIndexRange(B,inds)
 getindex(B::Block{1}, inds::Colon) = B

--- a/src/views.jl
+++ b/src/views.jl
@@ -69,28 +69,43 @@ _splatmap(f, t::Tuple) = (f(t[1])..., _splatmap(f, tail(t))...)
 # De-reference blocks before creating a view to avoid taking `global2blockindex`
 # path in `AbstractBlockStyle` broadcasting.
 @propagate_inbounds function Base.unsafe_view(
-        A::BlockArray{<:Any, N},
-        I::Vararg{BlockSlice{<:BlockIndexRange{1}}, N}) where {N}
+    A::BlockArray,
+    I1::BlockSlice{<:BlockIndexRange{1}},
+    Is::Vararg{BlockSlice{<:BlockIndexRange{1}}},
+)
+    I = (I1, Is...)
+    @assert ndims(A) == length(I)
     B = view(A, map(block, I)...)
     return view(B, _splatmap(x -> x.block.indices, I)...)
 end
 
 @propagate_inbounds function Base.unsafe_view(
-        A::BlockedArray{<:Any, N},
-        I::Vararg{BlockSlice{<:BlockIndexRange{1}}, N}) where {N}
-    return view(A.blocks, map(x -> x.indices, I)...)
+    A::BlockedArray,
+    I1::BlockSlice{<:BlockIndexRange{1}},
+    Is::Vararg{BlockSlice{<:BlockIndexRange{1}}},
+)
+    I = (I1, Is...)
+    @assert ndims(A) == length(I), return view(A.blocks, map(x -> x.indices, I)...)
 end
 
-@propagate_inbounds  function Base.unsafe_view(
-        A::ReshapedArray{<:Any, N, <:AbstractBlockArray{<:Any, M}},
-        I::Vararg{BlockSlice{<:BlockIndexRange{1}}, N}) where {N, M}
+@propagate_inbounds function Base.unsafe_view(
+    A::ReshapedArray{<:Any,N,<:AbstractBlockArray{<:Any,M}},
+    I1::BlockSlice{<:BlockIndexRange{1}},
+    Is::Vararg{BlockSlice{<:BlockIndexRange{1}}},
+) where {N,M}
     # Note: assuming that I[M+1:end] are verified to be singletons
+    I = (I1, Is...)
+    @assert ndims(A) == length(I)
     return reshape(view(A.parent, I[1:M]...), Val(N))
 end
 
-@propagate_inbounds  function Base.unsafe_view(
-        A::Array{<:Any, N},
-        I::Vararg{BlockSlice{<:BlockIndexRange{1}}, N}) where {N}
+@propagate_inbounds function Base.unsafe_view(
+    A::Array,
+    I1::BlockSlice{<:BlockIndexRange{1}},
+    Is::Vararg{BlockSlice{<:BlockIndexRange{1}}},
+)
+    I = (I1, Is...)
+    @assert ndims(A) == length(I)
     return view(A, map(x -> x.indices, I)...)
 end
 

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -328,12 +328,15 @@ end
             @test view(ret, Block()) == zeros()
             ret[] = 1
             @test ret[] == 1
+            @test view(ret) == ones()
+            view(ret)[] = 0
+            @test ret[] == 0
+            @test_broken Array(ret) == zeros()
 
             ret = BlockArrays.BlockArray(zeros())
             @test size(ret) == ()
             @test all(iszero, ret)
             @test ret[Block()] == zeros()
-            @test ret[] == 0
 
             ret = BlockedArray{Float64}(undef)
             fill!(ret, 0)
@@ -343,6 +346,7 @@ end
             @test ret[Block()] == zeros()
             ret[] = 1
             @test ret[] == 1
+            @test Array(ret) == ones()
 
             ret = BlockedArray(zeros())
             @test size(ret) == ()

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -326,6 +326,8 @@ end
             @test ret[Block()] == zeros()
             @test ret[] == 0
             @test view(ret, Block()) == zeros()
+            ret[] = 1
+            @test ret[] == 1
 
             ret = BlockArrays.BlockArray(zeros())
             @test size(ret) == ()
@@ -337,7 +339,10 @@ end
             fill!(ret, 0)
             @test size(ret) == ()
             @test all(iszero, ret)
+            @test ret[] == 0
             @test ret[Block()] == zeros()
+            ret[] = 1
+            @test ret[] == 1
 
             ret = BlockedArray(zeros())
             @test size(ret) == ()

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -318,6 +318,28 @@ end
             @test all(isone, M)
         end
 
+        @testset "zero dim" begin
+            ret = BlockArray{Float64}(undef)
+            fill!(ret, 0)
+            @test size(ret) == ()
+            @test_broken all(iszero, ret)
+            @test_broken ret[Block()] == 0
+            @test_broken ret[] == 0
+
+            @test_broken BlockArrays._BlockArray(ones())
+
+            ret = BlockedArray{Float64}(undef)
+            fill!(ret, 0)
+            @test size(ret) == ()
+            @test all(iszero, ret)
+            @test_broken ret[Block()] == 0
+
+            ret = BlockedArray(zeros())
+            @test size(ret) == ()
+            @test all(iszero, ret)
+            @test_broken ret[Block()] == 0
+        end
+
         @testset "BlockVector" begin
             a_data = [1,2,3]
             a = BlockVector(a_data,[1,2])

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -326,12 +326,12 @@ end
             @test ret[Block()] == zeros()
             @test ret[] == 0
             @test view(ret, Block()) == zeros()
+            @test Array(ret) == zeros()
             ret[] = 1
             @test ret[] == 1
             @test view(ret) == ones()
             view(ret)[] = 0
             @test ret[] == 0
-            @test_broken Array(ret) == zeros()
 
             ret = BlockArrays.BlockArray(zeros())
             @test size(ret) == ()
@@ -344,9 +344,12 @@ end
             @test all(iszero, ret)
             @test ret[] == 0
             @test ret[Block()] == zeros()
+            @test Array(ret) == zeros()
             ret[] = 1
             @test ret[] == 1
-            @test Array(ret) == ones()
+            @test_broken view(ret) == ones()
+            @test_broken view(ret)[] = 0
+            @test_broken ret[] == 0
 
             ret = BlockedArray(zeros())
             @test size(ret) == ()

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -328,6 +328,7 @@ end
             @test size(ret) == ()
             @test all(iszero, ret)
             @test ret[Block()] == zeros()
+            @test ret[Block()[]] == zeros()
             @test ret[] == 0
             @test view(ret, Block()) == zeros()
             @test Array(ret) == zeros()
@@ -354,6 +355,7 @@ end
             @test all(iszero, ret)
             @test ret[] == 0
             @test ret[Block()] == zeros()
+            @test ret[Block()[]] == zeros()
             @test Array(ret) == zeros()
             ret[] = 1
             @test ret[] == 1

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -337,12 +337,12 @@ end
             fill!(ret, 0)
             @test size(ret) == ()
             @test all(iszero, ret)
-            @test_broken ret[Block()] == 0
+            @test ret[Block()] == zeros()
 
             ret = BlockedArray(zeros())
             @test size(ret) == ()
             @test all(iszero, ret)
-            @test_broken ret[Block()] == 0
+            @test ret[Block()] == zeros()
         end
 
         @testset "BlockVector" begin

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -322,11 +322,16 @@ end
             ret = BlockArray{Float64}(undef)
             fill!(ret, 0)
             @test size(ret) == ()
-            @test_broken all(iszero, ret)
-            @test_broken ret[Block()] == 0
-            @test_broken ret[] == 0
+            @test all(iszero, ret)
+            @test ret[Block()] == zeros()
+            @test ret[] == 0
+            @test view(ret, Block()) == zeros()
 
-            @test_broken BlockArrays._BlockArray(ones())
+            ret = BlockArrays.BlockArray(zeros())
+            @test size(ret) == ()
+            @test all(iszero, ret)
+            @test ret[Block()] == zeros()
+            @test ret[] == 0
 
             ret = BlockedArray{Float64}(undef)
             fill!(ret, 0)

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -347,9 +347,9 @@ end
             @test Array(ret) == zeros()
             ret[] = 1
             @test ret[] == 1
-            @test_broken view(ret) == ones()
-            @test_broken view(ret)[] = 0
-            @test_broken ret[] == 0
+            @test view(ret) == ones()
+            view(ret)[] = 0
+            @test ret[] == 0
 
             ret = BlockedArray(zeros())
             @test size(ret) == ()

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -319,7 +319,11 @@ end
         end
 
         @testset "zero dim" begin
+            zerodim = ones()
+            @test view(zerodim) isa AbstractArray{Float64, 0}  #  check no type-piracy
+
             ret = BlockArray{Float64}(undef)
+            @test ret isa BlockArray{Float64, 0}
             fill!(ret, 0)
             @test size(ret) == ()
             @test all(iszero, ret)
@@ -334,11 +338,17 @@ end
             @test ret[] == 0
 
             ret = BlockArrays.BlockArray(zeros())
+            @test ret isa BlockArray{Float64, 0}
             @test size(ret) == ()
             @test all(iszero, ret)
             @test ret[Block()] == zeros()
 
+            ret = BlockArrays.BlockArray(zeros(1,1))
+            @test reshape(ret, ()) isa AbstractBlockArray{Float64, 0}  # may be BlockedArray
+            @test size(reshape(ret, ())) == ()
+
             ret = BlockedArray{Float64}(undef)
+            @test ret isa BlockedArray{Float64, 0}
             fill!(ret, 0)
             @test size(ret) == ()
             @test all(iszero, ret)
@@ -355,6 +365,10 @@ end
             @test size(ret) == ()
             @test all(iszero, ret)
             @test ret[Block()] == zeros()
+
+            ret = BlockArrays.BlockedArray(zeros(1,1))
+            @test reshape(ret, ()) isa BlockedArray{Float64, 0}
+            @test size(reshape(ret, ())) == ()
         end
 
         @testset "BlockVector" begin

--- a/test/test_blocklinalg.jl
+++ b/test/test_blocklinalg.jl
@@ -14,7 +14,9 @@ bview(a, b) = Base.invoke(view, Tuple{AbstractArray,Any}, a, b)
     @test a + a isa BlockArray{Float64,0}
     @test a + a == 2a
     @test_broken a .* a isa BlockArray{Float64,0}
-    @test_broken a .* a == 2a
+    @test (a .* a)[] == 4
+    @test_broken a .^ 2 isa BlockArray{Float64,0}
+    @test (a .^ 2)[] == 4
     @test norm(a) == 2
 
     a = BlockedArray{Float64}(2*ones())
@@ -23,7 +25,9 @@ bview(a, b) = Base.invoke(view, Tuple{AbstractArray,Any}, a, b)
     @test a + a isa BlockedArray{Float64,0}
     @test a + a == 2a
     @test_broken a .* a isa BlockedArray{Float64,0}
-    @test_broken a .* a == 2a
+    @test (a .* a)[] == 4
+    @test_broken a .^ 2 isa BlockedArray{Float64,0}
+    @test (a .^ 2)[] == 4
     @test norm(a) == 2
     end
 

--- a/test/test_blocklinalg.jl
+++ b/test/test_blocklinalg.jl
@@ -7,6 +7,20 @@ import ArrayLayouts: DenseRowMajor, ColumnMajor, StridedLayout
 bview(a, b) = Base.invoke(view, Tuple{AbstractArray,Any}, a, b)
 
 @testset "Linear Algebra" begin
+    @testset "zerodim" begin
+    a = BlockArray{Float64}(ones())
+    @test 2a isa BlockArray{Float64,0}
+    @test (2a)[] == 2
+    @test a + a == 2a
+    @test norm(a) == 1
+
+    a = BlockedArray{Float64}(ones())
+    @test_broken 2a isa BlockedArray{Float64,0}
+    @test_broken (2a)[] == 2
+    @test_broken a + a == 2a
+    @test norm(a) == 1
+    end
+
     @testset "BlockArray scalar * matrix" begin
         A = BlockArray{Float64}(randn(6,6), fill(2,3), 1:3)
         @test 2A == A*2 == 2Matrix(A)

--- a/test/test_blocklinalg.jl
+++ b/test/test_blocklinalg.jl
@@ -13,22 +13,26 @@ bview(a, b) = Base.invoke(view, Tuple{AbstractArray,Any}, a, b)
     @test (2a)[] == 4
     @test a + a isa BlockArray{Float64,0}
     @test a + a == 2a
-    @test_broken a .* a isa BlockArray{Float64,0}
-    @test (a .* a)[] == 4
-    @test_broken a .^ 2 isa BlockArray{Float64,0}
-    @test (a .^ 2)[] == 4
     @test norm(a) == 2
+
+    # same behavior as Array
+    @test a .* a isa Float64
+    @test a .* a == 4
+    @test a .^ 2 isa Float64
+    @test a .^ 2 == 4
 
     a = BlockedArray{Float64}(2*ones())
     @test 2a isa BlockedArray{Float64,0}
     @test (2a)[] == 4
     @test a + a isa BlockedArray{Float64,0}
     @test a + a == 2a
-    @test_broken a .* a isa BlockedArray{Float64,0}
-    @test (a .* a)[] == 4
-    @test_broken a .^ 2 isa BlockedArray{Float64,0}
-    @test (a .^ 2)[] == 4
     @test norm(a) == 2
+
+    # same behavior as Array
+    @test a .* a isa Float64
+    @test a .* a == 4
+    @test a .^ 2 isa Float64
+    @test a .^ 2 == 4
     end
 
     @testset "BlockArray scalar * matrix" begin

--- a/test/test_blocklinalg.jl
+++ b/test/test_blocklinalg.jl
@@ -15,9 +15,9 @@ bview(a, b) = Base.invoke(view, Tuple{AbstractArray,Any}, a, b)
     @test norm(a) == 1
 
     a = BlockedArray{Float64}(ones())
-    @test_broken 2a isa BlockedArray{Float64,0}
-    @test_broken (2a)[] == 2
-    @test_broken a + a == 2a
+    @test 2a isa BlockedArray{Float64,0}
+    @test (2a)[] == 2
+    @test a + a == 2a
     @test norm(a) == 1
     end
 

--- a/test/test_blocklinalg.jl
+++ b/test/test_blocklinalg.jl
@@ -8,17 +8,23 @@ bview(a, b) = Base.invoke(view, Tuple{AbstractArray,Any}, a, b)
 
 @testset "Linear Algebra" begin
     @testset "zerodim" begin
-    a = BlockArray{Float64}(ones())
+    a = BlockArray{Float64}(2*ones())
     @test 2a isa BlockArray{Float64,0}
-    @test (2a)[] == 2
+    @test (2a)[] == 4
+    @test a + a isa BlockArray{Float64,0}
     @test a + a == 2a
-    @test norm(a) == 1
+    @test_broken a .* a isa BlockArray{Float64,0}
+    @test_broken a .* a == 2a
+    @test norm(a) == 2
 
-    a = BlockedArray{Float64}(ones())
+    a = BlockedArray{Float64}(2*ones())
     @test 2a isa BlockedArray{Float64,0}
-    @test (2a)[] == 2
+    @test (2a)[] == 4
+    @test a + a isa BlockedArray{Float64,0}
     @test a + a == 2a
-    @test norm(a) == 1
+    @test_broken a .* a isa BlockedArray{Float64,0}
+    @test_broken a .* a == 2a
+    @test norm(a) == 2
     end
 
     @testset "BlockArray scalar * matrix" begin

--- a/test/test_blockviews.jl
+++ b/test/test_blockviews.jl
@@ -21,6 +21,9 @@ bview(a, b) = Base.invoke(view, Tuple{AbstractArray,Any}, a, b)
         @test collect(b) == [2,3]
         @test b[1] == 2
         @test b[1:2] == 2:3
+
+        rba = reshape(BlockedArray(collect(1:4),[2,2]), (2,2))
+        @test view(rba, Block(1,1)[1:1,1:1]) == ones(1,1)
     end
 
     @testset "block view" begin


### PR DESCRIPTION
Fixes #409 and add tests.

`BlockArrays` are now fine, however `BlockedArray` are still broken. This is due to the type piracy on `view` mentioned in #409. I do not see how to fix it at the moment.