### PR TITLE
fix zero-dim similar

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BlockArrays"
 uuid = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
-version = "1.6.0"
+version = "1.6.1"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/blockarray.jl
+++ b/src/blockarray.jl
@@ -453,6 +453,10 @@ end
 
 @inline Base.similar(B::BlockArray, ::Type{T}) where {T} = _BlockArray(similar.(blocks(B), T), axes(B))
 
+# specific 0-dim
+@inline Base.similar(B::BlockArray{<:Any,0}, ::Type{T}) where {T} = BlockArray(similar(only(blocks(B)), T), ())
+@inline Base.similar(::BlockArray, ::Type{T}, ::Tuple{}) where {T} = BlockArray(Array{T}(undef))
+
 const OffsetAxis = Union{Integer, UnitRange, Base.OneTo, Base.IdentityUnitRange}
 
 # avoid ambiguities

--- a/src/blockarray.jl
+++ b/src/blockarray.jl
@@ -455,7 +455,7 @@ end
 
 # specific 0-dim
 @inline Base.similar(B::BlockArray{<:Any,0}, ::Type{T}) where {T} = BlockArray(similar(only(blocks(B)), T), ())
-@inline Base.similar(::BlockArray, ::Type{T}, ::Tuple{}) where {T} = BlockArray(Array{T}(undef))
+@inline Base.similar(::BlockArray, ::Type{T}, ::Tuple{}) where {T} = BlockArray{T}(undef)
 
 const OffsetAxis = Union{Integer, UnitRange, Base.OneTo, Base.IdentityUnitRange}
 

--- a/src/blockedarray.jl
+++ b/src/blockedarray.jl
@@ -204,7 +204,7 @@ function Base.similar(block_array::BlockedArray{T,N}, ::Type{T2}) where {T,N,T2}
 end
 
 # specific zero dim
-Base.similar(::BlockedArray{<:Any,0}, ::Type{T}, ::Tuple{}) where {T} = BlockedArray(Array{T}(undef))
+Base.similar(::BlockedArray, ::Type{T}, ::Tuple{}) where {T} = BlockedArray{T}(undef)
 
 to_axes(r::AbstractUnitRange) = r
 to_axes(n::Integer) = Base.oneto(n)

--- a/src/blockedarray.jl
+++ b/src/blockedarray.jl
@@ -203,6 +203,9 @@ function Base.similar(block_array::BlockedArray{T,N}, ::Type{T2}) where {T,N,T2}
     BlockedArray(similar(block_array.blocks, T2), axes(block_array))
 end
 
+# specific zero dim
+Base.similar(::BlockedArray{<:Any,0}, ::Type{T}, ::Tuple{}) where {T} = BlockedArray(Array{T}(undef))
+
 to_axes(r::AbstractUnitRange) = r
 to_axes(n::Integer) = Base.oneto(n)
 

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -343,13 +343,18 @@ end
             view(ret)[] = 0
             @test ret[] == 0
 
-            ret = BlockArrays.BlockArray(zeros())
+            ret = BlockArray(zeros())
             @test ret isa BlockArray{Float64, 0}
             @test size(ret) == ()
             @test all(iszero, ret)
             @test ret[Block()] == zeros()
 
-            ret = BlockArrays.BlockArray(zeros(1,1))
+            @test similar(ret) isa BlockArray{Float64, 0}
+            @test similar(ret, Float32) isa BlockArray{Float32, 0}
+            @test similar(ret, Float32, ()) isa BlockArray{Float32, 0}
+            @test similar(ret, Float32, (blockedrange([1]),)) isa BlockVector{Float32}
+
+            ret = BlockArray(zeros(1,1))
             @test reshape(ret, ()) isa AbstractBlockArray{Float64, 0}  # may be BlockedArray
             @test size(reshape(ret, ())) == ()
 
@@ -373,7 +378,12 @@ end
             @test all(iszero, ret)
             @test ret[Block()] == zeros()
 
-            ret = BlockArrays.BlockedArray(zeros(1,1))
+            @test similar(ret) isa BlockedArray{Float64, 0}
+            @test similar(ret, Float32) isa BlockedArray{Float32, 0}
+            @test similar(ret, Float32, ()) isa BlockedArray{Float32, 0}
+            @test similar(ret, Float32, (blockedrange([1]),)) isa BlockedVector{Float32}
+
+            ret = BlockedArray(zeros(1,1))
             @test reshape(ret, ()) isa BlockedArray{Float64, 0}
             @test size(reshape(ret, ())) == ()
         end

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -325,6 +325,7 @@ end
 
         @testset "zero dim" begin
             zerodim = ones()
+            r = blockedrange([1])
             @test view(zerodim) isa AbstractArray{Float64, 0}  #  check no type-piracy
 
             ret = BlockArray{Float64}(undef)
@@ -352,7 +353,8 @@ end
             @test similar(ret) isa BlockArray{Float64, 0}
             @test similar(ret, Float32) isa BlockArray{Float32, 0}
             @test similar(ret, Float32, ()) isa BlockArray{Float32, 0}
-            @test similar(ret, Float32, (blockedrange([1]),)) isa BlockVector{Float32}
+            @test similar(ret, Float32, (r,)) isa BlockVector{Float32}
+            @test similar(BlockArray(zeros(r)), Float32, ()) isa BlockArray{Float32, 0}
 
             ret = BlockArray(zeros(1,1))
             @test reshape(ret, ()) isa AbstractBlockArray{Float64, 0}  # may be BlockedArray
@@ -382,6 +384,7 @@ end
             @test similar(ret, Float32) isa BlockedArray{Float32, 0}
             @test similar(ret, Float32, ()) isa BlockedArray{Float32, 0}
             @test similar(ret, Float32, (blockedrange([1]),)) isa BlockedVector{Float32}
+            @test similar(zeros(r), Float32, ()) isa BlockedArray{Float32, 0}
 
             ret = BlockedArray(zeros(1,1))
             @test reshape(ret, ()) isa BlockedArray{Float64, 0}


### PR DESCRIPTION
`similar(::BlockArray` behaves in a surprising way for 0-dimensional block arrays. This PR is a follow-up to #410 and aims for `Base.similar(::T{<:AbstractBlockArray}` to still return a `BlockArray/BlockedArray` in the zero-dimensional limit.