### PR TITLE
 Preserve axes in `similar` for `BlockArray`s

### DIFF
--- a/src/blockarray.jl
+++ b/src/blockarray.jl
@@ -451,7 +451,7 @@ end
 @inline Base.similar(block_array::Type{<:AbstractArray{T}}, axes::Tuple{Union{AbstractUnitRange{<:Integer},Integer},AbstractBlockedUnitRange,Vararg{Union{AbstractUnitRange{<:Integer},Integer}}}) where T =
     BlockArray{T}(undef, map(to_axes,axes))
 
-@inline Base.similar(B::BlockArray, ::Type{T}) where {T} = mortar(similar.(blocks(B), T))
+@inline Base.similar(B::BlockArray, ::Type{T}) where {T} = _BlockArray(similar.(blocks(B), T), axes(B))
 
 const OffsetAxis = Union{Integer, UnitRange, Base.OneTo, Base.IdentityUnitRange}
 

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -248,6 +248,9 @@ end
             @test similar(randn(6,5), Float64, (3,blockedrange(1:3))) isa BlockedMatrix
             @test similar(typeof(view(randn(5),1:3)), (blockedrange(1:3),)) isa BlockedVector
             @test similar(view(randn(5),1:3), Int, (blockedrange(1:3),)) isa BlockedVector{Int}
+
+            b = BlockVector([1,2,3,4,5,6,7,8,9,10], (BlockedOneTo(5:5:10),))
+            @test zero(b) isa typeof(b)
         end
 
         @test_throws DimensionMismatch BlockArray([1,2,3],[1,1])


### PR DESCRIPTION
Fixes #420

After this,
```julia
julia> using BlockArrays

julia> using BlockArrays: BlockedOneTo

julia> b = BlockVector([1,2,3,4,5,6,7,8,9,10], (BlockedOneTo(5:5:10),));

julia> typeof(b) == typeof(zero(b))
true
```