### PR TITLE
Make three more functions public

### DIFF
--- a/docs/src/lib/internals.md
+++ b/docs/src/lib/internals.md
@@ -19,9 +19,6 @@ Pages = ["internals.md"]
 ## Internals
 
 ```@docs
-blockcolsupport
-blockrowsupport
-blockedrange
 BlockedOneTo
 BlockedUnitRange
 BlockRange

--- a/docs/src/lib/public.md
+++ b/docs/src/lib/public.md
@@ -40,6 +40,9 @@ blocksizes
 blocks
 eachblock
 blockcheckbounds
+blockcolsupport
+blockrowsupport
+blockedrange
 ```
 
 ## BlockArray


### PR DESCRIPTION
This PR moves three functions from internals to public API:

- `blockcolsupport`
- `blockrowsupport`
- `blockedrange`

Fixes #418 