### PR TITLE
Inline blocksizes for better type-inference

### DIFF
--- a/src/blocks.jl
+++ b/src/blocks.jl
@@ -125,7 +125,7 @@ julia> blocksizes(A,2)
 ```
 """
 blocksizes(A::AbstractArray) = BlockSizes(A)
-blocksizes(A::AbstractArray, d::Integer) = blocklengths(axes(A, d))
+@inline blocksizes(A::AbstractArray, d::Integer) = blocklengths(axes(A, d))
 
 struct BlockSizes{T,N,A<:AbstractArray{<:Any,N}} <: AbstractArray{T,N}
     array::A

--- a/test/test_blocks.jl
+++ b/test/test_blocks.jl
@@ -127,6 +127,14 @@ end
         @test blocksizes(A, 1) == [2, 3]
         @test blocksizes(A, 2) == [3, 1]
     end
+
+    @testset "Inference: issue #425" begin
+        x = BlockedArray(rand(4, 4), [2, 2], [2, 2])
+        bs1 = @inferred (x -> blocksizes(x, 1))(x)
+        @test bs1 == [2,2]
+        bs4 = @inferred (x -> blocksizes(x, 4))(x)
+        @test bs4 == 1:1
+    end
 end
 
 end # module


### PR DESCRIPTION
Fixes https://github.com/JuliaArrays/BlockArrays.jl/issues/425

The type-inference should work within a function now, as the dimension will be propagated to `axes` as a constant:
```julia
julia> using BlockArrays, Test

julia> x = BlockedArray(rand(4, 4), [2, 2], [2, 2]);

julia> @inferred (x -> blocksizes(x, 1))(x)
2-element Vector{Int64}:
 2
 2
```