### PR TITLE
Fix nested broadcasting of BlockedArray

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BlockArrays"
 uuid = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
-version = "1.7.0"
+version = "1.7.1"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/src/blockbroadcast.jl
+++ b/src/blockbroadcast.jl
@@ -131,8 +131,8 @@ end
 @inline function Broadcast.materialize!(dest, bc::Broadcasted{BS}) where {NDims, BS<:AbstractBlockStyle{NDims}}
     dest_reshaped = ndims(dest) == NDims ? dest : reshape(dest, size(bc))
     bc2 = Broadcast.instantiate(
-            Broadcast.Broadcasted{BS}(bc.f, bc.args,
-                map(combine_blockaxes, axes(dest_reshaped), axes(bc))))
+            Broadcast.flatten(Broadcast.Broadcasted{BS}(bc.f, bc.args,
+                map(combine_blockaxes, axes(dest_reshaped), axes(bc)))))
     copyto!(dest_reshaped, bc2)
     return dest
 end

--- a/src/blockbroadcast.jl
+++ b/src/blockbroadcast.jl
@@ -129,10 +129,11 @@ end
 @inline _bview(A::AbstractArray, I...) = view(A, I...)
 
 @inline function Broadcast.materialize!(dest, bc::Broadcasted{BS}) where {NDims, BS<:AbstractBlockStyle{NDims}}
-    dest_reshaped = ndims(dest) == NDims ? dest : reshape(dest, size(bc))
+    bcf = Broadcast.flatten(bc)
+    dest_reshaped = ndims(dest) == NDims ? dest : reshape(dest, size(bcf))
     bc2 = Broadcast.instantiate(
-            Broadcast.flatten(Broadcast.Broadcasted{BS}(bc.f, bc.args,
-                map(combine_blockaxes, axes(dest_reshaped), axes(bc)))))
+            Broadcast.Broadcasted{BS}(bcf.f, bcf.args,
+                map(combine_blockaxes, axes(dest_reshaped), axes(bcf))))
     copyto!(dest_reshaped, bc2)
     return dest
 end

--- a/test/test_blockbroadcast.jl
+++ b/test/test_blockbroadcast.jl
@@ -67,10 +67,26 @@ using StaticArrays
         @test A .+ 1 .+ B == Vector(A) .+ 1 .+ B == Vector(A) .+ 1 .+ Matrix(B)
 
         @testset "preserve structure" begin
-             x = BlockedArray(1:6, Fill(3,2))
-             @test x + x isa BlockedVector{Int,<:AbstractRange}
-             @test 2x + x isa BlockedVector{Int,<:AbstractRange}
-             @test 2 .* (x .+ 1) isa BlockedVector{Int,<:AbstractRange}
+            x = BlockedArray(1:6, Fill(3,2))
+            @test x + x isa BlockedVector{Int,<:AbstractRange}
+            @test 2x + x isa BlockedVector{Int,<:AbstractRange}
+            @test 2 .* (x .+ 1) isa BlockedVector{Int,<:AbstractRange}
+        end
+
+        @testset "nested in-place broadcast" begin
+            x = BlockedVector(randn(4), [2, 2])
+            y = BlockedVector(randn(4), [2, 2])
+            dest = copy(x)
+            dest .+= 2 .* y
+            @test dest ≈ x + 2y
+        end
+
+        @testset "0-dim nested in-place broadcast" begin
+            x = BlockedArray(randn(()))
+            y = BlockedArray(randn(()))
+            dest = copy(x)
+            dest .+= 2 .* y
+            @test dest ≈ x + 2y
         end
     end
 


### PR DESCRIPTION
Fixes #295. That issue seemed to be caused by code in the generic block broadcasting logic such as https://github.com/JuliaArrays/BlockArrays.jl/blob/90ddfa96fb0ade3da4f67ac285fcb340350c19c6/src/blockbroadcast.jl#L121-L129 assuming the broadcasting expression is already flat. This PR adds a call to `Broadcast.flatten` to explicitly flatten the broadcast expression in the generic block broadcast code.

It appears that at some point `BlockedStyle` broadcasting expressions were being flattened in this `Broadcast.instantiate` definition: https://github.com/JuliaArrays/BlockArrays.jl/blob/90ddfa96fb0ade3da4f67ac285fcb340350c19c6/src/blockbroadcast.jl#L199-L202 but that was changed in #193. Reverting that change broke the tests introduced in #193 so I guess it is not safe to do that.

I have to admit I'm not sure if this is the best place to call `Broadcast.flatten`, a lot of this broadcasting code is hard to follow.