### PR TITLE
[DO NOT MERGE] Demonstration of LazyArrays extension loading issue

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        julia-version: ['1.11.0']
+        julia-version: ['1.11-nightly']
         os: [ubuntu-latest]
         package:
           - {repo: BlockBandedMatrices.jl, group: JuliaLinearAlgebra}

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        julia-version: ['1']
+        julia-version: ['1.11.0']
         os: [ubuntu-latest]
         package:
           - {repo: BlockBandedMatrices.jl, group: JuliaLinearAlgebra}

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        julia-version: ['1.11-nightly']
+        julia-version: ['1.11']
         os: [ubuntu-latest]
         package:
           - {repo: BlockBandedMatrices.jl, group: JuliaLinearAlgebra}


### PR DESCRIPTION
As discussed in #431, this PR is meant to demonstrate an issue loading the LazyArraysBlockArraysExt package extension in Julia v1.11.1 and the v1.11.2 pre-release.

As a summary, I've tried running the downstream tests against a few Julia versions, here are the results:

- Julia v1.11.0: All tests pass.
- Julia v1.11.1: LazyArrays.jl tests fail when LazyArraysBlockArraysExt is being loaded with the error "ERROR: LoadError: ArgumentError: Package LazyArraysBlockArraysExt does not have BlockArrays in its dependencies", all others pass.
- [Julia v1.11.2 pre-release](https://discourse.julialang.org/t/julia-v1-11-2-testing-period/122943): LazyArrays.jl tests fail with the same error as in Julia v1.11.1, all others pass. I tested it by setting `1.11-nightly` in the workflow.
- Julia nightly: The last time I checked LazyArrays.jl tests ran properly (so the original issue plaguing Julia v1.11.1 and v1.11.2 is fixed) but failed for another independent reason.

I haven't been able to reproduce this locally so this PR is the best I could do to demonstrate the issue. It seems like there is an issue in Julia v1.11.1 that is still in the v1.11.2 pre-release related to package extension loading.