### PR TITLE
Fewer arg type params in Array construction

### DIFF
--- a/src/blockarray.jl
+++ b/src/blockarray.jl
@@ -548,7 +548,7 @@ function Base.Array(zerodim::BlockArray{T, 0}) where {T}
     return arr
 end
 
-function Base.Array(block_array::BlockArray{T, N, R}) where {T,N,R}
+function Base.Array(block_array::BlockArray{T}) where {T}
     arr = Array{T}(undef, size(block_array))
     for block_index in Iterators.product(blockaxes(block_array)...)
         indices = getindex.(axes(block_array), block_index)


### PR DESCRIPTION
These parameters don't seem necessary