### PR TITLE
Fix axes and size of BlockIndices

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BlockArrays"
 uuid = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
-version = "1.9"
+version = "1.9.1"
 
 
 [deps]

--- a/src/blockindices.jl
+++ b/src/blockindices.jl
@@ -202,7 +202,7 @@ BlockIndex(indcs::Tuple{Vararg{BlockIndex{1},N}}) where N = BlockIndex(block.(in
     bl = block(I)
     checkbounds(Bool, A, bl) || return false
     # TODO: Replace with `eachblockaxes(A)[bl]` once that is defined.
-    binds = map(Base.axes1 ∘ getindex, axes(A), Tuple(bl))
+    binds = map(axes1 ∘ getindex, axes(A), Tuple(bl))
     Base.checkbounds_indices(Bool, binds, (blockindex(I),))
 end
 checkbounds(::Type{Bool}, A::AbstractArray{<:Any,N}, I::AbstractArray{<:BlockIndex{N}}) where N =
@@ -374,8 +374,8 @@ end
     nextstate, nextstate
 end
 
-size(iter::BlockIndices) = map(dimlength, first(iter).α, last(iter).α)
-length(iter::BlockIndices) = prod(size(iter))
+axes(iter::BlockIndices) = map(axes1, iter.indices)
+size(iter::BlockIndices) = map(length, iter.indices)
 
 
 Block(bs::BlockIndices) = bs.block
@@ -388,7 +388,7 @@ function checkbounds(::Type{Bool}, A::AbstractArray{<:Any,N}, I::BlockIndices{N}
     bl = block(I)
     checkbounds(Bool, A, bl) || return false
     # TODO: Replace with `eachblockaxes(A)[bl]` once that is defined.
-    binds = map(Base.axes1 ∘ getindex, axes(A), Tuple(bl))
+    binds = map(axes1 ∘ getindex, axes(A), Tuple(bl))
     Base.checkbounds_indices(Bool, binds, I.indices)
 end
 

--- a/test/test_blockindices.jl
+++ b/test/test_blockindices.jl
@@ -119,6 +119,13 @@ import BlockArrays: split_index, merge_indices
         @test eltype(BlockIndices{3}) ≡ BlockIndex{3}
         @test Base.IteratorSize(BlockIndices{3}) ≡ Base.HasShape{1}()
         @test isnothing(iterate(Block(3,3)[[1,3],[3,1]]))
+
+        I1 = BlockVector([2,4,7,2,3], (blockedrange([2,3]),))
+        I2 = blockedrange(2, [4,3])
+        b = Block(1,2)[I1,I2]
+        @test blockisequal(axes(b), (blockedrange([2,3]),blockedrange([4,3])))
+        @test size(b) == (5,7)
+        @test length(b) == 35
     end
 
     @testset "BlockRange" begin


### PR DESCRIPTION
The current definition of `size(iter::BlockIndices)` was assuming the indices were ranges (resulting from #483 where `BlockIndexRange` was generalized to `BlockIndices` but the definition if `size` wasn't updated accordingly), so for (non-contiguous) non-ranges it was giving the wrong result, this PR fixes that. Additionally, previously only `size` was defined which meant that BlockIndices where the indices had non-trivial axes (like blocked axes) lost information, which is now fixed and tested.