### PR TITLE
Improve test coverage for `BlockLogicalIndex`

### DIFF
--- a/src/views.jl
+++ b/src/views.jl
@@ -111,7 +111,6 @@ collect(I::BlockedLogicalIndex) = collect(I.blocks)
 checkbounds(::Type{Bool}, A::AbstractArray, i::BlockedLogicalIndex) = checkbounds(Bool, A, i.blocks.mask)
 # `checkbounds_indices` has been handled via `I::AbstractArray` fallback
 checkindex(::Type{Bool}, inds::AbstractUnitRange, i::BlockedLogicalIndex) = checkindex(Bool, inds, i.blocks.mask)
-checkindex(::Type{Bool}, inds::Tuple, i::BlockedLogicalIndex) = checkindex(Bool, inds, i.blocks.mask)
 
 # Instantiate the BlockedLogicalIndex when constructing a SubArray, similar to
 # `ensure_indexable(I::Tuple{LogicalIndex,Vararg{Any}})`:

--- a/test/test_blockviews.jl
+++ b/test/test_blockviews.jl
@@ -379,13 +379,11 @@ bview(a, b) = Base.invoke(view, Tuple{AbstractArray,Any}, a, b)
         end
         bl = BlockedLogicalIndex(BlockedVector([true, true, false, false, true, false], [3, 3]))
         @test sprint(show, "text/plain", bl) ==
-            "2-blocked 3-element BlockedVector{Int64, LogicalIndex{Int64, BlockedVector{Bool, Vector{Bool}, Tuple{BlockedOneTo{Int64, Vector{Int64}}}}}, Tuple{BlockedOneTo{Int64, Vector{Int64}}}}:\n 1\n 2\n ─\n 5"
+            "2-blocked 3-element BlockedVector{Int64, Base.LogicalIndex{Int64, BlockedVector{Bool, Vector{Bool}, Tuple{BlockedOneTo{Int64, Vector{Int64}}}}}, Tuple{BlockedOneTo{Int64, Vector{Int64}}}}:\n 1\n 2\n ─\n 5"
         @test checkbounds(Bool, randn(6), bl)
         @test !checkbounds(Bool, randn(5), bl)
         @test checkindex(Bool, 1:6, bl)
         @test !checkindex(Bool, 1:5, bl)
-        @test checkindex(Bool, (1:6,), bl)
-        @test !checkindex(Bool, (1:5,), bl)
     end
 end
 


### PR DESCRIPTION
I noticed #475 had some missing test coverage, this should fix that.