### PR TITLE
Pass a command line flag to downstream tests

### DIFF
--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -36,9 +36,8 @@ jobs:
         package:
           - {repo: BlockBandedMatrices.jl, group: JuliaLinearAlgebra}
           - {repo: ApproxFunBase.jl, group: JuliaApproximation}
-          - {repo: LazyArrays.jl, group: JuliaArrays}
           - {repo: LazyBandedMatrices.jl, group: JuliaLinearAlgebra}
-          # - {repo: InfiniteLinearAlgebra.jl, group: JuliaLinearAlgebra}
+          - {repo: InfiniteLinearAlgebra.jl, group: JuliaLinearAlgebra}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/downstream.yml
+++ b/.github/workflows/downstream.yml
@@ -36,6 +36,7 @@ jobs:
         package:
           - {repo: BlockBandedMatrices.jl, group: JuliaLinearAlgebra}
           - {repo: ApproxFunBase.jl, group: JuliaApproximation}
+          - {repo: LazyArrays.jl, group: JuliaArrays}
           - {repo: LazyBandedMatrices.jl, group: JuliaLinearAlgebra}
           - {repo: InfiniteLinearAlgebra.jl, group: JuliaLinearAlgebra}
 
@@ -59,7 +60,7 @@ jobs:
             # force it to use this PR's version of the package
             Pkg.develop(PackageSpec(path="."))  # resolver may fail with main deps
             Pkg.update()
-            Pkg.test()  # resolver may fail with test time deps
+            Pkg.test(test_args=["--downstream_integration_test"])  # resolver may fail with test time deps
           catch err
             err isa Pkg.Resolve.ResolverError || rethrow()
             # If we can't resolve that means this is incompatible by SemVer and this is fine


### PR DESCRIPTION
The command line flag `--downstream_integration_test` that is passed to the downstream test will allow us to selectively skip tests that might not be necessary. In particular, the Aqua test for stale dependencies is unnecessary in downstream tests if we want to test package extensions.

We also reinstate the test against `InfiniteLinearAlgebra` in this PR, which was commented out.