### PR TITLE
Define `copy(::BlockIndexRange)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BlockArrays"
 uuid = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
-version = "1.6.2"
+version = "1.6.3"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/blockindices.jl
+++ b/src/blockindices.jl
@@ -203,6 +203,8 @@ BlockIndexRange(block::Block{N}, inds::Vararg{AbstractUnitRange{<:Integer},N}) w
 
 block(R::BlockIndexRange) = R.block
 
+copy(R::BlockIndexRange) = BlockIndexRange(R.block, copy.(R.indices))
+
 getindex(::Block{0}) = BlockIndex()
 getindex(B::Block{N}, inds::Vararg{Integer,N}) where N = BlockIndex(B,inds)
 getindex(B::Block{N}, inds::Vararg{AbstractUnitRange{<:Integer},N}) where N = BlockIndexRange(B,inds)

--- a/src/blockindices.jl
+++ b/src/blockindices.jl
@@ -203,7 +203,7 @@ BlockIndexRange(block::Block{N}, inds::Vararg{AbstractUnitRange{<:Integer},N}) w
 
 block(R::BlockIndexRange) = R.block
 
-copy(R::BlockIndexRange) = BlockIndexRange(R.block, copy.(R.indices))
+copy(R::BlockIndexRange) = BlockIndexRange(R.block, map(copy, R.indices))
 
 getindex(::Block{0}) = BlockIndex()
 getindex(B::Block{N}, inds::Vararg{Integer,N}) where N = BlockIndex(B,inds)

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -861,6 +861,11 @@ end
         @test A[Block(1)[1], Block(1)[1:1]] == BlockArray(A)[Block(1)[1], Block(1)[1:1]] == A[1,1:1]
     end
 
+    @testset "BlockIndexRange blocks" begin
+        a = mortar([Block(1)[1:2], Block(2)[2:3]])
+        @test a[Block(1)] === Block(1)[1:2]
+        @test a[Block(2)] === Block(2)[2:3]
+    end
     @testset "permutedims" begin
         for a in (BlockArray(randn(3), [1,2]), BlockedArray(randn(3), [1,2]))
             @test permutedims(a) == permutedims(Vector(a))

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -862,10 +862,11 @@ end
     end
 
     @testset "BlockIndexRange blocks" begin
-        a = mortar([Block(1)[1:2], Block(2)[2:3]])
+        a = mortar([Block(1)[1:2], Block(3)[2:3]])
         @test a[Block(1)] === Block(1)[1:2]
-        @test a[Block(2)] === Block(2)[2:3]
+        @test a[Block(2)] === Block(3)[2:3]
     end
+
     @testset "permutedims" begin
         for a in (BlockArray(randn(3), [1,2]), BlockedArray(randn(3), [1,2]))
             @test permutedims(a) == permutedims(Vector(a))

--- a/test/test_blockindices.jl
+++ b/test/test_blockindices.jl
@@ -95,6 +95,7 @@ import BlockArrays: BlockIndex, BlockIndexRange, BlockSlice
         @test BlockIndex(UInt(2),(2,)) === BlockIndex((UInt(2),),(2,))
         @test BlockIndex(Block(2),2) === BlockIndex(Block(2),(2,))
         @test BlockIndex(Block(2),UInt(2)) === BlockIndex(Block(2),(UInt(2),))
+        @test copy(Block(1)[1:2]) === BlockIndexRange(Block(1),1:2)
     end
 
     @testset "BlockRange" begin


### PR DESCRIPTION
This defines `copy(::BlockIndexRange)`, which fixes #404.

Before, `copy(::BlockIndexRange)` was outputting a `Vector{<:BlockIndex}`, which was leading to the behavior reported in #404. I think this definition of `copy` makes sense, since it is similar to the definition of `copy` for unit ranges (i.e. it just returns the unit range instead of collecting into a `Vector`).