### PR TITLE
Fix ambiguity error in `similar` with 3 or more blocked axes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "BlockArrays"
 uuid = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
-version = "1.9.2"
+version = "1.9.3"
 
 
 [deps]

--- a/src/blockarray.jl
+++ b/src/blockarray.jl
@@ -448,6 +448,8 @@ end
 @inline Base.similar(block_array::AbstractArray, ::Type{T}, axes::Tuple{Union{AbstractUnitRange{<:Integer},Integer},Union{AbstractUnitRange{<:Integer},Integer},AbstractBlockedUnitRange,Vararg{Union{AbstractUnitRange{<:Integer},Integer}}}) where T =
     BlockArray{T}(undef, map(to_axes,axes))
 
+@inline Base.similar(block_array::Type{<:AbstractArray{T}}, axes::Tuple{AbstractBlockedUnitRange,Vararg{AbstractBlockedUnitRange}}) where T =
+    BlockArray{T}(undef, axes)
 @inline Base.similar(block_array::Type{<:AbstractArray{T}}, axes::Tuple{AbstractBlockedUnitRange,Vararg{Union{AbstractUnitRange{<:Integer},Integer}}}) where T =
     BlockArray{T}(undef, map(to_axes,axes))
 @inline Base.similar(block_array::Type{<:AbstractArray{T}}, axes::Tuple{AbstractBlockedUnitRange,AbstractBlockedUnitRange,Vararg{Union{AbstractUnitRange{<:Integer},Integer}}}) where T =

--- a/src/blockedarray.jl
+++ b/src/blockedarray.jl
@@ -215,6 +215,8 @@ to_axes(n::Integer) = Base.oneto(n)
 
 const IntegerOrUnitRange = Union{Integer,AbstractUnitRange{<:Integer}}
 
+@inline Base.similar(block_array::Type{<:StridedArray{T}}, axes::Tuple{AbstractBlockedUnitRange,Vararg{AbstractBlockedUnitRange}}) where T =
+    BlockedArray{T}(undef, axes)
 @inline Base.similar(block_array::Type{<:StridedArray{T}}, axes::Tuple{AbstractBlockedUnitRange,Vararg{IntegerOrUnitRange}}) where T =
     BlockedArray{T}(undef, map(to_axes,axes))
 @inline Base.similar(block_array::Type{<:StridedArray{T}}, axes::Tuple{AbstractBlockedUnitRange,AbstractBlockedUnitRange,Vararg{IntegerOrUnitRange}}) where T =

--- a/test/test_blockarrays.jl
+++ b/test/test_blockarrays.jl
@@ -260,6 +260,14 @@ end
             @test similar(typeof(view(randn(5),1:3)), (blockedrange(1:3),)) isa BlockedVector
             @test similar(view(randn(5),1:3), Int, (blockedrange(1:3),)) isa BlockedVector{Int}
 
+            # Regression test for method ambiguity.
+            A = Array{Float64}
+            @test similar(A, blockedrange.((1:3,1:3,1:3))) isa BlockedArray{Float64,3}
+            @test similar(A, blockedrange.((1:3,1:3,1:3,1:3))) isa BlockedArray{Float64,4}
+            A = typeof(view(randn(4,4,4),[1,2,4],[1,2,4],[1,2,4]))
+            @test similar(A, blockedrange.((1:3,1:3,1:3))) isa BlockArray{Float64,3}
+            @test similar(A, blockedrange.((1:3,1:3,1:3,1:3))) isa BlockArray{Float64,4}
+
             b = BlockVector([1,2,3,4,5,6,7,8,9,10], (BlockedOneTo(5:5:10),))
             @test zero(b) isa typeof(b)
         end


### PR DESCRIPTION
I found that `similar` calls such as:
```julia
using BlockArrays
r = blockedrange([2, 2])
similar(Array{Float64}, (r, r, r))
```
(with inputs of 3 or more blocked axes) lead to ambiguity errors between the `StridedArray` and `AbstractArray` versions which output `BlockedArray` and `BlockArray` respectively, this PR fixes that ambiguity by defining a more specialized `similar` method only for `AbstractBlockedUnitRange` inputs. The existing definitions accept mixtures of blocked, non-blocked, and integer dimensions which is more prone to ambiguities.

Related to #196 and #489.

I also noticed these definitions are not so friendly for GPU array types but that is a separate matter...