### PR TITLE
Skip Aqua stale deps check in downstream tests

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,8 +1,10 @@
 using BlockArrays, LinearAlgebra, Test
 
 using Aqua
+downstream_test = "--downstream_integration_test" in ARGS
 @testset "Project quality" begin
-    Aqua.test_all(BlockArrays, ambiguities=false)
+    Aqua.test_all(BlockArrays, ambiguities=false,
+        stale_deps=!downstream_test)
 end
 
 using Documenter


### PR DESCRIPTION
This allows adding extra packages in the downstream tests that might be necessary for testing package extensions.