### PR TITLE
Preserve block information in more slicing operations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BlockArrays"
 uuid = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
-version = "1.6.2"
+version = "1.7.0"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/blockindices.jl
+++ b/src/blockindices.jl
@@ -288,6 +288,16 @@ _indices(B) = B
 
 Block(bs::BlockSlice{<:BlockIndexRange}) = Block(bs.block)
 
+struct BlockInds{BB,T<:Integer,INDS<:AbstractVector{T}} <: AbstractVector{T}
+    block::BB
+    indices::INDS
+end
+
+for f in (:axes, :size)
+    @eval $f(S::BlockInds) = $f(S.indices)
+end
+
+@propagate_inbounds getindex(S::BlockInds, i::Integer) = getindex(S.indices, i)
 
 struct BlockRange{N,R<:NTuple{N,AbstractUnitRange{<:Integer}}} <: AbstractArray{Block{N,Int},N}
     indices::R

--- a/src/views.jl
+++ b/src/views.jl
@@ -11,7 +11,7 @@ function unblock(A, inds, I)
 end
 
 _blockslice(B, a::AbstractUnitRange) = BlockSlice(B, a)
-_blockslice(B, a) = a # drop block structure
+_blockslice(B, a) = BlockInds(B, a)
 
 # Allow `ones(2)[Block(1)[1:1], Block(1)[1:1]]` which is
 # similar to `ones(2)[1:1, 1:1]`.


### PR DESCRIPTION
This introduces a generalization of `BlockSlice` for views involving vectors of `Block` and `BlockIndexRange`, building off of #445.

I call it `BlockInds` but I'm open to suggestions (I was going to use `BlockIndices` but that clashes with #356). At first I tried to just generalize `BlockSlice` to be an `AbstractVector` subtype but some operations depend on it being an `AbstractUnitRange` so I think it makes sense to have both.

The motivation is that in https://github.com/ITensor/BlockSparseArrays.jl we would like to preserve information about the original blocks being sliced when taking views involving vectors of `Block` and `BlockIndexRange`. #445 drops the blocks input in the slice operation, so it is hard to tell if a certain slice operation was really originally blockwise.

@dlfivefifty curious to hear your thoughts on this since you wrote #445.