### PR TITLE
Generalize more functions to non-Int64 ranges

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BlockArrays"
 uuid = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
-version = "1.5.0"
+version = "1.6.0"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/blockaxis.jl
+++ b/src/blockaxis.jl
@@ -101,6 +101,10 @@ end
     return (first(a), (blocklasts(a)[oneto(end-1)] .+ oneunit(eltype(a)))...)
 end
 
+function Base.AbstractUnitRange{T}(r::BlockedUnitRange) where {T}
+    return _BlockedUnitRange(convert(T,first(r)), convert.(T,blocklasts(r)))
+end
+
 """
     BlockedOneTo{T, <:Union{AbstractVector{T}, NTuple{<:Any,T}}} where {T}
 
@@ -155,6 +159,10 @@ first(b::BlockedOneTo) = oneunit(eltype(b))
 BlockedOneTo(::BlockedOneTo) = throw(ArgumentError("Forbidden due to ambiguity"))
 
 axes(b::BlockedOneTo) = (b,)
+
+function Base.AbstractUnitRange{T}(r::BlockedOneTo) where {T}
+    return BlockedOneTo(convert.(T,blocklasts(r)))
+end
 
 """
     blockedrange(blocklengths::Union{Tuple, AbstractVector})

--- a/src/blockbroadcast.jl
+++ b/src/blockbroadcast.jl
@@ -100,7 +100,7 @@ Base.eltype(::Type{<:SubBlockIterator}) = BlockIndexRange{1,Tuple{UnitRange{Int}
 Base.IteratorSize(::Type{<:SubBlockIterator}) = Base.HasLength()
 Base.length(it::SubBlockIterator) = length(it.block_lasts)
 
-SubBlockIterator(arr::AbstractArray, bs::NTuple{N,AbstractUnitRange{Int}}, dim::Integer) where N =
+SubBlockIterator(arr::AbstractArray, bs::NTuple{N,AbstractUnitRange}, dim::Integer) where N =
     SubBlockIterator(blocklasts(axes(arr, dim)), blocklasts(bs[dim]))
 
 function Base.iterate(it::SubBlockIterator, (i, j) = (1,1))
@@ -113,10 +113,10 @@ function Base.iterate(it::SubBlockIterator, (i, j) = (1,1))
     return (bir, (i + 1, j))
 end
 
-subblocks(::Any, bs::NTuple{N,AbstractUnitRange{Int}}, dim::Integer) where N =
+subblocks(::Any, bs::NTuple{N,AbstractUnitRange}, dim::Integer) where N =
     (nothing for _ in blockaxes(bs[dim], 1))
 
-function subblocks(arr::AbstractArray, bs::NTuple{N,AbstractUnitRange{Int}}, dim::Integer) where N
+function subblocks(arr::AbstractArray, bs::NTuple{N,AbstractUnitRange}, dim::Integer) where N
     return SubBlockIterator(arr, bs, dim)
 end
 

--- a/src/blockbroadcast.jl
+++ b/src/blockbroadcast.jl
@@ -100,7 +100,7 @@ Base.eltype(::Type{<:SubBlockIterator}) = BlockIndexRange{1,Tuple{UnitRange{Int}
 Base.IteratorSize(::Type{<:SubBlockIterator}) = Base.HasLength()
 Base.length(it::SubBlockIterator) = length(it.block_lasts)
 
-SubBlockIterator(arr::AbstractArray, bs::NTuple{N,AbstractUnitRange}, dim::Integer) where N =
+SubBlockIterator(arr::AbstractArray, bs::Tuple{Vararg{AbstractUnitRange{<:Integer}}}, dim::Integer) =
     SubBlockIterator(blocklasts(axes(arr, dim)), blocklasts(bs[dim]))
 
 function Base.iterate(it::SubBlockIterator, (i, j) = (1,1))
@@ -113,10 +113,10 @@ function Base.iterate(it::SubBlockIterator, (i, j) = (1,1))
     return (bir, (i + 1, j))
 end
 
-subblocks(::Any, bs::NTuple{N,AbstractUnitRange}, dim::Integer) where N =
+subblocks(::Any, bs::Tuple{Vararg{AbstractUnitRange{<:Integer}}}, dim::Integer) =
     (nothing for _ in blockaxes(bs[dim], 1))
 
-function subblocks(arr::AbstractArray, bs::NTuple{N,AbstractUnitRange}, dim::Integer) where N
+function subblocks(arr::AbstractArray, bs::Tuple{Vararg{AbstractUnitRange{<:Integer}}}, dim::Integer)
     return SubBlockIterator(arr, bs, dim)
 end
 

--- a/test/test_blockrange.jl
+++ b/test/test_blockrange.jl
@@ -73,6 +73,17 @@ using BlockArrays, Test
         @test BlockRange(1:3) == collect(BlockRange(1:3)) == [Block(1),Block(2),Block(3)]
         @test BlockRange(1:3,1:2) == collect(BlockRange(1:3,1:2))
     end
+
+    # non Int64 range
+    r = blockedrange([Int32(1)])
+    @test convert(AbstractUnitRange{Int64}, r) isa BlockedOneTo{Int64}
+    v = mortar([[1]], (r,))
+    @test Int.(v) == v
+
+    r = blockedrange([Int32(1)])[Block(1):Block(1)]
+    @test convert(AbstractUnitRange{Int64}, r) isa BlockedUnitRange{Int64}
+    v = mortar([[1]], (r,))
+    @test Int.(v) == v
 end
 
 @testset "block index range" begin


### PR DESCRIPTION
This PR generalizes blocked ranges to any integer type, follow-up to #405 
fix #454 